### PR TITLE
Pdf images resizing (rebased onto develop)

### DIFF
--- a/omero/developers/scripts/advanced.txt
+++ b/omero/developers/scripts/advanced.txt
@@ -15,11 +15,22 @@ client machine.
 The first step is to connect to the server and set up the processor on
 the client (see diagram, below).
 
-.. figure:: /images/omero-scripting-workflow.png
-  :align: center
-  :alt: OMERO scripting workflow
+.. only:: html
 
-  OMERO scripting workflow
+    .. figure:: /images/omero-scripting-workflow.png
+      :align: center
+      :alt: OMERO scripting workflow
+
+      OMERO scripting workflow
+
+.. only:: latex
+
+    .. figure:: /images/omero-scripting-workflow.png
+      :align: center
+      :width: 70%
+      :alt: OMERO scripting workflow
+
+      OMERO scripting workflow
 
 -  You need to download 'Ice' from ZeroC and set the environment
    variables, as described in the server installation page (see 

--- a/omero/developers/scripts/index.txt
+++ b/omero/developers/scripts/index.txt
@@ -26,11 +26,23 @@ download files or images.
 
   Running a script from an OMERO client
 
-.. figure:: /images/scriptUI.png
-  :align: center
-  :alt: Scripts user interface
+.. only:: html
 
-  A script user interface
+    .. figure:: /images/scriptUI.png
+      :align: center
+      :alt: Scripts user interface
+
+      A script user interface
+
+.. only:: latex
+
+    .. figure:: /images/scriptUI.png
+      :align: center
+      :width: 70%
+      :alt: Scripts user interface
+
+      A script user interface
+
 
 Finding scripts
 ---------------

--- a/omero/developers/scripts/style-guide.txt
+++ b/omero/developers/scripts/style-guide.txt
@@ -7,11 +7,22 @@ interaction of the scripts with OMERO clients so that they can:
 -  generate a nice, usable UI for the script
 -  handle the script results appropriately
 
-.. figure:: /images/omero-scripting-movie-roi.png
-  :align: center
-  :alt: Scripting movie ROI figure
+.. only:: html
 
-  Movie ROI figure script UI
+    .. figure:: /images/omero-scripting-movie-roi.png
+      :align: center
+      :alt: Scripting movie ROI figure
+
+      Movie ROI figure script UI
+      
+.. only:: latex
+
+    .. figure:: /images/omero-scripting-movie-roi.png
+      :align: center
+      :width: 60%
+      :alt: Scripting movie ROI figure
+
+      Movie ROI figure script UI
 
 If you want instructions on how to get started with OMERO scripts, see
 the link above or the :doc:`user-guide`.


### PR DESCRIPTION
This is the same as gh-500 but rebased onto develop.

---

When reviewing #498 @mtbc pointed out that while my rescaling looked fine for the html pages, some of the screenshots were too big in the pdf, so this PR uses separate commands for the images so they are scaled appropriately for both formats (60 % one is reduced further than the others to get the placement right across the page breaks, I thought it was still large enough to be legible).
