### PR TITLE
Upgrade page fixes (rebased onto develop)

### DIFF
--- a/sysadmins/server-upgrade.txt
+++ b/sysadmins/server-upgrade.txt
@@ -35,9 +35,8 @@ below. Please refer to each section for additional details.
     :local:
     :depth: 1
 
-.. warning::
-    The passwords and logins used here are examples. Please consult the 
-    :ref:`troubleshooting-password` section for explanation.  In particular,
+.. warning:: The passwords and logins used here are examples. Please consult
+    the :ref:`troubleshooting-password` section for explanation.  In particular,
     make sure to replace the values of **db_user** and **omero_database**
     with the actual database user and database name for your installation.
 


### PR DESCRIPTION
This is the same as gh-263 but rebased onto develop.

---

This was discussed with @ctrueden and @sbesson in devteam on the evening of 22 February.

@ctrueden also suggested changing the formatting of the default/placeholder db names and credentials, so that it's more obvious what needs to be replaced.  Happy to do that here if @hflynn thinks that's a good plan; just let me know how best to accomplish it.
