### PR TITLE
Remove reference to toByteArray() function for 4.4.9 doc release

### DIFF
--- a/omero/developers/Matlab.txt
+++ b/omero/developers/Matlab.txt
@@ -722,7 +722,4 @@ Creating Image
 The :source:`CreateImage.m <examples/Training/matlab/CreateImage.m>` example
 script shows how to create an image in OMERO. A similar approach can be
 applied when uploading an image. To upload individual planes onto the server,
-the data must be converted into a byte (int8) array first. If the ``Pixels``
-object has been created, this conversion can done using the
-:source:`toByteArray <components/tools/OmeroM/src/helper/toByteArray.m>`
-function.
+the data must be converted into a byte (int8) array first.


### PR DESCRIPTION
The merging of #571 also includes changes specific to the `dev_4_4` branch and not ready for immediate release. This commit revert the function-specific sentence from the `Create Image` subsection. A reverting PR will opened and merged for 4.4.10 release.

--no-rebase
