### PR TITLE
Removing the 'in transition' banner from docs

### DIFF
--- a/omero/conf.py
+++ b/omero/conf.py
@@ -43,11 +43,6 @@ else:
     previousversion = 'UNKNOWN'
     release = 'UNKNOWN'
 
-rst_prolog = """
-**This documentation is in transition. Please refer to the**
-:omero_plone:`OME5 <>` **products page for more information**.
-"""
-
 rst_epilog += """
 .. |OmeroPy| replace:: :doc:`/developers/Python`
 .. |OmeroCpp| replace:: :doc:`/developers/Cpp`


### PR DESCRIPTION
OMERO 5 docs had an 'in transition' banner for beta1, not required anymore.

--no-rebase
