### PR TITLE
Rewrite the description of the `--continue` option in `scc rebase` (rebased onto develop)

### DIFF
--- a/omero/developers/scc-scripts.txt
+++ b/omero/developers/scc-scripts.txt
@@ -208,10 +208,10 @@ option is set to `none` meaning no PR is merged by default and no default
 :option:`--exclude` option is defined.
 
 The :option:`--include` filter is determined by parsing all the PR comments
-lines starting with :option:`--depends-on`. To include PR 67 in the merge, add
-a comment line starting with :option:`--depends-on #67` to the PR. To include
-PR 60 of the bioformats submodules, add a comment line starting with
-:option:`--depends-on bioformats#600` to the PR.
+lines starting with ``--depends-on``. To include PR 67 in the merge, add a
+comment line starting with ``--depends-on #67`` to the PR. To include PR 60 of
+the bioformats submodules, add a comment line starting with
+``--depends-on bioformats#60`` to the PR.
 
 scc update-submodules
 ---------------------
@@ -260,8 +260,8 @@ Assuming the head branch used to open the PR 142 was called `branch_142`, this
 command will rebase the tip of `branch_142` onto origin/develop, create a new
 local branch called `rebased/develop/branch_142`, push this branch to Github
 and open a new PR. Assuming the command opens PR 150, to facilitate the
-integration with :program:`scc unrebased-prs`, a :option:`--rebased-to #150`
-comment is added to PR 142 and a :option:`--rebased-from #142` comment is
+integration with :program:`scc unrebased-prs`, a ``--rebased-to #150``
+comment is added to PR 142 and a ``--rebased-from #142`` comment is
 added to the PR 150. Finally, the command will switch back to the original
 branch prior to rebasing and delete the local `rebased/develop/branch_142`.
 
@@ -325,8 +325,8 @@ branch prior to rebasing and delete the local `rebased/develop/branch_142`.
 		$ git checkout old_branch
 
 .. versionchanged:: 0.3.10
-	Automatically add :option:`--rebased-to` and :option:`--rebased-from`
-	comments to the	source and target PRs.
+	Automatically add ``--rebased-to`` and ``--rebased-from`` comments to the
+	source and target PRs.
 
 scc unrebased-prs
 -----------------
@@ -343,14 +343,14 @@ following:
 	the branch to check against.
 - 	exclude all merge commits with a note containing either "See gh-" or "n/a"
 - 	for each remaining merge commit, parse the PR number and look into the PR
-	body/comments for lines starting with :option:`--rebased-to`,
-	:option:`--rebased-from` or	:option:`--no-rebase`
+	body/comments for lines starting with ``--rebased-to``, ``--rebased-from``
+	or ``--no-rebase``.
 
-Additionally, for each line of each PR starting with :option:`--rebased-to` or
-:option:`--rebased-from`, the existence of a matching line is checked in the
+Additionally, for each line of each PR starting with ``--rebased-to`` or
+``--rebased-from``, the existence of a matching line is checked in the
 corresponding source/target PR. For instance, if PR 70 has a
-:option:`--rebased-from #67` line and a :option:`--rebased-from #66` line,
-then both PRs 66 and 67 should have a :option:`--rebased-to #70` line.
+``--rebased-from #67`` line and a ``--rebased-from #66`` line, then both PRs
+66 and 67 should have a ``--rebased-to #70`` line.
 
 This command requires two positional arguments corresponding to the name of
 the branch of origin to compare::
@@ -370,7 +370,7 @@ the branch of origin to compare::
 		$ scc unrebased-prs dev_4_4 develop --no-check
 
 .. versionadded:: 0.3.10
-	Added support for body/comment parsing and :option:`--rebased-to/from`
+	Added support for body/comment parsing and ``--rebased-to/from``
 	linkcheck
 
 scc version


### PR DESCRIPTION
This is the same as gh-482 but rebased onto develop.

---

As hinted in openmicroscopy/snoopycrimecop#32, the workflow to be followed when `scc rebase` fails because of conflicts is not very clear and poorly documented.

This PR attempts to solve the second point by describing more thoroughly the `--continue` option of `scc rebase` and the expected workflow from the user. 

/cc @bpindelski @ximenesuk
