### PR TITLE
Redirect tablestest source link

### DIFF
--- a/omero/developers/Tables.txt
+++ b/omero/developers/Tables.txt
@@ -363,7 +363,7 @@ store. Any suggestions or ideas would be
     :source:`Tables.ice <components/blitz/resources/omero/Tables.ice>`
         The API definition for OMERO.tables
 
-    :sourcedir:`The Tables test suite <components/tools/OmeroPy/test/tablestest/>`
+    :sourcedir:`The Tables test suite <components/tools/OmeroPy/test/integration/tablestest/>`
         The testsuite for OMERO.tables
 
     :doc:`/sysadmins/server-tables`


### PR DESCRIPTION
The table test suite test as moved under `components/tools/OmeroPy/test/integration/`. This PR fixes the source link in the tables documentation page.
