### PR TITLE
Change broken link for git alias examples (rebased onto develop)

### DIFF
--- a/developers/Development/UsingGit.txt
+++ b/developers/Development/UsingGit.txt
@@ -167,7 +167,7 @@ that is often used among the OME team is "graph":
 
          git config --global alias.graph "log --date-order --graph --decorate --oneline"
 
-See `<http://www.arthurkoziel.com/2008/05/02/git-configuration/>`_
+See `<http://gitready.com/intermediate/2009/02/06/helpful-command-aliases.html>`_
 for even more examples.
 
 Getting started with github


### PR DESCRIPTION
This is the same as gh-194 but rebased onto develop.

---

The actual target is not too terribly critical other than that it should be
clear that alises are very useful.
