### PR TITLE
Fixing webmobile links to will-moore/webmobile. See #9745

### DIFF
--- a/sysadmins/unix/install-web.txt
+++ b/sysadmins/unix/install-web.txt
@@ -442,7 +442,7 @@ Customising your OMERO.web installation
 
    -  The OMERO.web framework allows you to add additional Django apps.
       For an example with installation instructions, see
-      `webmobile <https://github.com/openmicroscopy/webmobile/>`_
+      `webmobile <http://github.com/will-moore/webmobile/>`_
 
    -  Download or clone from the git repository into the /omeroweb/
       directory, then run

--- a/sysadmins/windows/install-web.txt
+++ b/sysadmins/windows/install-web.txt
@@ -369,7 +369,7 @@ Customising your OMERO.web installation
 
    -  The OMERO.web framework allows you to add additional Django apps.
       For an example with installation instructions, see
-      `webmobile <https://github.com/openmicroscopy/webmobile/>`_
+      `webmobile <http://github.com/will-moore/webmobile/>`_
 
    -  Download or clone from the git repository into the /omeroweb/
       directory, then run


### PR DESCRIPTION
Fix a single link (x2 for unix & windows) to http://github.com/will-moore/webmobile/
