### PR TITLE
Do not override environement variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    ?=
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build


### PR DESCRIPTION
Allow `SPHINXOPTS` to be passed by environment variable

```
export SPHINXOPTS='"-D html_theme=plonematch"
make clean html
```

or by command-line argument

```
make clean html SPHINXOPTS='"-D html_theme=plonematch"
```

This allows the `SPHINXOPTS` option to be set with the top-level build and in the environment variable section of the hudson job.

Additionally, we could set "-D html_theme=plonematch" as the default  options in the Makefile
