### PR TITLE
Homebrew installation command (rebased onto develop)

### DIFF
--- a/sysadmins/unix/server-install-homebrew.txt
+++ b/sysadmins/unix/server-install-homebrew.txt
@@ -77,7 +77,7 @@ requirements for OMERO will be installed to ``/usr/local``.
 
 ::
 
-    $ ruby <(curl -fsSkL raw.github.com/mxcl/homebrew/go)
+    $ ruby -e "$(curl -fsSkL raw.github.com/mxcl/homebrew/go)"
     $ brew install git
 
 If you are having issues with curl, see the the :ref:`install_homebrew_curl` section under :ref:`install_homebrew_common_issues`.


### PR DESCRIPTION
This is the same as gh-234 but rebased onto develop.

---

Main goal of this PR is to fix the wrong Homebrew installation command (thanks @stick for noticing it) - see commit 4c2b874.

Added a number of commits fixing redirected links (see [linkcheck output](http://hudson.openmicroscopy.org.uk/job/OMERO-docs-merge-stable/ws/_build/linkcheck/output.txt) ). Linkcheck should still pass, hyperlinks should be unchanged and the size of output.txt reduced.
