### PR TITLE
Define Spring hyperlink and extlink for Spring doc in OMERO conf.py (rebased onto develop)

### DIFF
--- a/omero/conf.py
+++ b/omero/conf.py
@@ -85,6 +85,7 @@ rst_epilog += """
 .. |ExtendingOmero| replace:: :doc:`/developers/Server/ExtendingOmero`
 .. |BlitzGateway| replace:: :doc:`/developers/Python`
 .. |DevelopingOmeroClients| replace:: :doc:`/developers/GettingStarted/AdvancedClientDevelopment`
+.. _Spring: http://spring.io
 .. |previousversion| replace:: %s
 .. |devbranch| replace:: %s
 .. |iceversion| replace:: 3.5.0
@@ -109,6 +110,8 @@ omero_extlinks = {
     'omerojob' : (omero_job_root + '/%s', ''),
     'javadoc' : (omero_job_root + '/javadoc/%s', ''),
     'virtualjob' : (virtual_job_root + '/%s', ''),
+    # Miscellaneous links
+    'springdoc' : ('http://docs.spring.io/spring/docs/%s', ''),
     }
 extlinks.update(omero_extlinks)
 

--- a/omero/developers/Server/Aop.txt
+++ b/omero/developers/Server/Aop.txt
@@ -9,9 +9,9 @@ complicate an initial examination of the code. Therefore, it is important
 to be aware of what portions of the OMERO code base are "advised" and
 where to find the advisors (in the case of OMERO solely interceptors).
 
-In `Spring <http://www.springsource.org/>`_, advisors are declared in
-the bean definition files (under
-:sourcedir:`components/server/resources/ome/services`, :source:`services.xml <components/server/resources/ome/services/services.xml>`,
+In Spring_, advisors are declared in the bean definition files (under
+:sourcedir:`components/server/resources/ome/services`,
+:source:`services.xml <components/server/resources/ome/services/services.xml>`,
 :source:`hibernate.xml <components/server/resources/ome/services/hibernate.xml>`,
 and others.
 
@@ -73,7 +73,7 @@ you just write:
 
 .. seealso::
 
-    `Aspect Oriented Programming <http://static.springsource.org/spring/docs/2.0.x/reference/aop.html>`_
+    :springdoc:`Aspect Oriented Programming <2.0.x/reference/aop.html>`
         Chapter of the Spring documentation    
 
     `AOP Alliance  <http://aopalliance.sourceforge.net/>`_

--- a/omero/developers/Server/Context.txt
+++ b/omero/developers/Server/Context.txt
@@ -11,9 +11,9 @@ restricted to a single task).
 The container for all OMERO applications is the
 :doc:`/developers/Server/Context`
 (:source:`components/common/src/ome/system/OmeroContext.java`).
-Based on the ` Spring <http://www.springsource.org/>`_ configuration
-backing the context, it can be one of : ``client``, ``internal``, or
-``managed``. The use of a ServiceFactory simplifies this usage for the client. 
+Based on the Spring_ configuration backing the context, it can be one of
+``client``, ``internal``, or ``managed``. The use of a ServiceFactory
+simplifies this usage for the client. 
 
 Hibernate sessions
 ------------------

--- a/omero/developers/Server/ExtendingOmero.txt
+++ b/omero/developers/Server/ExtendingOmero.txt
@@ -225,9 +225,8 @@ little indirection. You can see how such an object is configured in
 Java configuration
 ^^^^^^^^^^^^^^^^^^
 
-Configuration in the Java servers takes place via
-` Spring <http://www.springsource.org/>`_. One or more files matching a
-pattern like ``ome/services/blitz-*.xml`` should be added to your
+Configuration in the Java servers takes place via Spring_. One or more files
+matching a pattern like ``ome/services/blitz-*.xml`` should be added to your
 application.
 
 ::

--- a/omero/developers/Server/HowToCreateAService.txt
+++ b/omero/developers/Server/HowToCreateAService.txt
@@ -33,8 +33,6 @@ factory <components/common/src/ome/system/ServiceFactory.java>`
 Files to create
 ~~~~~~~~~~~~~~~
 
-.. _Spring: http://www.springsource.org/
-
 :source:`components/common/src/ome/api/IConfig.java`
     the interface which will be made available to client and server
     alike (which is why all interfaces must be located in the
@@ -101,7 +99,7 @@ Files involved
 :source:`components/server/resources/beanRefContext.xml`
 
 :source:`components/blitz/resources/beanRefContext.xml`
-    `Singleton definitions <http://static.springsource.org/spring/docs/2.0.x/reference/beans.html#beans-factory-scopes-singleton>`_
+    :springdoc:`Singleton definitions <2.0.x/reference/beans.html#beans-factory-scopes-singleton>`
     which allow for the static location of the active context. These do
     not need to be edited, but in the case of the server
     :source:`beanRefContext.xml <components/server/resources/beanRefContext.xml>`,


### PR DESCRIPTION
This is the same as gh-490 but rebased onto develop.

---
- Use new Spring URLs (http://spring.io and http://docs.spring.io)
- Update all links to Spring main page/documentation in the developers documentation
