### PR TITLE
Exchange "Link" for user-friendlier "Mix data" cf. Gus's comment

### DIFF
--- a/omero/sysadmins/server-permissions.txt
+++ b/omero/sysadmins/server-permissions.txt
@@ -3,7 +3,7 @@ Permissions overview
 
 In the 4.4 release of OMERO, the groups and permissions system has been
 revamped to allow users to share data with more control. **Users can now
-copy data between groups that they are a member of**.
+move data between groups that they are a member of**.
 
 .. seealso:: :doc:`/developers/Server/Permissions`
 
@@ -189,7 +189,7 @@ of the user performing the action.
 :term:`Edit`                              Y                      Y                       Y
 :term:`Move between groups`               Y                      Y                       Y
 :term:`Remove annotations`                Y                      Y                       Y
-:term:`Link`                              N                      Y                       Y
+:term:`Mix data`                              N                      Y                       Y
 =============================== ======================= ===================== ======================
 
 |
@@ -210,7 +210,7 @@ of the user performing the action.
 :term:`Edit`                              Y                      Y                       Y
 :term:`Move between groups`               N                      N                       N
 :term:`Remove annotations`                Y                      Y                       Y
-:term:`Link`                              N                      Y                       Y
+:term:`Mix data`                              N                      Y                       Y
 =============================== ======================= ===================== ======================
 
 |
@@ -231,7 +231,7 @@ of the user performing the action.
 :term:`Edit`                              N                      N                       N
 :term:`Move between groups`               N                      N                       N
 :term:`Remove annotations`                N                      N                       N
-:term:`Link`                              N                      N                       N
+:term:`Mix data`                              N                      N                       N
 =============================== ======================= ===================== ======================
 
 Key
@@ -279,7 +279,7 @@ Key
 	Remove annotations
 		Remove annotations made by others on your data.
 
-	Link
+	Mix data
 		Copy, Move or Remove other users' data to or from your Projects, Datasets or Screens.
 		Copy, Move or Remove your or others' data to or from others' Projects, Datasets or Screens.
 


### PR DESCRIPTION
During testing of 4.4 -> 5.0 db upgrade the term "Link" have been deemed not to be too informative for the users. 

[See Line 3](https://docs.google.com/spreadsheet/ccc?key=0AoKiTAl8UOxndGt5bm5mOWl4M1lMc1NkQzVVRW5CZGc&usp=drive_web#gid=15) 

Also this PR fixes the inaccurate information about possibility of Copy between groups (this is not possible, only Move is possible).

To test, check [this page](https://www.openmicroscopy.org/site/support/omero5-staging/sysadmins/server-permissions.html) 

/cc @gusferguson @hflynn
