### PR TITLE
Limitations update (webstart etc)

### DIFF
--- a/users/limitations.txt
+++ b/users/limitations.txt
@@ -28,7 +28,7 @@ make lib/scripts a git repository?"
 <https://www.openmicroscopy.org/site/support/faq/omero/how-do-i-make-lib-scripts-a-git-repository>`_
 in the FAQ.
 
-Building OMERO.cpp 4.4.0 and 4.4.1 under Windows with Ice 3.4 fails.
+Building OMERO.cpp 4.4.x under Windows with Ice 3.4 fails.
 ====================================================================
 
 ::
@@ -67,16 +67,6 @@ large dynamic range. While the files import into OMERO they are
 currently now viewable. This fix would require deep changes to several
 parts of the code and we have chosen not to make the changes yet. See
 :ticket:`3256`.
-
-Postgres 9.x defaults to 'hex' bytea\_output format
-===================================================
-
-Newer version of Postgres default to the 'hex' as opposed to 'escape'
-format for bytea\_output which OMERO uses for storing script and share
-data in the DB. This causes problems with OMERO 4.3 and earlier, which
-can't understand this format. OMERO 4.4 works with both formats
-without problems. A workaround is available under
-:doc:`/sysadmins/unix/server-postgresql`. See :ticket:`5662`.
 
 OMERO.web 'development server' does not work under Windows XP
 =============================================================
@@ -129,16 +119,6 @@ settings. The system wide setting needs to be changed in preferences,
 and this would have security implications. We are looking into code 
 signing to resolve this issue.
 
-Non-LDAP user password security
-===============================
-
-Encrypted login and communication, via SSL, has been available in
-OMERO for some time. However, under some circumstances it is possible
-for passwords to end up on the wire in the clear. Further details and
-status can be found on :ticket:`3232`. Users who have their
-credentials stored in LDAP and who have OMERO configured to use their
-LDAP server are **not** affected by this issue.
-
 Synchronising with LDAP
 =======================
 
@@ -149,15 +129,50 @@ result in users being removed from these groups. The groups will still
 exist in OMERO but user membership will be treated as being defined by
 LDAP alone.
 
+Binary delete on Windows servers
+================================
+
+On Windows servers not all binary files corresponding to a delete may
+be removed from the binary repository. See 
+:ref:`DeleteBinaryData` for more details.
+
+
+Previous known issues (Prior to 4.4.0)
+======================================
+
+
+Postgres 9.x defaults to 'hex' bytea\_output format
+---------------------------------------------------
+
+Newer version of Postgres default to the 'hex' as opposed to 'escape'
+format for bytea\_output which OMERO uses for storing script and share
+data in the DB. This causes problems with OMERO 4.3 and earlier, which
+can't understand this format. OMERO 4.4 works with both formats
+without problems. A workaround is available under
+:doc:`/sysadmins/unix/server-postgresql`. See :ticket:`5662`.
+
+
+Non-LDAP user password security
+-------------------------------
+
+Encrypted login and communication, via SSL, has been available in
+OMERO for some time. However, under some circumstances it is possible
+for passwords to end up on the wire in the clear. Further details and
+status can be found on :ticket:`3232`. Users who have their
+credentials stored in LDAP and who have OMERO configured to use their
+LDAP server are **not** affected by this issue.
+
+
 Moving data between groups
-==========================
+--------------------------
 
 Prior to OMERO 4.4, users cannot move data between groups. We
 encourage users to be aware of their **working group** at all times,
 especially when importing.
 
+
 Import of reagents and screens
-==============================
+------------------------------
 
 The import of some, complicated OME-XML files may not work with
 4.2.0. Shortly before release, we tested a file with two entire
@@ -167,9 +182,3 @@ contain this level of data, but if you have issues getting screening
 data imported in the OME-XML format, please :community_plone:`let us know
 <>`.
 
-Binary delete on Windows servers
-================================
-
-On Windows servers not all binary files corresponding to a delete may
-be removed from the binary repository. See 
-:ref:`DeleteBinaryData` for more details.


### PR DESCRIPTION
Added a limitation re: 9370 to the limitations page, as well as moved older limitations to a block at the bottom. I'm not sure this is the strategy we want to follow. Perhaps better to just remove them?
