### PR TITLE
Update Homebrew installation page to expose Ice 3.4 as the default version (rebased onto develop)

### DIFF
--- a/omero/sysadmins/unix/server-install-homebrew.txt
+++ b/omero/sysadmins/unix/server-install-homebrew.txt
@@ -216,7 +216,7 @@ required entries and correspond to a Homebrew installation of OMERO |version|:
     export PATH=/usr/local/bin:/usr/local/sbin:/usr/local/lib/node_modules:$ICE_HOME/bin:$PATH
     export DYLD_LIBRARY_PATH=$ICE_HOME/lib:$DYLD_LIBRARY_PATH
 
-If you have installed Ice 3.3, replace :envvar:ICE_HOME:  by ``$(brew --prefix zeroc-ice33)``.
+If you have installed Ice 3.3, replace :envvar:`ICE_HOME` by ``$(brew --prefix zeroc-ice33)``.
 
 
 .. note::


### PR DESCRIPTION
This is the same as gh-451 but rebased onto develop.

---

This PR documents the set of changes merged in ome/homebrew-alt#42 defining Ice 3.4 as the new default Ice version for the OMERO Homebrew formula.

/cc @rleigh-dundee
