### PR TITLE
Add recommended shebang line to conf.py

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # ome documentation build configuration file, created by


### PR DESCRIPTION
This PR arises from comment from @manics in https://github.com/openmicroscopy/openmicroscopy/pull/948#issuecomment-15514413

Documentation should still build as previously configured.
