### PR TITLE
Removing reference to beta2

### DIFF
--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -35,7 +35,7 @@ below. Please refer to each section for additional details.
     :depth: 1
 
 .. warning::
-	With 5.0.0-beta2, the default JDBC password provider has been modified to
+	With 5.0.0, the default JDBC password provider has been modified to
 	add password salting support. This implies that once a server has been
 	upgraded and deployed, if passwords are modified, you will not be able
 	to easily revert to a configuration without salting. To keep using the


### PR DESCRIPTION
Git grep shows one hard coded reference to beta2 in the OMERO docs, aside from the one I already removed from the whatsnew file on #590.
