### PR TITLE
Add parameter to control source code branch on Github

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -96,8 +96,8 @@ pygments_style = 'sphinx'
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []
 
-if "MERGE_BRANCH" in os.environ:
-    branch = os.environ.get('MERGE_BRANCH')
+if "SOURCE_BRANCH" in os.environ:
+    branch = os.environ.get('SOURCE_BRANCH')
 else:
     branch = 'develop'
 


### PR DESCRIPTION
Allow to select the branch for the source code links using environment variable `SOURCE_BRANCH`

See openmicroscopy/bioformats#172 for a more detailed description.
