### PR TITLE
Fixing Win OMERO.server installation web format

### DIFF
--- a/sysadmins/windows/server-installation.txt
+++ b/sysadmins/windows/server-installation.txt
@@ -613,12 +613,12 @@ Installation
 -  You can now test that you can log-in as "root", either with the
    OMERO.insight client or command-line:
 
-    .. parsed-literal::
+   .. parsed-literal::
 
-        C:\\OMERO.server-|version|> bin\\omero login
-        Server: [localhost]
-        Username: [root]
-        Password:         # root_password
+       C:\\OMERO.server-|version|> bin\\omero login
+       Server: [localhost]
+       Username: [root]
+       Password:         # root_password
 
 OMERO.web and administration
 ----------------------------


### PR DESCRIPTION
Web page had funny blue shadows next to some of the highlighted sections and some numbering missing because the file wasn't correctly formatted in places - too many spaces and inconsistent mark-up.

Check between 'Creating a database as root' and 'OMERO.web and administration'
