### PR TITLE
Add note about Java UTF-8 source in Insight.

### DIFF
--- a/developers/Insight/Contributing.txt
+++ b/developers/Insight/Contributing.txt
@@ -25,7 +25,11 @@ Requirements
 Running code
 ~~~~~~~~~~~~
 
-It is helpful to setup the project in `Eclipse <http://www.eclipse.org>`_.
+It is helpful to set up the project in `Eclipse <http://www.eclipse.org>`_.
+Because the OMERO Java and Python source files are encoded in UTF-8, ensure
+that the encoding in Eclipse
+(:menuselection:`Preferences --> General --> Workspace --> Text file encoding`)
+is also set to UTF-8.
 
 Build system
 ~~~~~~~~~~~~

--- a/developers/standards.txt
+++ b/developers/standards.txt
@@ -45,11 +45,11 @@ People are welcome to speak up for things that they would prefer or pet
 peeves that they have. I will be pulling general wisdom from the
 following:
 
--  ` Mozilla Coding Style
+-  `Mozilla Coding Style
    Guide <http://www.mozilla.org/hacking/mozilla-style-guide.html>`_
--  ` Mono Coding
+-  `Mono Coding
    Guidelines <http://www.mono-project.com/Coding_Guidelines>`_
--  ` GNU Coding
+-  `GNU Coding
    Standards <http://www.gnu.org/prep/standards/html_node/index.html>`_
 -  ...
 
@@ -58,7 +58,12 @@ First versions of our coding styles are available from git at:
 -  :sourcedir:`docs/styles`
 
 Eventually all code will be formatted using these settings and the
-` Eclipse 3.1+ <http://eclipse.org>`_ formatter.
+`Eclipse 3.1+ <http://eclipse.org>`_ formatter. Because the OMERO Java
+and Python source files are encoded in UTF-8, ensure that the encoding
+in Eclipse
+(:menuselection:`Preferences --> General --> Workspace --> Text file encoding`)
+is also set to UTF-8. A policy of UTF-8 encoding for C++ source files is under
+consideration, along with instructions for configuring MSVC accordingly.
 
 Security
 ~~~~~~~~


### PR DESCRIPTION
openmicroscopy/openmicroscopy#721 changes some Insight code to use UTF-8 literals in response to comments in openmicroscopy/openmicroscopy#690
