### PR TITLE
Split out main doc sections with bullets

### DIFF
--- a/omero/index.txt
+++ b/omero/index.txt
@@ -2,18 +2,16 @@
 OMERO |release| Documentation
 #############################
 
-The OMERO |release| documentation is divided into three parts. The 
-:doc:`users/index` covers the basic usage of OMERO as well as training 
-material suitable for most end-users. System administrators wanting to install 
-an OMERO server will be more interested by the :doc:`sysadmins/index` and 
-subsequent sections. Finally, developers can find more specific information 
-about OMERO in the :doc:`developers/index`.
+The OMERO |release| documentation is divided into three parts:
 
-.. only:: html
+- :doc:`users/index` covers the basic usage of OMERO as well as
+  training material suitable for most end-users.
 
-    - :doc:`users/index`
-    - :doc:`sysadmins/index`
-    - :doc:`developers/index`
+- :doc:`sysadmins/index` will interest system administrators wanting
+  to install an OMERO server.
+
+- :doc:`developers/index` has more specific information about OMERO
+  for developers.
 
 Additional online resources can be found at:
 


### PR DESCRIPTION
We were already listing them as bullets, but then we also redundantly
linked to them in the introductory paragraph above as well.

Bulleted lists are often much easier to read and digest
(http://www.contentious.com/2004/09/17/bulleted-lists/), so let's just
stick to a single list with the description inline per bullet point.
