### PR TITLE
Blitz api5 11852

### DIFF
--- a/omero/developers/Python.txt
+++ b/omero/developers/Python.txt
@@ -1118,7 +1118,7 @@ Filesets - New in OMERO 5
 
 ::
 
-    conn = BlitzGateway("will", "ome", host=HOST, port=PORT)
+    conn = BlitzGateway(USERNAME, PASSWORD, host=HOST, port=PORT)
     conn.connect() 
 
 -  **Configuration**

--- a/omero/developers/Python.txt
+++ b/omero/developers/Python.txt
@@ -10,8 +10,8 @@ we have developed a more user-friendly Python module 'Blitz Gateway' that
 facilitates several aspects of working with the Python API, such as
 connection handling, object graph traversal and lazy loading.
 
-This page first gives you a large number of code samples to get you 
-started. Below these we describe a bit more about :ref:` using the Blitz Gateway <Python#Blitz>`.
+This page gives you a large number of code samples to get you 
+started. Then we describe a bit more about :doc:`PythonBlitzGateway`.
 
 The Python libraries are part of the server build and can be found under
 OMERO\_HOME/lib/python. These include the core omero.model objects and
@@ -20,17 +20,17 @@ services as well as the Blitz Gateway code
 
 
 To use OmeroPy, you will need to download the libraries (E.g. as part of
-the server package) and setup your PYTHONPATH to include them:
+the server package) and setup your :envvar:`PYTHONPATH` to include them:
 
 .. parsed-literal::
 
       export OMERO_PREFIX=~/Desktop/|OMEROserver|       # for example
-      export PYTHONPATH=$OMERO_PREFIX/lib/python
+      export PYTHONPATH=$PYTHONPATH:$OMERO_PREFIX/lib/python
 
 .. |OMEROserver| replace:: OMERO.server-|release|-ice3x-byy
 
 
-You will also need Ice libraries 3.3.x or 3.4.x as described in the 
+You will also need Ice libraries as described in the 
 :doc:`/sysadmins/unix/server-installation` and an OMERO server to connect to, 
 which must be the same major version, i.e. |version|.x.
 
@@ -1115,261 +1115,3 @@ OMERO.web by any users of the server. See :doc:`/developers/scripts/user-guide`.
 
 .. _Python#Blitz:
 
