### PR TITLE
Update Windows service docs (see #11448) (rebased onto develop)

### DIFF
--- a/omero/sysadmins/windows/service-tools.txt
+++ b/omero/sysadmins/windows/service-tools.txt
@@ -4,25 +4,25 @@ OMERO.server Windows Service
 OMERO.server installs a Windows Service to make the startup of the software
 automatic at Windows boot time.
 
-The :omerocmd:`admin start` command creates and starts a Windows service. In 
-turn, :omerocmd:`admin stop` stops and deletes the OMERO Windows service. 
-Therefore, once :omerocmd:`admin start` succeeds, it is possible to use all 
+The :omerocmd:`admin start` command creates and starts a Windows service. In
+turn, :omerocmd:`admin stop` stops and deletes the OMERO Windows service.
+Therefore, once :omerocmd:`admin start` succeeds, it is possible to use all
 the regular Windows utilities, like ``sc.exe`` or the Services Manager, to
 stop OMERO.server without having the service removed completely.
 
 If required, the OMERO.server service can be run as a different user
 (by modifying the `Log On` settings of the Windows service).
 
-OMERO.server service user
+Service `Log On` user
 -------------------------
 
 Default Windows Local System user
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When no specific Windows user has been defined using :omerocmd:`config set`, 
-the OMERO.server starts as the `Local System` user. This user has enough 
-permissions to access data on the local file system. In most circumstances 
-that should allow the OMERO.server service to access data inside the binary 
+When no specific Windows user has been defined using :omerocmd:`config set`,
+the OMERO.server starts as the `Local System` user. This user has enough
+permissions to access data on the local file system. In most circumstances
+that should allow the OMERO.server service to access data inside the binary
 repository.
 
 Custom user
@@ -58,11 +58,11 @@ the OMERO.server service by accessing the Windows Services Manager (see
     Windows Service `Log On` User Settings
 
 
-Windows Services Manager
-------------------------
+Service startup mode
+--------------------
 
 To start the Services Manager, simply navigate to :menuselection:`Start -->
-All Programs --> Accessories --> Run` (Windows 7). In the dialog, type in 
+All Programs --> Accessories --> Run` (Windows 7). In the dialog, type in
 ``services.msc`` and select :guilabel:`OK` (see :ref:`windows_run_services`).
 
 .. _windows_run_services:
@@ -83,12 +83,18 @@ name the service is started (see :doc:`server-binary-repository`).
 
    OMERO.master Service
 
-Windows Event Viewer
---------------------
+It is also possible to change the service start-up type from
+:guilabel:`Automatic` to :guilabel:`Manual`. The automatic mode guarantees
+that OMERO.server will start during the Windows boot phase. Manual mode
+allows the logged in user or administrator to start the service after
+Windows has finished booting.
 
-Windows Event Viewer allows for watching events occuring in the OMERO.server
+Service events
+--------------
+
+Windows Event Viewer allows for watching events occurring in the OMERO.server
 service. To start the viewer, follow the same path as for Windows Services
-Manager, but this time type in ``eventvwr.msc`` (see 
+Manager, but this time type in ``eventvwr.msc`` (see
 :ref:`windows_run_event`).
 
 .. _windows_run_event:


### PR DESCRIPTION
This is the same as gh-476 but rebased onto develop.

---

This PR updates the doc related to configuring the OMERO.server Windows service. Code changes are in https://github.com/openmicroscopy/openmicroscopy/pull/1508.

This will have to be rebased to `develop`.
--rebased-from #476 
