### PR TITLE
OMERO.fs tidy dev_4_4

### DIFF
--- a/omero/developers/Server/FS.txt
+++ b/omero/developers/Server/FS.txt
@@ -1,13 +1,12 @@
 OMERO.fs
 ========
 
-The OMERO.fs service runs somewhere within
-|OmeroGrid| and is responsible for watching a
-particular filesystem directory for changes. These change events are
-then signaled to any observers, who can optionally begin reading the
-file once updated.
+OMERO.fs is a series of on-going changes designed to improve the way an 
+OMERO.server interacts with existing directories of acquired image data. These 
+changes are currently being implemented almost exclusively in the OMERO 5 
+development line. In OMERO version 4.4, OMERO.fs consists of a single 
+component:
 
-One critical use of OMERO.fs is watching a
-directory and kicking off an automatic import. Another is allowing
-system administrators to point OMERO at an existing directory without
-requiring the data duplication required by a traditional import.
+OMERO.dropbox is designed for watching a directory and kicking off an 
+automatic import. The configuration of the DropBox system is covered on the 
+:doc:`OMERO.dropbox </sysadmins/dropbox>` system administrator’s page.


### PR DESCRIPTION
Changes to the OMERO.fs file hadn't been rebased because they were specific to the develop branch, leaving dev_4_4 with an out-of-date page that was confused between OMERO.dropbox and planned FS changes. This makes the dev_4_4 version as close to the develop version as possible. 

Note - because the relative links to the docs and product pages are branch-specific, I can't link to OMERO 5 without putting a full external hard-coded link into this page, which I want to avoid.
