### PR TITLE
Redirect links from LOCI website to openmicroscopy.org

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -116,7 +116,6 @@ extlinks = {
     'jenkins' : ('http://hudson.openmicroscopy.org.uk/%s', ''),
     'mailinglist' : ('http://lists.openmicroscopy.org.uk/mailman/listinfo/%s', ''),
     'forum' : ('http://www.openmicroscopy.org/community/%s', ''),
-    'bioformats' : ('http://loci.wisc.edu/software/bio-formats/%s', ''),
     # Plone links. Separating them out so that we can add prefixes and
     # suffixes during testing.
     'community_plone' : ('http://www.openmicroscopy.org/site/community/%s', ''),
@@ -128,6 +127,7 @@ extlinks = {
     'faq_plone' : ('http://www.openmicroscopy.org/site/support/faq/%s', ''),
     'omero_plone' : ('http://www.openmicroscopy.org/site/products/omero/%s/', ''),
     'bf_plone' : ('http://www.openmicroscopy.org/site/products/bio-formats/%s/', ''),
+    'bf_doc' : ('http://www.openmicroscopy.org/site/support/bio-formats/%s', ''),
     }
 
 rst_epilog = """

--- a/developers/Development/Process.txt
+++ b/developers/Development/Process.txt
@@ -82,8 +82,7 @@ Review meetings how to
 Acknowledgement
 ---------------
 
--  Maintain a list of contributors, similar to `loci
-   authors <http://loci.wisc.edu/bio-formats/authors>`_ and
+-  Maintain a list of contributors, similar to
    :about_plone:`contributors <contributers>`.
 -  When a script is submitted:
 

--- a/developers/Development/UsingGit.txt
+++ b/developers/Development/UsingGit.txt
@@ -34,10 +34,9 @@ Bio-Formats
 
 The Bio-Formats repository is available from:
 
--  git@…:bio-formats.git (read/write; requires gitosis configuration)
--  git://openmicroscopy.org/bioformats.git
 -  `<https://github.com/openmicroscopy/bioformats>`_
--  git://dev.loci.wisc.edu/bio-formats.git
+-  git://openmicroscopy.org/bioformats.git
+
 
 OME
 ^^^

--- a/users/client-tutorials/insight/insight-import.txt
+++ b/users/client-tutorials/insight/insight-import.txt
@@ -2,7 +2,7 @@ Importing images
 ================
 
 For more information on the file formats currently supported in OMERO see
-:bioformats:`File Formats <>`.
+:bf_doc:`Supported Formats <supported-formats.html>`.
 
 In order to begin the import of images into an OMERO server, you need to:
 

--- a/users/clients-overview.txt
+++ b/users/clients-overview.txt
@@ -139,7 +139,8 @@ image files to an OMERO Server. For a full tutorial, please see
 :doc:`client-tutorials/insight/insight-import`.
 
 The tool uses Bio-Formats for translation of proprietary file formats in
-preparation for upload to an OMERO Server. Visit :bioformats:`File Formats <>`
+preparation for upload to an OMERO Server. Visit 
+:bf_doc:`Supported Formats <supported-formats.html>`
 for a detailed list of supported formats.
 
 .. figure:: /images/omero_importer_4_4.png

--- a/users/command-line-import.txt
+++ b/users/command-line-import.txt
@@ -6,7 +6,8 @@ OMERO.server from the command line, and is ideally suited for anyone
 wanting to use a shell-scripted or web-based front-end interface for
 importing. Based upon the same set of libraries as the standard
 importer, the command line version supports the same files formats and
-functions in much the same way. Visit :bioformats:`File Formats <>` for a detailed list of supported formats.
+functions in much the same way. Visit :bf_doc:`Supported Formats <supported-formats.html>` 
+for a detailed list of supported formats.
 
 Starting the Command Line Importer
 ----------------------------------

--- a/users/community-resources.txt
+++ b/users/community-resources.txt
@@ -12,7 +12,7 @@ Web
 ---
 
 Our main website is at `<http://www.openmicroscopy.org/site>`_. Bio-Formats
-is at `<http://loci.wisc.edu/software/bio-formats>`_.
+is at `<http://www.openmicroscopy.org/site/products/bio-formats>`_.
 
 
 .. _community/resources/mailinglists:


### PR DESCRIPTION
Same as #142 rebased onto `origin/develop`
