### PR TITLE
Clean up testing.txt (rebased onto develop)

### DIFF
--- a/omero/developers/testing.txt
+++ b/omero/developers/testing.txt
@@ -88,11 +88,10 @@ places several restrictions on the environment:
 Integration tests assume that:
 
 - :envvar:`ICE_CONFIG` has been properly set. The contents of the
-  :file:`ice.config` file located in :file:`etc` should
-  be enough to configure a running server for integration testing. This
-  means that
-  ``omero.client client = new omero.client(); client.createSession()``
-  should be usable with no further configuration needed.
+  :file:`etc/ice.config` file should be enough to configure a running server
+  for integration testing. This means that code creating a client connection
+  as outlined in :doc:`GettingStarted/AdvancedClientDevelopment` should
+  execute without errors.
 - An OMERO.server instance is running on the host and port specified in
   the :envvar:`ICE_CONFIG` file.
 


### PR DESCRIPTION
This is the same as gh-455 but rebased onto develop.

---

This is an initial attempt at cleaning up the developers testing guide. Additions are probably needed, but it is a start.
/cc @joshmoore, @ximenesuk

--rebased-from #455
