### PR TITLE
Replace old version Django docs link

### DIFF
--- a/omero/sysadmins/unix/install-web.txt
+++ b/omero/sysadmins/unix/install-web.txt
@@ -30,9 +30,9 @@ Prerequisites
 -  OMERO and its prerequisites (see :doc:`server-installation`).
 
 -  Python version from 2.4 to 2.7 (due to backwards incompatibilities in
-   Python 3.0, Django does not currently work with Python 3.0; for more
-   information see the `Django documentation page
-   <https://docs.djangoproject.com>`_).
+   Python 3.0, Django 1.3 does not work with Python 3.0; for more
+   information see the `Django Installation page
+   <https://docs.djangoproject.com/en/1.3/intro/install/>`_).
 
    -  `Python Imaging Library`_ should be available for your distribution
 

--- a/omero/sysadmins/windows/install-web.txt
+++ b/omero/sysadmins/windows/install-web.txt
@@ -31,9 +31,9 @@ Prerequisites
 -  OMERO and its prerequisites (see :doc:`server-installation`).
 
 -  Python version from 2.4 to 2.7 (due to backwards incompatibilities in
-   Python 3.0, Django does not currently work with Python 3.0; for more
-   information see the `Django documentation page
-   <https://docs.djangoproject.com>`_).
+   Python 3.0, Django 1.3 does not work with Python 3.0; for more
+   information see the `Django Installation page
+   <https://docs.djangoproject.com/en/1.3/intro/install/>`_).
 
    -  `Python Imaging Library`_ should be available for your distribution
 


### PR DESCRIPTION
The OMERO-docs-merge-stable build is unstable because the docs are linking to an out-of-date version-specific Django docs page. This PR replaces both links with a general one that shouldn't change when new versions of Django are released. Should make the build green again.

--no-rebase (link has been removed from the OMERO 5 docs)