-Blitz Gateway documentation
----------------------------
-
-The epydoc-generated documentation of methods provided by OMERO Gateway
-is available showing :javadoc:` wrapper classes <epydoc/omero.gateway-module.html>`.
-
-Specifically, the API for the 'conn' connection wrapper created above is
-:javadoc:` here <epydoc/omero.gateway._BlitzGateway-class.html>`.
-
-When working with :javadoc:` OMERO model objects <slice2html/omero/model.html>`
-(omero.model.Image etc) the Gateway will wrap these objects in classes
-such as
-:javadoc:` omero.gateway.ImageWrapper <epydoc/omero.gateway._ImageWrapper-class.html>`
-to handle object loading and hierarchy traversal. For example:
-
-::
-
-    >>> for p in conn.listProjects():         # Initially we just load Projects
-    ...     print p.getName()
-    ...     for dataset in p.listChildren():      # lazy-loading of Datasets here
-    ...             print "  ", dataset.getName()
-    ... 
-    TestProject
-       Aurora-B
-    tiff stacks
-       newTimeStack
-       test
-    siRNAi
-       CENP
-       live-cell
-       survivin
-
-Access to the OMERO API services
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-If you need access to API methods that are not provided by the gateway
-library, you can get hold of the |OmeroApi|. 
-
-.. note::
- 
-    These services will always work
-    with omero.model objects and not the gateway wrapper objects.
-
-The gateway handles creation and reuse of the API services, so that new
-ones are not created unnecessarily. Services can be accessed using the
-methods of the underlying :javadoc:` Service
-Factory <slice2html/omero/api/ServiceFactory.html>`
-with the Gateway handling reuse as needed. Stateless services (those
-retrieved with get… methods E.g.
-:javadoc:` getQueryService <slice2html/omero/api/ServiceFactory.html#getQueryService>`)
-are always reused for each call, E.g. blitzon.getQueryService() whereas
-stateful services E.g.
-:javadoc:` createRenderingEngine <slice2html/omero/api/ServiceFactory.html#createRenderingEngine>`
-may be created each time.
-
-Not all methods of the service factory are currently supported in the
-gateway. You can get an idea of the currently supported services by
-looking at the source code under the
-:javadoc:` \_createProxies <epydoc/omero.gateway-pysrc.html#_BlitzGateway._createProxies>`
-method.
-
-Example: ContainerService can load Projects and Datasets in a single
-call to server (no lazy loading)
-
-::
-
-    cs = conn.getContainerService()
-    projects = cs.loadContainerHierarchy("Project", None, None)
-    for p in projects:                # omero.model.ProjectI
-        print p.getName().getValue()     # need to 'unwrap' rstring
-        for d in p.linkedDatasetList():
-            print d.getName().getValue()
-
-Stateful services, reconnection, error handling etc
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The Blitz gateway was designed for use in the |OmeroWeb| framework and it is 
-not expected that stateful services will be maintained on the client for 
-significant time.
-There is various error-handling functionality in the Blitz gateway that
-will close existing services and recreate them in order to maintain a
-working connection. If this happens then any stateful services that you
-have on the client-side will become stale. We will attempt to document
-this a little better in due course, but our general advice is to create,
-use and close the stateful services in the shortest practicable time.
-
-Overwriting and extending omero.gateway classes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-When working with
-:javadoc:` omero.gateway <epydoc/omero.gateway._BlitzGateway-class.html>`
-or wrapper classes such as
-:javadoc:` omero.gateway.ImageWrapper <epydoc/omero.gateway._ImageWrapper-class.html>`
-you might want to add your own functionality or customize an existing
-one. NB: Note the call to ``omero.gateway.refreshWrappers()`` to ensure
-that your subclasses are returned by calls to getObjects() For example:
-
-::
-
-    class MyBlitzGateway (omero.gateway.BlitzGateway):
-
-        def __init__ (self, *args, **kwargs):
-            super(MyBlitzGateway, self).__init__(*args, **kwargs)
-            
-            ...do something, e.g. add new field...
-            self.new_field = 'foo'
-
-        def connect (self, *args, **kwargs):
-                    
-            rv = super(MyBlitzGateway, self).connect(*args,**kwargs)
-            if rv: 
-                ...do something, e.g. modify new field...
-                self.new_field = 'bla'
-            
-            return rv
-        
-    omero.gateway.BlitzGateway = MyBlitzGateway
-
-    class MyBlitzObjectWrapper (object):
-        
-        annotation_counter = None
-
-        def countAnnotations (self):
-            """
-            Count on annotations linked to the object and set the value
-            on the custom field 'annotation_counter'.
-
-            @return     Counter
-            """
-            
-            if self.annotation_counter is not None:
-                return self.annotation_counter
-            else:
-                container = self._conn.getContainerService()
-                m = container.getCollectionCount(self._obj.__class__.__name__, type(self._obj).ANNOTATIONLINKS, [self._oid], None)
-                if m[self._oid] > 0:
-                    self.annotation_counter = m[self._oid]
-                    return self.annotation_counter
-                else:
-                    return None
-
-    class ImageWrapper (MyBlitzObjectWrapper, omero.gateway.ImageWrapper):
-        """
-        omero_model_ImageI class wrapper overwrite omero.gateway.ImageWrapper
-        and extends MyBlitzObjectWrapper.
-        """
-        
-        def __prepare__ (self, **kwargs):
-            if kwargs.has_key('annotation_counter'):
-                self.annotation_counter = kwargs['annotation_counter']
-
-    omero.gateway.ImageWrapper = ImageWrapper
-
-    # IMPORTANT to update the map of wrappers for 'Image' etc. returned by getObjects("Image")
-    omero.gateway.refreshWrappers()
-
-This page provides some background information on the OMERO Python
-client 'gateway' (omero.gateway module) and describes work to improve
-the API, beginning with the OMERO 4.3 release.
-
-The Blitz Gateway is a Python client-side library that facilitates working 
-with the OMERO API, handling connection to the server, loading of data
-objects and providing convenience methods to access the data. It was
-originally designed as part of the |OmeroWeb| framework, 
-to provide connection and data retrieval services to various
-web clients. However, we have now decided to encourage its use for all
-access to the OMERO Python API.
-
-Wrapper objects
-^^^^^^^^^^^^^^^
-
-The Gateway consists of a number of wrapper objects:
-
-Connection wrapper
-""""""""""""""""""
-
-The BlitzGateway class (see :javadoc:` API of development code <epydoc/omero.gateway._BlitzGateway-class.html>`)
-is a wrapper for the OMERO client and session objects. It provides
-various methods for connecting to the OMERO server, querying the status
-or context of the current connection and as a starting point for
-retrieving data objects from OMERO.
-
-::
-
-    from omero.gateway import *
-
-    conn = BlitzGateway("username", "password", host="localhost", port=4064)
-    conn.connect()
-
-    for p in conn.listProjects():
-        print p.name
-
-Model object wrappers
-"""""""""""""""""""""
-
-OMERO model objects, E.g. omero.model.Project, omero.model.Pixels etc
-(see :javadoc:` full list <slice2html/omero/model.html>`)
-are code-generated and mapped to the OMERO database schema. They are
-language agnostic and their data is in the form of omero.rtypes as
-described: :ref:` about model objects <AdvancedClientDevelopment#Objects>`).
-
-::
-
-    import omero
-    from omero.model import *
-    from omero.rtypes import rstring
-    p = omero.model.ProjectI()
-    p.name = rstring("My Project")   # attributes are all rtypes
-    print p.getName().getValue()     # getValue() to unwrap the rtype
-    print p.name.val                 # short-hand 
-
-To facilitate work in Python, particularly in web page templates, these
-Python model objects are wrapped in Blitz Object Wrappers. This hides
-the use of rtypes.
-
-::
-
-    import omero
-    from omero.model import *
-    from omero.rtypes import rstring
-    p = omero.model.ProjectI()
-    p.setName(rstring("Omero Model Project"))   # attributes are all rtypes
-    print p.getName().getValue()                # getValue() to unwrap the rtype
-    print p.name.val                            # short-hand
-
-    from omero.gateway import *
-    project = ProjectWrapper(obj=p)             # wrap the model.object
-    project.setName("Project Wrapper")          # Don't need to use rtypes
-    print project.getName()
-    print project.name
-
-    print project._obj                  # access the wrapped object with ._obj
-
-These wrappers also have a reference to the BlitzGateway connection
-wrapper, so they can make calls to the server and load more data when
-needed (lazy loading).
-
-E.g.
-
-::
-
-    # connect as above
-    for p in conn.listProjects():
-        print p.name
-        for dataset in p.listChildren():   # lazy loading of datasets, wrapped in DatasetWrapper
-            print "Dataset", d.name
-
-Wrapper coverage
-""""""""""""""""
-
-The OMERO data model has a large number of objects, not all of which
-are used by the |OmeroWeb| framework. For this reason, the Blitz
-gateway (which was originally built for |OmeroWeb|) has not yet been
-extended to wrap every omero.model object with a specific Blitz Object
-Wrapper. The current list of object wrappers can be found in the
-omero.gateway module :javadoc:`API<epydoc/omero.gateway-module.html>`.
-As more functionality is provided by the Blitz Gateway, the coverage
-of object wrappers will increase accordingly.

