### PR TITLE
Updating forum list on community resources page

### DIFF
--- a/users/community-resources.txt
+++ b/users/community-resources.txt
@@ -45,9 +45,10 @@ Forums
 Discussion on a number topics is also available through our
 :forum:`forums <>`.  Forums include:
 
+- :forum:`OME Announcements <viewforum.php?f=11>`
+
 - :forum:`OMERO <viewforum.php?f=3>`
 
-  + :forum:`Announcements  <viewforum.php?f=11>`
   + :forum:`User Discussion  <viewforum.php?f=4>`
   + :forum:`Installation and Deployment  <viewforum.php?f=5>`
   + :forum:`Developer Discussion  <viewforum.php?f=6>`


### PR DESCRIPTION
Fixing http://www.openmicroscopy.org/site/support/omero4-staging/users/community-resources.html in light of changes to forum
