### PR TITLE
Review Matlab documentation (see #10389)

### DIFF
--- a/omero/developers/Matlab.txt
+++ b/omero/developers/Matlab.txt
@@ -440,7 +440,7 @@ function::
 
 	thumbnailSet = getThumbnailSet(session, images, width, height);
 
-To preserve the aspect ratio of the retrieved thumbnails, use the :source:`getThumbnailSetByLongestSide <components/tools/OmeroM/src/image/getThumbnailSetByLongestSide.m>` function::
+To preserve the aspect ratio of the retrieved thumbnails, use the :source:`getThumbnailByLongestSideSet <components/tools/OmeroM/src/image/getThumbnailByLongestSideSet.m>` function::
 
 	thumbnailSet = getThumbnailSetByLongestSide(session, images, size);
 
@@ -832,23 +832,6 @@ Rendering images
 
     %Close the rendering engine.
     re.close();
-
--  **Retrieves thumbnails**
-
-::
-
-    store = session.createThumbnailStore();
-    map = store.getThumbnailByLongestSideSet(omero.rtypes.rint(96), java.util.Arrays.asList(java.lang.Long(pixelsId)));
-    %Display the thumbnail;
-    collection = map.values();
-    i = collection.iterator();
-    while (i.hasNext())
-       figure(100);
-       stream = java.io.ByteArrayInputStream(i.next());
-       image = javax.imageio.ImageIO.read(stream);
-       stream.close();
-       imshow(JavaImageToMatlab(image));
-    end
 
 Creating Image
 --------------


### PR DESCRIPTION
This PR reviews the Matlab developers page as describe in the ticket https://trac.openmicroscopy.org.uk/ome/ticket/10389.

It also serves as a placeholder to describe the changes added to OMERO.matlab source code:
- ROI functions: openmicroscopy/openmicroscopy#797
- object loading functions: openmicroscopy/openmicroscopy#817, openmicroscopy/openmicroscopy#1045
- pixels/thumbnail functions: openmicroscopy/openmicroscopy#909, openmicroscopy/openmicroscopy#971
- object deleting function: openmicroscopy/openmicroscopy#952
- annotation functions: openmicroscopy/openmicroscopy#976, openmicroscopy/openmicroscopy#1035, openmicroscopy/openmicroscopy#1040

:warning: Do not merge before 4.4.7
