### PR TITLE
Fix Java code examples (rebased onto develop)

### DIFF
--- a/omero/developers/Java.txt
+++ b/omero/developers/Java.txt
@@ -834,7 +834,7 @@ in OMERO. Similar approach can be applied when uploading an image.
 
     for (int z = 0; z < sizeZ; z++) {
         for (int t = 0; t < sizeT; t++) {
-            list.add(store.getPlane(z, 0, t));
+            planes.add(store.getPlane(z, 0, t));
         }
     }
 


### PR DESCRIPTION
This is the same as gh-478 but rebased onto develop.

---

This branch addresses a few minor issues with the Java code examples at:
https://www.openmicroscopy.org/site/support/omero4/developers/Java.html

In particular, it corrects a method name of the raw pixels store.
It also corrects indentation and whitespace issues.
