### PR TITLE
Fix typos on landing page

### DIFF
--- a/omero/index.txt
+++ b/omero/index.txt
@@ -22,7 +22,8 @@ Additional online resources can be found at:
 - :omero_plone:`Screenshots <screenshots>`
 - :omero_plone:`Security Vulnerabilities <secvuln>`
 
-The version *4* releases use the *June 2012* release of the :model_doc:`OME-Model <>`
+OMERO version *4* uses the *June 2012* release of the
+:model_doc:`OME-Model <>`.
 
 This documentation is a work in progress and many aspects of OMERO are not yet 
 covered. The source code is hosted on Github. To propose changes and fix 


### PR DESCRIPTION
This PR fixes a typo on the landing page and makes the sentence easier to understand. This PR will be rebased onto `develop`.

---

--rebased-to #465
