### PR TITLE
Fix target configuration (latexpdf, man, texinfo)

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -42,7 +42,10 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'OMERO'
-copyright = u'2000-2012, The Open Microscopy Environment'
+title = u'OMERO Documentation'
+author = u'The Open Microscopy Environment'
+copyright = u'2000-2012, ' + author
+target = 'OMEROdocs'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -237,8 +240,7 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'ome-full.tex', u'OME Documentation',
-   u'The Open Microscopy Environment', 'manual'),
+  (master_doc, target + '.tex', title, author, 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -267,8 +269,7 @@ latex_show_urls = 'footnote'
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('foo', 'omedocs', u'OME Documentation',
-     [u'The Open Microscopy Environment'], 1)
+    (master_doc, 'OMERO', title, author, 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -281,8 +282,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('foo', 'omedocs', u'OME Documentation',
-   u'The Open Microscopy Environment', 'omedocs', 'One line description of project.',
+  (master_doc, target, title, author, 'omedocs', 'One line description of project.',
    'Miscellaneous'),
 ]
 


### PR DESCRIPTION
- Define variables shared between sphinx targets (name, author, title)
- Fix PDF output name

Two comments/questions:
- should we insert the release number in the target name, e.g. OMEROdocs-4.4.4.pdf
- how to differentiate the name of this pdf from the OMERO docs we provide in the downloads page?
