### PR TITLE
Fixing link to developer docs

### DIFF
--- a/contributing/using-git.txt
+++ b/contributing/using-git.txt
@@ -6,8 +6,7 @@ contributing to our code base using git. It should contain all the useful
 commands and configuration you need for doing most git tasks.
 
 For basic instructions on how to install and configure Git and checkout the
-source code, look at the
-:omero_doc:`installing OMERO from source <developers/installation.html>` page.
+source code, look at the :doc:`source-code` page.
 
 .. note::
     This section assumes that “gh” is your own personal GitHub repository, and


### PR DESCRIPTION
Link was going to developer docs but this content is actually also within the contributing docs so link should go there.
