### PR TITLE
Hide header and menu when printing

### DIFF
--- a/themes/plonematch/static/plonematch.css_t
+++ b/themes/plonematch/static/plonematch.css_t
@@ -176,5 +176,9 @@ pre {
 }
 
 @media print{
-	
+
+#portal-top {
+	display:none;
+}
+
 }


### PR DESCRIPTION
When you print sphinx html pages the header and menu should be hidden.
