### PR TITLE
Add paragraph about GitHub 2FA and scc commands

### DIFF
--- a/contributing/scc-scripts.txt
+++ b/contributing/scc-scripts.txt
@@ -22,8 +22,8 @@ with the standard library.
 Github connection
 -----------------
 
-.. _About Two-Factor Authentication: https://help.github.com/articles/about-two-factor-authentication
-.. _Creating an access token for command-line use: https://help.github.com/articles/creating-an-access-token-for-command-line-use
+.. _About Two-Factor Authentication: http://help.github.com/articles/about-two-factor-authentication
+.. _Creating an access token for command-line use: http://help.github.com/articles/creating-an-access-token-for-command-line-use
 
 Most of the scc commands instantiate a Github connection using the PyGithub
 package. GitHub strongly recommends to turn on two-factor authentification


### PR DESCRIPTION
Fixes https://trac.openmicroscopy.org.uk/ome/ticket/11760
- Add link on how to create Personal Access Tokens using GitHub interface
- Add command to set personal access token globally
- Mention connection via username/password is not possible if 2FA is on
  ---

--no-rebase
