### PR TITLE
Update homebrew git link

### DIFF
--- a/omero/developers/source_code.txt
+++ b/omero/developers/source_code.txt
@@ -61,7 +61,7 @@ example, on Debian or Ubuntu::
 Mac OS X
 ^^^^^^^^
 
-You can install git using `Homebrew <http://mxcl.github.com/homebrew/>`_::
+You can install git using `Homebrew <https://github.com/mxcl/homebrew/>`_::
 
         brew install git
 


### PR DESCRIPTION
Link was broken making OMERO-docs-merge-develop unstable. This should make it green again.
