### PR TITLE
Scc 0.3.10 (rebased onto develop)

### DIFF
--- a/omero/developers/scc-scripts.txt
+++ b/omero/developers/scc-scripts.txt
@@ -280,7 +280,7 @@ Additionally, for each line of each PR starting with :option:`--rebased-to` or
 :option:`--rebased-from`, the existence of a matching line is checked in the
 corresponding source/target PR. For instance, if PR 70 has a
 :option:`--rebased-from #67` line and a :option:`--rebased-from #66` line,
-then both PRs 66 and 67 should have a :option:`--rebased-to #67` line.
+then both PRs 66 and 67 should have a :option:`--rebased-to #70` line.
 
 This command requires two positional arguments corresponding to the name of
 the branch of origin to compare::


### PR DESCRIPTION
This is the same as gh-472 but rebased onto develop.

---

This PR documents `scc` usage changes since version 0.3.8 .
- add section about `scc update-submodules` command
- add section about `scc unrebased-prs` command including workflow description with the 0.3.10 additions
- expose the `--shallow`/`--remote` options in `scc merge`
- add `--rebased-to/from` comments to the `scc rebase` workflow description

/cc @bpindelski
