### PR TITLE
Add section about tag plugin in users CLI documentation

### DIFF
--- a/omero/users/command-line-interface.txt
+++ b/omero/users/command-line-interface.txt
@@ -193,7 +193,7 @@ Link tags
 
 Tags can be linked to objects on the server using the :omerocmd:`tag link`
 command. The object must be specified as ``object_type:object_id``. To link
-the tag of identifier ``1260` to the Image of identifier ``1000``, use::
+the tag of identifier ``1260`` to the Image of identifier ``1000``, use::
 
     $ bin/omero tag link Image:1000 1260
 


### PR DESCRIPTION
This commit adds some basic user documentation for the tag plugin written by
by @criswell. The main functionalities of the CLI tag plugin (create, list
and link) are listed as subsections.

---

--no-rebase
