### PR TITLE
Tables ArrayColumn docs 9957 (rebased onto develop)

### DIFF
--- a/developers/Tables.txt
+++ b/developers/Tables.txt
@@ -98,15 +98,15 @@ These columns store an array in each row.
 
 .. class:: omero.grid.FloatArrayColumn(name, description, size, [values])
 
-    A value column with fixed width arrays of `float` (32 bit) values.
+    A value column with fixed-width arrays of `float` (32 bit) values.
 
 .. class:: omero.grid.DoubleArrayColumn(name, description, size, [values])
 
-    A value column with fixed width arrays of `double` (64 bit) values.
+    A value column with fixed-width arrays of `double` (64 bit) values.
 
 .. class:: omero.grid.LongArrayColumn(name, description, size, [values])
 
-    A value column with fixed width arrays of `long` (64 bit) values.
+    A value column with fixed-width arrays of `long` (64 bit) values.
 
     :param string name: The column name.
 


### PR DESCRIPTION
This is the same as gh-279 but rebased onto develop.

---

The belated second part of [ticket 9957](http://trac.openmicroscopy.org.uk/ome/ticket/9957), documentation for ArrayColumns.

This applies to new features, so should be held back until the next release.
