### PR TITLE
Fix linkcheck target for Python (2.5 or less)

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -308,7 +308,8 @@ texinfo_documents = [
 # -- Options for the linkcheck builder ----------------------------------------
 
 # Timeout value, in seconds, for the linkcheck builder
-linkcheck_timeout = 30
+if not (sys.version_info[0] == 2 and sys.version_info[1] <= 5):
+    linkcheck_timeout = 30
 
 # Regular expressions that match URIs that should not be checked when doing a linkcheck build
 linkcheck_ignore = [r'http://localhost:\d+/', 'http://localhost/', 'http://www.hibernate.org',


### PR DESCRIPTION
@jburel, this PR can be tested post 4.4.4.
It should fix `make linkcheck` on systems with Python 2.5 or less.
