### PR TITLE
Sysadmin server overview tidy

### DIFF
--- a/omero/sysadmins/server-overview.txt
+++ b/omero/sysadmins/server-overview.txt
@@ -37,5 +37,5 @@ in a separate process but is co-ordinated centrally.
 
 If you are interested in building components for the server, modifying
 an existing component, or just looking for more background information, there 
-is a section obout the server within the :doc:`/developers/index`;
+is a section about the server within the :doc:`/developers/index`;
 the best starting point is the :doc:`/developers/Server` for developers.


### PR DESCRIPTION
While reviewing the dropbox changes, I noticed the server overview page was basically acting as a second, out-of-date, index page for the sysadmin docs. This fix can be rebased to develop once merged.
