### PR TITLE
Corrections to TIFF supporters urls

### DIFF
--- a/formats/ome-tiff/index.txt
+++ b/formats/ome-tiff/index.txt
@@ -52,7 +52,7 @@ Public image repositories allowing image downloads as OME-TIFF
 
 * `ASCB CELL Image Library <http://www.cellimagelibrary.org/>`_
 * `Harvard Medical School LINCS Project <http://lincs.hms.harvard.edu/>`_
-* `JCB Dataviewer <http://jcb-dataviewer.rupress.org/>`_
+* `JCB DataViewer <http://jcb-dataviewer.rupress.org/>`_
 * `Stowers Institute Original Data Repository <http://odr.stowers.org/>`_
 
 |


### PR DESCRIPTION
A few changes to the OME-TIFF supporters list to correct urls and move Harvard Medical School to the right list.

See https://www.openmicroscopy.org/site/support/ome-model-staging/ome-tiff/index.html to review 
