### PR TITLE
Fixing links so version 5 always links to 5

### DIFF
--- a/common/conf.py
+++ b/common/conf.py
@@ -139,6 +139,7 @@ extlinks = {
     'bf_doc' : (oo_site_root + '/support/bio-formats5/%s', ''),
     # Downloads
     'downloads' : (downloads_root + '/omero/%s', ''),
+    'bf_downloads' : (downloads_root + '/bio-formats/%s', ''),
     # Miscellaneous links
     'snapshot' : (cvs_root + '/snapshots/%s', ''),
     'zeroc' : ('http://zeroc.com/%s', ''),

--- a/formats/ome-xml/java-library.txt
+++ b/formats/ome-xml/java-library.txt
@@ -20,7 +20,7 @@ Download
 --------
 
 You can download **ome-xml.jar** from the 
-:bf_plone:`Bio-Formats downloads <downloads>` page. The
+:bf_downloads:`Bio-Formats downloads <>` page. The
 license is `LGPL <http://www.gnu.org/licenses/lgpl.html>`_.
 
 Installation


### PR DESCRIPTION
When reviewing #413 I noticed that the OMERO 5 docs were still linking to the Bio-Formats 4 documentation for supported formats so I've fixed the conf.py so all the version 5 docs link to other version 5 docs and plone pages.

N.B. Feature_plone isn't currently in use in the develop docs but I've updated it anyway as there are plans to extend the OMERO 5 feature page in future.

**Test** on omero5-staging pages - there are links to the BF docs on https://www.openmicroscopy.org/site/support/omero5-staging/users/clients-overview.html and https://www.openmicroscopy.org/site/support/omero5-staging/users/command-line-import.html
And links to BF docs, BF plone and BF downloads on ome-model-staging:
https://www.openmicroscopy.org/site/support/ome-model-staging/ome-tiff/tools.html
https://www.openmicroscopy.org/site/support/ome-model-staging/ome-tiff/code.html
https://www.openmicroscopy.org/site/support/ome-model-staging/ome-xml/java-library.html

**No need to rebase, develop only**
