### PR TITLE
Adding FLIMfit to products & docs menu (rebased onto develop)

### DIFF
--- a/common/themes/plonematch/layout.html
+++ b/common/themes/plonematch/layout.html
@@ -36,6 +36,9 @@
                                     <a href="/site/products/bio-formats" accesskey="b" title="">Bio-Formats</a>
                                 </li>
                                 <li>
+                                    <a href="/site/products/partner" accesskey="p" title="">Partner Projects</a>
+                            </li>
+                            <li>
                                     <a href="/site/products/legacy" accesskey="l" title="">Legacy</a>
                                 </li>
                             </ul>
@@ -51,6 +54,9 @@
                                 </li>
                                 <li>
                                     <a href="/site/support/ome-model" accesskey="f" title="">OME Model and Formats</a>
+                                </li>
+                                <li>
+                                    <a href="/site/support/partner" accesskey="p" title="">Partner Projects</a>
                                 </li>
                                 <li>
                                     <a href="/site/support/legacy" accesskey="l" title="">Legacy</a>


### PR DESCRIPTION
This is the same as gh-335 but rebased onto develop.

---

Making the partner project links to FLIMfit visible so the menus in the docs will match the rest of the site once plone is updated.
