### PR TITLE
Zeroc forum link update (rebased onto develop)

### DIFF
--- a/omero/developers/GettingStarted/AdvancedClientDevelopment.txt
+++ b/omero/developers/GettingStarted/AdvancedClientDevelopment.txt
@@ -2397,4 +2397,4 @@ Other
 -  Annotation-link-loading can behave strangely if
    ``AnnotationLink.child`` is not loaded.
 -  Python applications can segfault under certain orderings of imports:
-   See :zeroc:`Bus Error under Mac OX 10.4 and IcePy 3.3.0 <forums/bug-reports/3883-bus-error-under-mac-ox-10-4-icepy-3-3-0-a.html>`
+   See :zeroc:`Bus Error under Mac OX 10.4 and IcePy 3.3.0 <forums/showthread.php?t=3883>`


### PR DESCRIPTION
This is the same as gh-468 but rebased onto develop.

---

Zeroc forum links have changed, this updates the link that was making the build unstable - omero-docs-merge-develop should be green again with this built.
