### PR TITLE
Fixed forward declartion incomplete type error in c++ example code

### DIFF
--- a/examples/omerocpp/yourcode.cpp
+++ b/examples/omerocpp/yourcode.cpp
@@ -4,6 +4,7 @@
 
 // Domain
 #include <omero/client.h>
+#include <omero/api/IAdmin.h>
 // Std
 #include <iostream>
 #include <cassert>


### PR DESCRIPTION
Compiling the existing example code results in an incomplete type error as omero/client.h includes omero/ServicesF.h which forward declares IAdmin

Fix by including omero/api/IAdmin.h

```
g++  -c -o yourcode.o yourcode.cpp -I/home/dpwrussell/Ice/omero/OMERO.cpp-4.4.5-ice33-posix-gcc-4.6.3-64dbg/include -I/home/dpwrussell/Ice/home/Ice-3.3.1//include 
yourcode.cpp: In function ‘int main(int, char**)’:
yourcode.cpp:30:18: error: invalid use of incomplete type ‘struct IceProxy::omero::api::IAdmin’
/home/dpwrussell/Ice/omero/OMERO.cpp-4.4.5-ice33-posix-gcc-4.6.3-64dbg/include/omero/ServicesF.h:60:7: error: forward declaration of ‘struct IceProxy::omero::api::IAdmin’
make: *** [yourcode.o] Error 1
```
