### PR TITLE
Fix installation link for Homebrew (rebased onto develop)

### DIFF
--- a/omero/sysadmins/unix/server-install-homebrew.txt
+++ b/omero/sysadmins/unix/server-install-homebrew.txt
@@ -63,7 +63,7 @@ requirements for OMERO will be installed to :file:`/usr/local`.
 
 ::
 
-    $ ruby -e "$(curl -fsSkL raw.github.com/mxcl/homebrew/go)"
+    $ ruby -e "$(curl -fsSL https://raw.github.com/mxcl/homebrew/go/install)"
     $ brew install git
 
 If you are having issues with curl, see the :ref:`install_homebrew_curl`


### PR DESCRIPTION
This is the same as gh-555 but rebased onto develop.

---

Document upstream installation changes tested as part of openmicroscopy/openmicroscopy#1812
