### PR TITLE
Script sample gh 470 (rebased onto develop)

### DIFF
--- a/omero/developers/scripts/user-guide.txt
+++ b/omero/developers/scripts/user-guide.txt
@@ -79,11 +79,11 @@ and the script returns them as outputs.
     client = scripts.client("Get_Channels.py", "Get channel names for an image",
         scripts.Long("imageId", optional=False))
 
+    # get the Image Id from the parameters.
+    imageId = client.getInput("imageId", unwrap=True)   # unwrap the rtype
+
     # Use the Python Blitz Gateway for convenience
     conn = BlitzGateway(client_obj=client)
-
-    # get the Image Id from the parameters.
-    imageId = client.getInput("imageId").getValue()   # unwrap the rtype
 
     # get the Image, print it's name
     image = conn.getObject("Image", imageId)


### PR DESCRIPTION
This is the same as gh-480 but rebased onto develop.

---

Following on from the discussion on #470, I've updated the sample script to use Blitz Gateway and take an Image ID as input. 

Also removed .inout() from the sample ping script, since we don't use it in any other examples.
