### PR TITLE
index.txt: Correct typos on landing page.

### DIFF
--- a/omero/index.txt
+++ b/omero/index.txt
@@ -21,7 +21,8 @@ Additional online resources can be found at:
 - :omero_plone:`Features (movie tutorials coming soon)<feature-list>`
 - :omero_plone:`Security Vulnerabilities <secvuln>`
 
-The version *5* releases use the *June 2013* release of the :model_doc:`OME-Model <>`
+OMERO version *5* uses the *June 2013* release of the
+:model_doc:`OME-Model <>`.
 
 This documentation is a **work in progress** and many aspects of OMERO are not 
 yet covered. For those already familiar with the documentation, there are 


### PR DESCRIPTION
This is a rebase of #463 onto develop. Due to conflicts `scc` rebase didn't work, hence a manual rebase.

---

--rebased-from #463
