### PR TITLE
Homebrew xquartz (rebased onto develop)

### DIFF
--- a/omero/sysadmins/unix/server-install-homebrew.txt
+++ b/omero/sysadmins/unix/server-install-homebrew.txt
@@ -135,15 +135,20 @@ can use.
 Python dependencies
 ^^^^^^^^^^^^^^^^^^^
 
-Download and execute the ``python_deps.sh`` installation script:
-
-::
+If you installed OMERO using Homebrew, execute the ``omero_python_deps``
+script::
 
     $ cd /usr/local
-    $ curl -fsSkL https://raw.github.com/openmicroscopy/openmicroscopy/dev_4_4/docs/install/python_deps.sh > python_deps.sh
-    $ source python_deps.sh
+    $ bash bin/omero_python_deps
 
-If you encounter problems with the installation script, please take a look at :ref:`install_homebrew_common_issues`.
+If you use a development server, execute the ``python_deps.sh`` script under
+:file:`docs/install`::
+
+    $ cd ~/code/projects/OMERO
+    $ bash docs/install/python_deps.sh
+
+If you encounter problems with the installation script, please take a look at
+:ref:`install_homebrew_common_issues`.
 
 Configuration
 -------------


### PR DESCRIPTION
This is the same as gh-371 but rebased onto develop.

---
- Add instructions for xquartz installation on 10.8
- Fix python dependencies script location