--- a/omero/developers/Python.txt
+++ b/omero/developers/Python.txt
@@ -152,6 +152,13 @@ Connect to OMERO
 
 ::
 
+        # New in OMERO 5
+        print "Admins:"
+        for exp in conn.getAdministrators():
+            print "   ID:", exp.getId(), exp.getOmeName(), " Name:", exp.getFullName()
+
+::
+
         # The 'context' of our current session
         ctx = conn.getEventContext()
         # print ctx     # for more info 
@@ -1096,6 +1103,68 @@ Create Image
     desc = "Image created from Image ID: %s by averaging Channel 1 and Channel 2" % imageId
     i = conn.createImageFromNumpySeq(planeGen(), "new image",\
             sizeZ, newSizeC, sizeT, description=desc, dataset=dataset) 
+
+-  **Close connection:**
+
+::
+
+    # When you are done, close the session to free up server resources.
+    conn._closeSession() 
+
+Filesets - New in OMERO 5
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  **Create a connection**
+
+::
+
+    conn = BlitzGateway("will", "ome", host=HOST, port=PORT)
+    conn.connect() 
+
+-  **Configuration**
+
+::
+
+    imageId = 101 
+
+-  **Get the 'Fileset' for an Image**
+
+::
+
+    # A Fileset is a collection of the original files imported to
+    # create an image or set of images in OMERO.
+    image = conn.getObject("Image", imageId)
+    fileset = image.getFileset()       # will be None for pre-FS images
+    fsId = fileset.getId()
+    # List all images that are in this fileset
+    for fsImage in fileset.copyImages():
+        print fsImage.getId(), fsImage.getName()
+    # List original imported files
+    for origFile in fileset.listFiles():
+        name = origFile.getName()
+        path = origFile.getPath()
+        print path, name 
+
+-  **Get Original Imported Files directly from the image**
+
+::
+
+    # this will include pre-FS data IF images were archived on import
+    print image.countImportedImageFiles()
+    # specifically count Fileset files
+    fileCount = image.countFilesetFiles()
+    # list files
+    if fileCount > 0:
+        for origFile in image.getImportedImageFiles():
+            name = origFile.getName()
+            path = origFile.getPath()
+            print path, name 
+
+-  **Can get the Fileset using conn.getObject()**
+
+::
+
+    fileset = conn.getObject("Fileset", fsId) 
 
 -  **Close connection:**
 

