### PR TITLE
Remove duplicate entries for "blitz" component. (rebased onto develop)

### DIFF
--- a/omero/developers/build-system.txt
+++ b/omero/developers/build-system.txt
@@ -26,9 +26,6 @@ it is put, and what role it plays in the distribution.
     * - components/blitz/target/blitz.jar
       - lib/server
       - Primary Ice servants
-    * - components/blitz/target/blitz.jar
-      - lib/server
-      - Primary Ice servants
     * - components/blitz/target/server.jar
       - lib/server
       - Primary server logic


### PR DESCRIPTION
This is the same as gh-563 but rebased onto develop.

---

The same item is listed twice in the list of what is in a binary distribution
of OMERO.
