### PR TITLE
Document changes in scc 0.4.0 (rebased onto dev_4_4)

### DIFF
--- a/omero/developers/scc-scripts.txt
+++ b/omero/developers/scc-scripts.txt
@@ -147,7 +147,7 @@ The first argument is the name of the base branch of origin, e.g.::
 	Three options are currently implemented: `none`, `no-error` and
 	`success-only`.	By default (`none`), the status of the last commit on the
 	PR is not taken into account.
-	To include PRs with have a successful status only, e.g. PRs where the
+	To include PRs which have a successful status only, e.g. PRs where the
 	Travis build is green, use the `success-only` option::
 
 		$ scc merge develop -S success-only
@@ -400,7 +400,7 @@ the branch of origin to compare::
 	linkcheck
 
 .. versionchanged:: 0.4.0
-	Improve command output and add support for submodule processing
+	Improved command output and added support for submodule processing
 
 scc version
 -----------


### PR DESCRIPTION
This is the same as gh-545 but rebased onto dev_4_4.

---

See https://github.com/openmicroscopy/snoopycrimecop/issues?milestone=5&state=closed for the set of changes included in the 0.4.0 release.
This PR should describe the principal improvement from a scc user perspective:
- addition of `scc check-status` to check the API status
- addition of `--check-commit-status` filter (currently tested with docs jobs)
- `scc unrebased-prs` improvements

Since versions 0.4.1 and 0.4.2 have been released where 
- 0.4.1 adds internal retries to deal with failing GH API calls 
- 0.4.2 makes an internal fix to hanging scc in a specific case of a Glencoe CI
  Unless people really want to know more about this, I don't think there is anything to document for these 2 releases.
