### PR TITLE
Review the Homebrew installation page

### DIFF
--- a/sysadmins/unix/server-install-homebrew.txt
+++ b/sysadmins/unix/server-install-homebrew.txt
@@ -75,7 +75,7 @@ requirements for OMERO will be installed to :file:`/usr/local`.
     $ ruby -e "$(curl -fsSkL raw.github.com/mxcl/homebrew/go)"
     $ brew install git
 
-If you are having issues with curl, see the the :ref:`install_homebrew_curl` section under :ref:`install_homebrew_common_issues`.
+If you are having issues with curl, see the :ref:`install_homebrew_curl` section under :ref:`install_homebrew_common_issues`.
 
 OMERO installation
 ------------------
@@ -90,7 +90,7 @@ If you just want a deployment of the |release| release of OMERO.server then a si
     $ brew tap ome/alt
     $ brew install omero
 
-This should install OMERO alongside with most of the non-Python requirements.
+This should install OMERO along with most of the non-Python requirements.
 Additional installation options can be listed using the ``info`` command:
 
 ::
@@ -116,26 +116,23 @@ Prepare a place for your OMERO code to live, e.g.
     $ mkdir -p ~/code/projects/OMERO
     $ cd ~/code/projects/OMERO
 
-Now clone the OMERO github repository:
+Now clone and build the OMERO github repository:
 
 ::
 
     $ git clone --recursive git://github.com/openmicroscopy/openmicroscopy
+    $ cd openmicroscopy && ./build.py
 
 .. note::
-    If you have a github account & you plan to develop code for OMERO
-    then you should make a fork into your own account then clone to your
+    If you have a github account and you plan to develop code for OMERO then
+    you should make a fork into your own account then clone this fork to your
     local development machine, e.g.
 
     ::
 
         $ git clone --recursive git://github.com/YOURNAMEHERE/openmicroscopy
+        $ cd openmicroscopy && ./build.py
 
-Then build
-
-::
-
-    $ cd openmicroscopy && ./build.py
 
 Additional OMERO requirements
 -----------------------------
@@ -191,7 +188,7 @@ Edit your .profile as appropriate. The following are indicators of required entr
         connections on Unix domain socket "/var/pgsql_socket/.s.PGSQL.5432"?
 
     make sure :file:`$BREW_DIR/bin` is at the beginning of your :envvar:`PATH`
-    (see also `this post <http://nextmarvel.net/blog/2011/09/brew-install-postgresql-on-os-x-lion/>`_ ).
+    (see also `this post <http://nextmarvel.net/blog/2011/09/brew-install-postgresql-on-os-x-lion/>`_).
 
 Database creation
 ^^^^^^^^^^^^^^^^^
@@ -329,7 +326,7 @@ If you run into problems with Homebrew, you can always run:
 Also, please check the Homebrew `Bug Fixing Checklist <https://github.com/mxcl/homebrew/wiki/Bug-Fixing-Checklist>`_.
 
 Below is a non-exhaustive list of errors/warnings specific to the OMERO
-installation. Some if not all of them could be possible avoided by removing
+installation. Some if not all of them could possibly be avoided by removing
 any previous OMERO installation artifacts from your system.
 
 .. _install_homebrew_curl:


### PR DESCRIPTION
This PR updated the Homebrew installation page to reflect the changes brought:
- to the Homebrew formula including the new style dependencies (ome/homebrew-alt#20) and the 4.4.6 bump (ome/homebrew-alt#21) 
- to the Python dependencies installation script (openmicroscopy/openmicroscopy#764)

Summary of changes:
- modify the installation order as 1- Homebrew, 2- OMERO, 3- Postgresql, 4- Python deps
- merge & update the OSX & Xcode requirements sections (10.5 no longer tested)
- fix various text formatting markup
- add a section about failing `brew install gfortran` under 32-bit Snow Leopard
