### PR TITLE
Update DropBox docs for develop

### DIFF
--- a/omero/sysadmins/dropbox.txt
+++ b/omero/sysadmins/dropbox.txt
@@ -22,7 +22,7 @@ the following more specific requirements:
     OMERO.dropbox will currently function on the following systems:
 
     -   Linux with kernel 2.6.13 and higher.
-    -   Mac OS 10.5 and above.
+    -   Mac OS 10.6 and later.
     -   Windows XP and Windows Server 2003.
 
 -   In addition some platforms require further Python packages to be


### PR DESCRIPTION
This very trivial change alters the minimum Mac OS version for DropBox. This simply brings it into line with the system requirements to avoid any confusion.

The Linux kernel version is still a limiting factor though most modern distributions will surpass this minimum. However, our Linux requirements are less tight so the kernel version probably still needs to be stated.

The Windows minimum should probably updated too but how far has DropBox been tested on newer Windows servers?

--no-rebase
