### PR TITLE
Add mount-point suggestion from Douglas Russell (Fix #9801)

### DIFF
--- a/sysadmins/unix/server-binary-repository.txt
+++ b/sysadmins/unix/server-binary-repository.txt
@@ -29,6 +29,26 @@ The repository is internally laid out as follows:
    OMERO.importer) binaries are
 -  Your PostgreSQL data directory
 
+Locking and remote shares
+-------------------------
+
+The OMERO server requires proper locking semantics on all files in the binary
+repository. In practice, this means that remotely mounted shares such as AFS,
+CIFS, and NFS can cause issues. If you have experience and/or the time to
+manage and monitor the locking implementations of your remote filesystem, then
+using them as for your binary repository should be fine.
+
+If, however, you are seeing errors such as NullPointerExceptions, "Bad file
+descriptors" and similar in your server log, then you will need to use
+directly connected disks.
+
+.. Warning::
+
+    If your binary repository is a remote share and mounting the share fails
+    or is dismounted, OMERO will continue operating using the mount point
+    instead! To prevent this, make the mount point read-only for the OMERO
+    user so that no data can be written to the mount point.
+
 Changing your repository location
 ---------------------------------
 
@@ -78,23 +98,3 @@ dedicated to running OMERO.server. For example:
     drwxr-xr-x  2 omero  omero  1656 Dec 18 14:31 Files
     drwxr-xr-x 25 omero  omero 23256 Dec 10 19:06 Pixels
     drwxr-xr-x  2 omero  omero    48 Dec  8  2006 Thumbnails
-
-Locking and remote shares
--------------------------
-
-The OMERO server requires proper locking semantics on all files in the binary
-repository. In practice, this means that remotely mounted shares such as AFS,
-CIFS, and NFS can cause issues. If you have experience and/or the time to
-manage and monitor the locking implementations of your remote filesystem, then
-using them as for your binary repository should be fine.
-
-If, however, you are seeing errors such as NullPointerExceptions, "Bad file
-descriptors" and similar in your server log, then you will need to use
-directly connected disks.
-
-.. Warning::
-
-    If your binary repository is a remote share and mounting the share fails
-    or is dismounted, OMERO will continue operating using the mount point
-    instead! To prevent this, make the mount point read-only for the OMERO
-    user so that no data can be written to the mount point.


### PR DESCRIPTION
As suggested by Douglas, if the mounted shared disappears or is not present,
OMERO will try to use the mount point instead.

Might be worth checking what happens when a mount disappears.

Questions:
- Is the text too low on the page?
- Does the warning need to be clearly linked from somewhere else?
  
  /cc @hflynn, @bpindelski, @dpwrussell
