### PR TITLE
Move top toctree to the bottom and hide

### DIFF
--- a/index.txt
+++ b/index.txt
@@ -9,6 +9,12 @@ an OMERO server will be more interested by the :doc:`sysadmins/index` and
 subsequent sections. Finally, developers can find more specific information 
 about OMERO in the :doc:`developers/index`.
 
+.. only:: html
+
+    - :doc:`users/index`
+    - :doc:`sysadmins/index`
+    - :doc:`developers/index`
+
 Additional online resources can be found at:
 
 - :omero_plone:`Downloads <downloads>`


### PR DESCRIPTION
The text under the toctree directive was being placed
at the end of the PDF which was disconcerting. Having
the three links show up at the bottom of the page w/o
explanation in the HTML is also a bit disconcerting.
