### PR TITLE
Github help links

### DIFF
--- a/omero/developers/source_code.txt
+++ b/omero/developers/source_code.txt
@@ -80,7 +80,7 @@ when using git on Windows, please be aware of the `CRLF conversion issue`_.
 .. _Cygwin: http://www.cygwin.com/
 .. _TortoiseGit: http://code.google.com/p/tortoisegit/
 .. _VirtualBox: https://www.virtualbox.org/
-.. _CRLF conversion issue: https://help.github.com/articles/dealing-with-line-endings
+.. _CRLF conversion issue: http://help.github.com/articles/dealing-with-line-endings
 
 
 Git configuration

--- a/omero/developers/using-git.txt
+++ b/omero/developers/using-git.txt
@@ -84,7 +84,7 @@ The flip-side of pushing your own branches is being aware that other OME
 developers will also be pushing theirs. GitHub provides a number of ways
 of monitoring either a user or a repository. Notifications about what
 watched users and repositories are doing can be seen in your GitHub
-inbox or via RSS feeds. See `Be social <https://help.github.com/articles/be-social>`_ for more information.
+inbox or via RSS feeds. See `Be social <http://help.github.com/articles/be-social>`_ for more information.
 
 Even if you do not feel able to watch the everyone's repository, you will
 likely want to periodically check in on the current `Pull Requests
@@ -783,7 +783,7 @@ then the target user need only click on a button. If not, then there may
 be some back-and-forth on the work done, similar to the code reviews of
 a deliverable branch. For background, see
 
--  `Using Pull Requests <https://help.github.com/articles/using-pull-requests>`_
+-  `Using Pull Requests <http://help.github.com/articles/using-pull-requests>`_
 -  `Pull Requests 2.0 <https://github.com/blog/712-pull-requests-2-0>`_
 
 If you have discovered that something in the proposed branch needs

--- a/omero/index.txt
+++ b/omero/index.txt
@@ -29,7 +29,7 @@ covered. The source code is hosted on Github. To propose changes and fix
 errors, go to the :omedocs:`documentation repository <>`, fork it, edit the 
 file contents and propose your file changes to the OME team using `Pull Requests`_.
 
-.. _Pull Requests: https://help.github.com/articles/using-pull-requests
+.. _Pull Requests: http://help.github.com/articles/using-pull-requests
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
https help article links are breaking the linkchecker despite actually working, this PR changes the links to http which are still working to make the builds green again without having to add them to the ignore list.
