### PR TITLE
Add paragraph about Ice 3.5 server not supported under Windows

### DIFF
--- a/omero/sysadmins/limitations.txt
+++ b/omero/sysadmins/limitations.txt
@@ -62,10 +62,11 @@ be removed from the binary repository. See
 Ice 3.5
 ^^^^^^^
 
-The Ice 3.5 OMERO.server is not supported on Windows because Ice 3.5 requires
-Python 3, which OMERO does not support (see
-:forum:`OME forum topic <viewtopic.php?f=5&t=7352>`). This limitation does not
-affect Windows Ice 3.5 clients which can connect to an Ice 3.4 server.
+The Ice 3.5 OMERO.server is not supported on Windows out of the box because
+the Ice 3.5 binaries from ZeroC_ require Python 3, which OMERO does not
+support (see :forum:`OME forum topic <viewtopic.php?f=5&t=7352>`). This
+limitation does not affect Windows Ice 3.5 clients which can connect to an Ice
+3.4 server.
 
 Mac OS X issues
 ---------------


### PR DESCRIPTION
This PR documents the limitation of the Ice 3.5 server under Windows as discussed in
https://www.openmicroscopy.org/community/viewtopic.php?f=5&t=7352
