### PR TITLE
Add "Link" action to permissions table and to the Key

### DIFF
--- a/sysadmins/server-permissions.txt
+++ b/sysadmins/server-permissions.txt
@@ -201,6 +201,7 @@ Group administrator
 :term:`Edit`        Y         Y          Y
 :term:`Move`        Y         Y          Y
 :term:`Remove`      Y         Y          Y
+:term:`Link`        N         Y          Y
 ================ ======= ========= =============
 
 Group owner
@@ -217,6 +218,7 @@ Group owner
 :term:`Edit`        Y        Y           Y
 :term:`Move`        N        N           N
 :term:`Remove`      Y        Y           Y
+:term:`Link`        N        Y           Y
 ================ ======= ========= =============
 
 Group member
@@ -233,6 +235,7 @@ Group member
 :term:`Edit`        N        N           N
 :term:`Move`        N        N           N
 :term:`Remove`      N        N           N
+:term:`Link`        N        N           N
 ================ ======= ========= =============
 
 Key
@@ -284,6 +287,10 @@ Key
 
 	Remove
 		Remove annotations made by others on your data.
+
+	Link
+		Copy/Move/Remove other users' data to/from your Projects/Datasets/Screens.
+		Copy/Move/Remove your or and others' data to/from others' Projects/Datasets/Screens
 
 
 Issues to be aware of


### PR DESCRIPTION
In preparation of the permissions testing round next week, this is an update of the permissions table. The "Link" functionality was added, which enables users to link their data to others' projects, datasets, screens. This table is used as a reference point for testing scenarios.
