### PR TITLE
Removing BF anchor until it exists

### DIFF
--- a/omero/sysadmins/UpgradeCheck.txt
+++ b/omero/sysadmins/UpgradeCheck.txt
@@ -14,7 +14,7 @@ this page).
     ``http://upgrade.openmicroscopy.org.uk`` in an error message or log while 
     trying to run one of the **Bio-Formats command line tools**, please see 
     the :bf_doc:`Bio-Formats command line tools documentation 
-    <users/comlinetools/index.html#version-checker>` for assistance.
+    <users/comlinetools/index.html>` for assistance.
 
 
 Actions


### PR DESCRIPTION
This is a temporary PR, **not to be merged**, that removes the anchor link which is making the OMERO docs build yellow until we do a BF version 5 docs release, so I don't miss problems with other PRs again because I'm expecting the build to be yellow anyway.

Makes omero-docs-merge-develop green again.
