### PR TITLE
Adding JVM memory settings to main install docs (rebased onto develop) (rebased onto dev_4_4)

### DIFF
--- a/omero/sysadmins/windows/server-installation.txt
+++ b/omero/sysadmins/windows/server-installation.txt
@@ -749,7 +749,7 @@ descriptors is increasing the memory settings. This is not done by
 default since it would prevent starting the server on some sites' test
 instance, but for production use a setting higher than 512MB is
 **highly** recommended. You can edit the 
-:source:`templates.xml <etc/grid/templates>` file manually using a 
+:source:`templates.xml <etc/grid/templates.xml>` file manually using a 
 notepad-like editor. You should change each occurrence of ``Xmx512M`` to 
 ``Xmx2048M``; similarly ``XX:MaxPermSize=128m`` should be changed to 
 ``XX:MaxPermSize=256M``.


### PR DESCRIPTION
This is the same as gh-538 but rebased onto dev_4_4.

---

This is the same as gh-536 but rebased onto develop.

---

Ticket #11649 fix and some heading tidying to match style-guide
