### PR TITLE
Product link removal

### DIFF
--- a/omero/developers/release-process.txt
+++ b/omero/developers/release-process.txt
@@ -126,7 +126,6 @@ Documentation
 
          -  :omero_plone:`Feature List Page <feature-list>`
          -  :omero_plone:`Big Images Support <big-images-support>`
-         -  :omero_plone:`Import in OMERO.insight <import-in-omero.insight>`
          -  :omero_plone:`About Omero <omero-platform-v4>`
          -  :omero_plone:`Volume Viewer in OMERO.web <volume-viewer-in-omero.web>`
          -  :omero_plone:`Downloads <downloads>`


### PR DESCRIPTION
Import-in-omero 4.4 product page was removed as no longer useful or worth promoting separately. This should make omero-docs-merge-stable green again.

N.B. NO REBASE REQUIRED
