### PR TITLE
Update homebrew git link (rebased onto dev_4_4)

### DIFF
--- a/omero/developers/source_code.txt
+++ b/omero/developers/source_code.txt
@@ -61,7 +61,7 @@ example, on Debian/Ubuntu::
 Mac OS X
 ^^^^^^^^
 
-You can install git using `Homebrew <http://mxcl.github.com/homebrew/>`_::
+You can install git using `Homebrew <https://github.com/mxcl/homebrew/>`_::
 
         brew install git
 


### PR DESCRIPTION
This is the same as gh-534 but rebased onto dev_4_4.

---

Link was broken making OMERO-docs-merge-develop unstable. This should make it green again.

Same link exists in OMERO 4 docs but hasn't been caught by the build yet, link must have only been turned off today.
