### PR TITLE
Script docs image rescaling

### DIFF
--- a/omero/developers/scripts/advanced.txt
+++ b/omero/developers/scripts/advanced.txt
@@ -17,7 +17,6 @@ the client (see diagram, below).
 
 .. figure:: /images/omero-scripting-workflow.png
   :align: center
-  :width: 70%
   :alt: OMERO scripting workflow
 
   OMERO scripting workflow

--- a/omero/developers/scripts/index.txt
+++ b/omero/developers/scripts/index.txt
@@ -28,7 +28,6 @@ download files or images.
 
 .. figure:: /images/scriptUI.png
   :align: center
-  :width: 70%
   :alt: Scripts user interface
 
   A script user interface

--- a/omero/developers/scripts/style-guide.txt
+++ b/omero/developers/scripts/style-guide.txt
@@ -9,7 +9,6 @@ interaction of the scripts with OMERO clients so that they can:
 
 .. figure:: /images/omero-scripting-movie-roi.png
   :align: center
-  :width: 70%
   :alt: Scripting movie ROI figure
 
   Movie ROI figure script UI


### PR DESCRIPTION
Looking over the merged changes to the developers' scripting docs I realised a few of the images were unnecessarily scaled, making them not as clear and also larger than full size. This fixes the issue.
