### PR TITLE
User docs on urls supported by webclient. See #9799

### DIFF
--- a/developers/Web/WebGateway.txt
+++ b/developers/Web/WebGateway.txt
@@ -5,8 +5,9 @@ WebGateway is a Django app within the |OmeroWeb|.
 It provides a web API for rendering images and accessing data
 on the OMERO server via urls.
 
-NB: The OMERO.web client also supports urls linking to specified data in OMERO.
-See :doc:`/users/client-tutorials/web/urls_to_data` for more details.
+.. note::
+    NB: The OMERO.web client also supports urls linking to specified data in OMERO.
+    See :doc:`/users/client-tutorials/web/urls_to_data` for more details.
 
 Web services
 ------------

--- a/developers/Web/WebGateway.txt
+++ b/developers/Web/WebGateway.txt
@@ -6,7 +6,7 @@ It provides a web API for rendering images and accessing data
 on the OMERO server via urls.
 
 .. note::
-    NB: The OMERO.web client also supports urls linking to specified data in OMERO.
+    The OMERO.web client also supports urls linking to specified data in OMERO.
     See :doc:`/users/client-tutorials/web/urls_to_data` for more details.
 
 Web services

--- a/developers/Web/WebGateway.txt
+++ b/developers/Web/WebGateway.txt
@@ -5,6 +5,9 @@ WebGateway is a Django app within the |OmeroWeb|.
 It provides a web API for rendering images and accessing data
 on the OMERO server via urls.
 
+NB: The OMERO.web client also supports urls linking to specified data in OMERO.
+See :doc:`/users/client-tutorials/web/urls_to_data` for more details.
+
 Web services
 ------------
 

--- a/users/client-tutorials/web/urls_to_data.txt
+++ b/users/client-tutorials/web/urls_to_data.txt
@@ -1,0 +1,43 @@
+Urls to Data
+============
+
+Since the 4.4.4 release of OMERO, the OMERO.web client has supported direct linking
+to Projects, Datasets, Images etc using a url of this form:
+
+
+::
+
+    /webclient/?show=<datatype>-<id>
+
+For example, to link to Dataset 314 on OMERO.web hosted at http://yourdomain.org/omero/webclient
+the full url will be:
+
+::
+
+    http://yourdomain.org/omero/webclient/?show=dataset-314
+
+This url is supported for the following data types:
+
+ * project
+ * dataset
+ * image
+ * screen
+ * plate
+ * tag
+
+The OMERO.web client will navigate to the specified object, regardless of what containers it is in.
+It will also switch the web client to the correct Group and User (so it will work for any user who has permission to see the object).
+
+For example, if you create a link to an Image, this will be valid even if you move the Image to a 
+different Dataset and/or move it to a different Group.
+
+You can find this url when viewing any object by clicking on the 'link' icon in the right-hand panel.
+
+Multiple objects are also supported using the | symbol, as long as they are in the same container.
+
+::
+
+    webclient/?show=image-2451|image-2452
+
+This will select 2 Images assuming the second one is in the same Dataset as the first. You can generate this
+url by clicking on the 'link' icon when multiple objects are selected.

--- a/users/client-tutorials/web/urls_to_data.txt
+++ b/users/client-tutorials/web/urls_to_data.txt
@@ -18,12 +18,12 @@ the full url will be:
 
 This url is supported for the following data types:
 
- * project
- * dataset
- * image
- * screen
- * plate
- * tag
+* project
+* dataset
+* image
+* screen
+* plate
+* tag
 
 The OMERO.web client will navigate to the specified object, regardless of what containers it is in.
 It will also switch the web client to the correct Group and User (so it will work for any user who has permission to see the object).
@@ -33,7 +33,7 @@ different Dataset and/or move it to a different Group.
 
 You can find this url when viewing any object by clicking on the 'link' icon in the right-hand panel.
 
-Multiple objects are also supported using the | symbol, as long as they are in the same container.
+Multiple objects are also supported using the ``|`` symbol, as long as they are in the same container.
 
 ::
 

--- a/users/index.txt
+++ b/users/index.txt
@@ -53,6 +53,15 @@ OMERO.insight tutorials
     client-tutorials/insight/insight-scripts
     client-tutorials/insight/insight-util-scripts
 
+OMERO.web tutorials
+=======================
+
+.. toctree::
+    :maxdepth: 2
+    :titlesonly:
+
+    client-tutorials/web/urls_to_data
+
 OMERO.editor tutorials
 =======================
 


### PR DESCRIPTION
Docs are under user docs (new OMERO.web section) since this is really OMERO.web client behaviour and is nothing to do with the OMERO.web framework in general. However, there is a link from the developers WebGateway page.
