### PR TITLE
Removes references to http, https and /docs/

### DIFF
--- a/themes/plonematch/layout.html
+++ b/themes/plonematch/layout.html
@@ -10,15 +10,15 @@
         <div id="portal-header">
             <ul id="portal-siteactions">
                 <li id="siteaction-sitemap">
-                    <a href="http://www.openmicroscopy.org/site/sitemap" accesskey="3" title="Site Map">Site Map</a>
+                    <a href="/site/sitemap" accesskey="3" title="Site Map">Site Map</a>
                 </li>
                 <li id="siteaction-accessibility">
-                    <a href="http://www.openmicroscopy.org/site/accessibility-info" accesskey="0" title="Accessibility">Accessibility</a>
+                    <a href="/site/accessibility-info" accesskey="0" title="Accessibility">Accessibility</a>
                 </li>
                 <li id="siteaction-contact">
-                    <a href="http://www.openmicroscopy.org/site/contact-info" accesskey="9" title="Contact">Contact</a>
+                    <a href="/site/contact-info" accesskey="9" title="Contact">Contact</a>
                 </li>
-            </ul><a id="portal-logo" accesskey="1" href="http://www.openmicroscopy.org/site" name="portal-logo"><img src="http://www.openmicroscopy.org/site/logo.jpg" alt="" title="" height="73" width="450" /></a>
+            </ul><a id="portal-logo" accesskey="1" href="/site" name="portal-logo"><img src="/site/logo.jpg" alt="" title="" height="73" width="450" /></a>
             <div id="portal-globalnav">
                 <div class="csshover">
                     <ul>
@@ -155,7 +155,7 @@
             </ul>
         </div>
         <div id="portal-breadcrumbs">
-            <span id="breadcrumbs-you-are-here">You are here:</span> <a href="http://www.openmicroscopy.org/site">Home</a> <span class="breadcrumbSeparator">→</span> <span dir="ltr"><a href="http://www.openmicroscopy.org/site/support">Support</a> <span class="breadcrumbSeparator">→</span></span> <span dir="ltr"><a href="http://www.openmicroscopy.org/site/support/omero4">OMERO Platform v4</a> <span class="breadcrumbSeparator">→</span> <span dir="ltr"><a href="http://www.openmicroscopy.org/site/support/omero4/docs">Documentation</a> <span class="breadcrumbSeparator">:</span></span> <span dir="ltr"><span>{{title}}</span></span>
+            <span id="breadcrumbs-you-are-here">You are here:</span> <a href="/site">Home</a> <span class="breadcrumbSeparator">→</span> <span dir="ltr"><a href="/site/support">Support</a> <span class="breadcrumbSeparator">→</span></span> <span dir="ltr"><a href="/site/support/omero4">OMERO Platform v4</a> <span class="breadcrumbSeparator">:</span></span> <span dir="ltr"><span>{{title}}</span></span>
         </div>
     </div>
     <div class="visualClear" id="clear-space-before-wrapper-table">


### PR DESCRIPTION
All the paths for links and images on www.openmicroscopy.org are
now relative to top of the website, so the page top menu will only
work after Hudson build has deployed the pages.
