### PR TITLE
Fix .. note indentation

### DIFF
--- a/sysadmins/unix/install-web.txt
+++ b/sysadmins/unix/install-web.txt
@@ -203,12 +203,12 @@ OMERO.web is quite straightforward.
        735 static files copied to '/Users/omero/Desktop/omero/lib/python/omeroweb/static'.
        Starting OMERO.web... [OK]
 
-       .. note::
-           The Django FastCGI workers are managed **separately**
-           from other OMERO.server processes. You can check their status or
-           stop them using the following commands:
+   .. note::
+     The Django FastCGI workers are managed **separately** from other
+     OMERO.server processes. You can check their status or stop them using the
+     following commands:
 
-   ::
+     ::
 
        $ bin/omero web status
        OMERO.web status... [RUNNING] (PID 59217)


### PR DESCRIPTION
This is a small indentation fix that makes the "Note" box render properly on the Web for Unix installation page.