--- a/omero/developers/PythonBlitzGateway.txt
+++ b/omero/developers/PythonBlitzGateway.txt
@@ -1,0 +1,258 @@
+Blitz Gateway documentation
+---------------------------
+
+The epydoc-generated documentation of methods provided by OMERO Gateway
+is available showing :javadoc:` wrapper classes <epydoc/omero.gateway-module.html>`.
+
+Specifically, the API for the 'conn' connection wrapper created above is
+:javadoc:` here <epydoc/omero.gateway._BlitzGateway-class.html>`.
+
+When working with :javadoc:` OMERO model objects <slice2html/omero/model.html>`
+(omero.model.Image etc) the Gateway will wrap these objects in classes
+such as
+:javadoc:` omero.gateway.ImageWrapper <epydoc/omero.gateway._ImageWrapper-class.html>`
+to handle object loading and hierarchy traversal. For example:
+
+::
+
+    >>> for p in conn.listProjects():         # Initially we just load Projects
+    ...     print p.getName()
+    ...     for dataset in p.listChildren():      # lazy-loading of Datasets here
+    ...             print "  ", dataset.getName()
+    ... 
+    TestProject
+       Aurora-B
+    tiff stacks
+       newTimeStack
+       test
+    siRNAi
+       CENP
+       live-cell
+       survivin
+
+Access to the OMERO API services
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you need access to API methods that are not provided by the gateway
+library, you can get hold of the |OmeroApi|. 
+
+.. note::
+ 
+    These services will always work
+    with omero.model objects and not the gateway wrapper objects.
+
+The gateway handles creation and reuse of the API services, so that new
+ones are not created unnecessarily. Services can be accessed using the
+methods of the underlying :javadoc:` Service
+Factory <slice2html/omero/api/ServiceFactory.html>`
+with the Gateway handling reuse as needed. Stateless services (those
+retrieved with get… methods E.g.
+:javadoc:` getQueryService <slice2html/omero/api/ServiceFactory.html#getQueryService>`)
+are always reused for each call, E.g. blitzon.getQueryService() whereas
+stateful services E.g.
+:javadoc:` createRenderingEngine <slice2html/omero/api/ServiceFactory.html#createRenderingEngine>`
+may be created each time.
+
+Not all methods of the service factory are currently supported in the
+gateway. You can get an idea of the currently supported services by
+looking at the source code under the
+:javadoc:` \_createProxies <epydoc/omero.gateway-pysrc.html#_BlitzGateway._createProxies>`
+method.
+
+Example: ContainerService can load Projects and Datasets in a single
+call to server (no lazy loading)
+
+::
+
+    cs = conn.getContainerService()
+    projects = cs.loadContainerHierarchy("Project", None, None)
+    for p in projects:                # omero.model.ProjectI
+        print p.getName().getValue()     # need to 'unwrap' rstring
+        for d in p.linkedDatasetList():
+            print d.getName().getValue()
+
+Stateful services, reconnection, error handling etc
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The Blitz gateway was designed for use in the |OmeroWeb| framework and it is 
+not expected that stateful services will be maintained on the client for 
+significant time.
+There is various error-handling functionality in the Blitz gateway that
+will close existing services and recreate them in order to maintain a
+working connection. If this happens then any stateful services that you
+have on the client-side will become stale. We will attempt to document
+this a little better in due course, but our general advice is to create,
+use and close the stateful services in the shortest practicable time.
+
+Overwriting and extending omero.gateway classes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When working with
+:javadoc:` omero.gateway <epydoc/omero.gateway._BlitzGateway-class.html>`
+or wrapper classes such as
+:javadoc:` omero.gateway.ImageWrapper <epydoc/omero.gateway._ImageWrapper-class.html>`
+you might want to add your own functionality or customize an existing
+one. NB: Note the call to ``omero.gateway.refreshWrappers()`` to ensure
+that your subclasses are returned by calls to getObjects() For example:
+
+::
+
+    class MyBlitzGateway (omero.gateway.BlitzGateway):
+
+        def __init__ (self, *args, **kwargs):
+            super(MyBlitzGateway, self).__init__(*args, **kwargs)
+            
+            ...do something, e.g. add new field...
+            self.new_field = 'foo'
+
+        def connect (self, *args, **kwargs):
+                    
+            rv = super(MyBlitzGateway, self).connect(*args,**kwargs)
+            if rv: 
+                ...do something, e.g. modify new field...
+                self.new_field = 'bla'
+            
+            return rv
+        
+    omero.gateway.BlitzGateway = MyBlitzGateway
+
+    class MyBlitzObjectWrapper (object):
+        
+        annotation_counter = None
+
+        def countAnnotations (self):
+            """
+            Count on annotations linked to the object and set the value
+            on the custom field 'annotation_counter'.
+
+            @return     Counter
+            """
+            
+            if self.annotation_counter is not None:
+                return self.annotation_counter
+            else:
+                container = self._conn.getContainerService()
+                m = container.getCollectionCount(self._obj.__class__.__name__, type(self._obj).ANNOTATIONLINKS, [self._oid], None)
+                if m[self._oid] > 0:
+                    self.annotation_counter = m[self._oid]
+                    return self.annotation_counter
+                else:
+                    return None
+
+    class ImageWrapper (MyBlitzObjectWrapper, omero.gateway.ImageWrapper):
+        """
+        omero_model_ImageI class wrapper overwrite omero.gateway.ImageWrapper
+        and extends MyBlitzObjectWrapper.
+        """
+        
+        def __prepare__ (self, **kwargs):
+            if kwargs.has_key('annotation_counter'):
+                self.annotation_counter = kwargs['annotation_counter']
+
+    omero.gateway.ImageWrapper = ImageWrapper
+
+    # IMPORTANT to update the map of wrappers for 'Image' etc. returned by getObjects("Image")
+    omero.gateway.refreshWrappers()
+
+This page provides some background information on the OMERO Python
+client 'gateway' (omero.gateway module) and describes work to improve
+the API, beginning with the OMERO 4.3 release.
+
+The Blitz Gateway is a Python client-side library that facilitates working 
+with the OMERO API, handling connection to the server, loading of data
+objects and providing convenience methods to access the data. It was
+originally designed as part of the |OmeroWeb| framework, 
+to provide connection and data retrieval services to various
+web clients. However, we have now decided to encourage its use for all
+access to the OMERO Python API.
+
+Wrapper objects
+^^^^^^^^^^^^^^^
+
+The Gateway consists of a number of wrapper objects:
+
+Connection wrapper
+""""""""""""""""""
+
+The BlitzGateway class (see :javadoc:` API of development code <epydoc/omero.gateway._BlitzGateway-class.html>`)
+is a wrapper for the OMERO client and session objects. It provides
+various methods for connecting to the OMERO server, querying the status
+or context of the current connection and as a starting point for
+retrieving data objects from OMERO.
+
+::
+
+    from omero.gateway import *
+
+    conn = BlitzGateway("username", "password", host="localhost", port=4064)
+    conn.connect()
+
+    for p in conn.listProjects():
+        print p.name
+
+Model object wrappers
+"""""""""""""""""""""
+
+OMERO model objects, E.g. omero.model.Project, omero.model.Pixels etc
+(see :javadoc:` full list <slice2html/omero/model.html>`)
+are code-generated and mapped to the OMERO database schema. They are
+language agnostic and their data is in the form of omero.rtypes as
+described: :ref:` about model objects <AdvancedClientDevelopment#Objects>`).
+
+::
+
+    import omero
+    from omero.model import *
+    from omero.rtypes import rstring
+    p = omero.model.ProjectI()
+    p.name = rstring("My Project")   # attributes are all rtypes
+    print p.getName().getValue()     # getValue() to unwrap the rtype
+    print p.name.val                 # short-hand 
+
+To facilitate work in Python, particularly in web page templates, these
+Python model objects are wrapped in Blitz Object Wrappers. This hides
+the use of rtypes.
+
+::
+
+    import omero
+    from omero.model import *
+    from omero.rtypes import rstring
+    p = omero.model.ProjectI()
+    p.setName(rstring("Omero Model Project"))   # attributes are all rtypes
+    print p.getName().getValue()                # getValue() to unwrap the rtype
+    print p.name.val                            # short-hand
+
+    from omero.gateway import *
+    project = ProjectWrapper(obj=p)             # wrap the model.object
+    project.setName("Project Wrapper")          # Don't need to use rtypes
+    print project.getName()
+    print project.name
+
+    print project._obj                  # access the wrapped object with ._obj
+
+These wrappers also have a reference to the BlitzGateway connection
+wrapper, so they can make calls to the server and load more data when
+needed (lazy loading).
+
+E.g.
+
+::
+
+    # connect as above
+    for p in conn.listProjects():
+        print p.name
+        for dataset in p.listChildren():   # lazy loading of datasets, wrapped in DatasetWrapper
+            print "Dataset", d.name
+
+Wrapper coverage
+""""""""""""""""
+
+The OMERO data model has a large number of objects, not all of which
+are used by the |OmeroWeb| framework. For this reason, the Blitz
+gateway (which was originally built for |OmeroWeb|) has not yet been
+extended to wrap every omero.model object with a specific Blitz Object
+Wrapper. The current list of object wrappers can be found in the
+omero.gateway module :javadoc:`API<epydoc/omero.gateway-module.html>`.
+As more functionality is provided by the Blitz Gateway, the coverage
+of object wrappers will increase accordingly.

--- a/omero/developers/index.txt
+++ b/omero/developers/index.txt
@@ -58,6 +58,7 @@ Using the OMERO API
     :titlesonly:
 
     Python
+    PythonBlitzGateway
     command-line-interface
     Java
     Matlab

--- a/omero/developers/whatsnew.txt
+++ b/omero/developers/whatsnew.txt
@@ -25,3 +25,5 @@ What's new for OMERO 5
   :devs_doc:`Contributing Developer Documentation <>` section so it is easier
   to find. It has also been updated to better explain our development
   processes.
+
+- :doc:`Python` describes additions to the BlitzGateway API to support Filesets.


### PR DESCRIPTION
Update the Python API page to include what's new in OMERO 5 - mostly Fileset stuff.

This code has been added to /examples/Training/python and tested before porting to docs.

Also split the Python page into 2, since it was getting too big. This will probably need to be back-ported to 4.4.
