### PR TITLE
Adding ome 5 to product menu (rebased onto dev_4_4)

### DIFF
--- a/common/themes/plonematch/layout.html
+++ b/common/themes/plonematch/layout.html
@@ -39,6 +39,9 @@
                                     <a href="/site/products/partner" accesskey="p" title="">Partner Projects</a>
                             </li>
                             <li>
+                                <a href="/site/products/ome5" accesskey="5" title="">OME 5</a>
+                            </li>
+                            <li>
                                     <a href="/site/products/legacy" accesskey="l" title="">Legacy</a>
                                 </li>
                             </ul>


### PR DESCRIPTION
This is the same as gh-387 but rebased onto dev_4_4.

---

Adding OME 5 product page link to menu shown on documentation pages.

**DO NOT MERGE UNTIL WE ARE READY TO RELEASE OMERO 5 DOCS INCASE THERE IS A 4.4.9 RELEASE BEFORE THEN**
