### PR TITLE
Allow to build documentation offline

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -393,7 +393,11 @@ linkcheck_ignore = [
 
 import urllib
 brokenfiles_url = 'https://raw.github.com/openmicroscopy/sphinx-ignore-links/master/broken_links.txt'
-linkcheck_ignore.extend(urllib.urlopen(brokenfiles_url).read().splitlines())
+try:
+   brokenlinks = urllib.urlopen(brokenfiles_url)
+   linkcheck_ignore.extend(brokenlinks.read().splitlines())
+except IOError:
+    print "Could not open list of broken links."
 
 # -- Custom roles for the OMERO documentation -----------------------------------------------
 


### PR DESCRIPTION
This PR was initiated on a train with no Internet connection. In this case, our use of `urllib.urlopen()` fails to read the broken list from GitHub. 

This commit fixes this bug by embedding the url lib call in a `try, except` block and printing a warning message if no URL is found.
