### PR TITLE
Homebrew and Python (rebased onto develop)

### DIFF
--- a/omero/sysadmins/unix/server-install-homebrew.txt
+++ b/omero/sysadmins/unix/server-install-homebrew.txt
@@ -170,14 +170,18 @@ can use.
 
     $ brew install postgresql
 
+
+.. _python_dependencies:
+
 Python dependencies
 ^^^^^^^^^^^^^^^^^^^
 
-The Python dependencies can be installed using either the system-wide Python,
-the Homebrew Python or within a virtual environment. If you are using the
-system-wide Python, you may need to use ``sudo`` to install the dependencies.
-If you are using a virtual environment, activate it before calling the Python
-dependencies installation script.
+The Python dependencies can be installed in the system-wide Python
+site-packages, in the Homebrew Python site-packages or within a virtual
+environment. If you are using the system-wide Python site-packages, you may
+need to use ``sudo`` to install the dependencies. If you are using a virtual
+environment, activate it before calling the Python dependencies installation
+script.
 
 If you installed OMERO using Homebrew, execute the ``omero_python_deps``
 script::


### PR DESCRIPTION
This is the same as gh-442 but rebased onto develop.

---

Fixes https://trac.openmicroscopy.org.uk/ome/ticket/11361

This PR does not make an explicit choice between various flavors of Python but rather 
- describes both options i.e. system-wide vs Homebrew Python and highlights their specificities during the OMERO installation. 
- adds links to the Homebrew and Python Wiki page describing the Python formula and its pros/cons
- adds a couple of instructions about virtual environments as well as a link to the Homebrew installation script.
- fixes the environment variables block (remove deprecated `BREW_DIR` and remove `$ICE_HOME/python` from `DYLD_LIBRARY_PATH`)

/cc @bpindelski
