### PR TITLE
Fix broken links after script forum removal.

### DIFF
--- a/omero/users/community-resources.txt
+++ b/omero/users/community-resources.txt
@@ -61,10 +61,6 @@ Discussion on a number topics is also available through our
 
   + :forum:`User Discussion and Suggestions <viewforum.php?f=15>`
 
-- :forum:`Community Code <viewforum.php?f=17>`
-
-  + :forum:`Code Submissions <viewforum.php?f=16>`
-
 Developer documentation
 -----------------------
 


### PR DESCRIPTION
This PR removes the links to the scripts forum which has been removed. This should fix the job error as seen in http://hudson.openmicroscopy.org.uk/view/Failing/job/OMERO-docs-merge-develop/432/.

To test - verify that the OMERO-docs-merge-develop job is stable.
