### PR TITLE
Update download link in read me

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -434,8 +434,9 @@ for the following:
  
 * Trac tickets: ``:ticket: `3442```, displayed as ``<a>#3442</a>``
 * Snapshots: ``:snapshot: `omero/myzip.zip```
-* Plone pages: ``:omero_plone: `Downloads <downloads>```
+* Plone pages: ``:omero_plone: `OME 5 <>```
 * OME Forums: ``:forum: `viewforum.php?f=3```
+* Downloads: ``:downloads: `OMERO downloads <>```
 
 For the most up-to-date list, please consult ``conf.py`` (section
 ``extlinks``).


### PR DESCRIPTION
Realised I forgot to update the extlink section in the read me file when I changed the conf.py

N.B. omero_plone links will go to OME 5 once these pages are live and further PR to change conf.py is done.
