### PR TITLE
Explicitly disallow Python 3 and Ice 3.5 in stable docs

### DIFF
--- a/sysadmins/unix/server-installation.txt
+++ b/sysadmins/unix/server-installation.txt
@@ -74,8 +74,8 @@ installed and available via your $PATH as follows...
     by default, it will be necessary to unselect it and select the Sun 
     version. For more information, see :forum:`this thread  <viewtopic.php?f=5&t=273&p=572&hilit=openjdk#p572>` .
 
-Python (2.4 or higher)
-^^^^^^^^^^^^^^^^^^^^^^
+Python 2 (2.4 or higher)
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 Check you have Python (and what version) by typing:
 
@@ -84,9 +84,7 @@ Check you have Python (and what version) by typing:
     $ python --version
     Python 2.5.1
 
-Due to backwards incompatibilities in Python 3.0, Django does not
-currently work with Python 3.0; for more information see the `Django
-Installation page <https://docs.djangoproject.com/en/1.1/intro/install/>`_.
+OMERO does not support Python 3.
 
 The following are optional depending on what services you require:
 
@@ -126,8 +124,8 @@ The following are optional depending on what services you require:
 .. [3] Allows larger volumes to be viewed in the :omero_plone:`Volume Viewer <volume-viewer-in-omero.web>`.
 
 
-Ice (3.3.x or higher)
-^^^^^^^^^^^^^^^^^^^^^
+Ice (3.3.x or 3.4.x)
+^^^^^^^^^^^^^^^^^^^^
 
 .. note::
 

--- a/sysadmins/windows/server-installation.txt
+++ b/sysadmins/windows/server-installation.txt
@@ -51,8 +51,8 @@ Java SE Development Kit (JDK) (1.5 or higher)
 
 Java SE Downloads are available from `<http://www.oracle.com/technetwork/java/javase/downloads/index.html>`_
 
-Ice (3.3.x or higher)
-^^^^^^^^^^^^^^^^^^^^^
+Ice (3.3.x or 3.4.x)
+^^^^^^^^^^^^^^^^^^^^
 
 .. note::
 
@@ -82,12 +82,8 @@ where :omerocmd:`admin diagnostics` throws any errors related to unexpected
 paths with Ice, please consider installing Ice in the root of the partition
 (e.g. :file:`C:\\Ice`).
 
-Python (2.4 or higher)
-^^^^^^^^^^^^^^^^^^^^^^
-
-Due to backwards incompatibilities in Python 3.0, Django does not
-currently work with Python 3.0; for more information see the `Django
-Installation page <https://docs.djangoproject.com/en/1.1/intro/install/>`_.
+Python 2 (2.4 or higher)
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 Ice 3.4.x requires Python 2.6.x. You must download the 32-bit version
 from `python.org <http://www.python.org/download/releases/2.6.6/>`_.
@@ -95,6 +91,8 @@ As this is the "vanilla" python distribution (no extra libraries),
 you will need to install further dependencies, making sure to
 download the correct version (release number, 32/64-bit) for your Python
 distribution.
+
+OMERO does not currently support Python 3.
 
 PyWin32
 """""""


### PR DESCRIPTION
With the new release of Ice 3.5 we need to make it immediately clear that
Ice 3.5 is not (yet) supported. Similarly, Python 3 is not an option,
whether with or without Django involved.

See forum thread:
- https://www.openmicroscopy.org/community/viewtopic.php?f=5&t=4788&p=9654#p9654
