### PR TITLE
Doc running App from anywhere & CreateApp refactor dev_4_4

### DIFF
--- a/omero/developers/Web.txt
+++ b/omero/developers/Web.txt
@@ -62,7 +62,7 @@ Getting started
 ---------------
 
 The preferred workflow for extending OMERO.web is to create a new
-Django app Django apps provide a
+Django app. Django apps provide a
 nice way for you to keep all your code in one place and make it much
 easier to port your app to new OMERO releases or share it with other
 users. To get started, see :doc:`/developers/Web/CreateApp`. 

--- a/omero/developers/Web.txt
+++ b/omero/developers/Web.txt
@@ -61,11 +61,14 @@ other apps in development:
 Getting started
 ---------------
 
-All your development should be in a new 'app'. Django apps provide a
+The preferred workflow for extending OMERO.web is to create a new
+Django app Django apps provide a
 nice way for you to keep all your code in one place and make it much
 easier to port your app to new OMERO releases or share it with other
 users. To get started, see :doc:`/developers/Web/CreateApp`. 
-But if you want to have a quick look at some example code, see below...
+Further documentation on editing the core OMERO.web code is at 
+:doc:`/developers/Web/EditingOmeroWeb`.
+If you want to have a quick look at some example code, see below...
 
 Quick example - webtest
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/omero/developers/Web/CreateApp.txt
+++ b/omero/developers/Web/CreateApp.txt
@@ -50,8 +50,15 @@ movie <movies/omero-4-3/mov/OmeroWebIntro-4.3.mov>`.
 
 If you want to run OMERO.web from source code, see :doc:`/developers/Web/EditingOmeroWeb`.
 
-Since OMERO 4.4.10 or 5.0, you can place your app anywhere on your PYTHONPATH,
-so that it can be imported by OMERO.web.
+You can place your app anywhere on your PYTHONPATH,
+as long as it can be imported by OMERO.web.
+
+.. note::
+
+   OMERO 5 uses Django 1.6 which has a different project layout from OMERO 4.4. 
+   If you are upgrading your app from 4.4.x you may need to update some import
+   statements. E.g. ``from omeroweb import webgateway`` will become
+   ``import webgateway``.
 
 Creating an app
 ---------------

--- a/omero/developers/Web/CreateApp.txt
+++ b/omero/developers/Web/CreateApp.txt
@@ -23,18 +23,6 @@ server when you log in. That page also describes how to set debug to 'True'
 which is important when developing with OMERO.web and you should also be using 
 the Django 'development' server.
 
-You can either add your app to the omeroweb under an OMERO.server release build,
-or run directly from the OMERO.web source code:
-
-Option 1: Using OMERO.server release build
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If all your edits will be under your own app, and you are not editing or building
-the OMERO.web source code, then
-the simplest option is to directly add your app to the server build
-under lib/python/omeroweb. This code is run when you start the Django
-server with
-
 ::
 
     $ bin/omero web start
@@ -48,64 +36,22 @@ server with
 
 .. note:: Port number is 4080
 
-When you edit and save the code, under lib/python/omeroweb/, Django
-automatically detects this and you only need to refresh your browser
-to see the changes. You can see this in the :snapshot:`OMERO.web intro
-movie <movies/omero-4-3/mov/OmeroWebIntro-4.3.mov>`.
-
-Option 2: Working from source code
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Alternatively,if you have checked out the OMERO.server source code and
-are building from source, you will have 2 copies of the OMERO.web code -
-source code is under components/tools/OmeroWeb/omeroweb and the server
-build is under dist/lib/python/omeroweb. You should be editing the
-source code since any edits to the build code will get wiped out each
-time you build! In order to run Django directly from the source code you
-need to follow a few steps (commands are shown below):
-
--  Set $OMERO_HOME, so that OMERO.web knows where to find config, write logs etc.
-
-   .. note:: You should not set $OMERO_HOME on production servers
-
--  Make sure that the Django libraries that are under the build:
-   dist/lib/python/django are on your PYTHONPATH.
--  Remove the built omeroweb folder, otherwise this will get used
-   instead of the source omeroweb 
-
-   .. note:: You have to do this again if you build the server
-
--  From the source omeroweb/ folder, manually run the Django development
-   server
-
-   ::
-
-       $ export OMERO_HOME = ~/Desktop/OMERO/dist      # Example server build path
-
-       # Make sure the Django code etc can be imported
-       $ export PYTHONPATH=$OMERO_HOME/lib/python/:$PYTHONPATH
-       $ cd $OMERO_HOME
-       # need to remove the built omeroweb code so it doesn't get imported
-       $ rm -rf lib/python/omeroweb/
-
-       $ cd ../components/tools/OmeroWeb/omeroweb
-       $ python manage.py runserver
-       Validating models...
-       0 errors found
-
-       Django version 1.1.1, using settings 'omeroweb.settings'
-       Development server is running at http://127.0.0.1:8000/
-       Quit the server with CONTROL-C.
-
-   .. note:: Default port number is 8000. To specify port, use 
-       E.g: $ python manage.py runserver 0.0.0.0:4080
 
 You should make sure that you can access the webclient and webadmin on
 your local machine before starting to develop your own code. Be sure to
-use the correct port number as mentioned above, either:
+use the correct port number, E.g:
 
 -  ` http://localhost:4080/webclient/ <http://localhost:4080/webclient/>`_
--  ` http://localhost:8000/webclient/ <http://localhost:8000/webclient/>`_
+
+When you edit and save your app, Django will
+automatically detect this and you only need to refresh your browser
+to see the changes. You can see this in the :snapshot:`OMERO.web intro
+movie <movies/omero-4-3/mov/OmeroWebIntro-4.3.mov>`.
+
+If you want to run OMERO.web from source code, see :doc:`/developers/Web/EditingOmeroWeb`.
+
+Since OMERO 4.4.10 or 5.0, you can place your app anywhere on your PYTHONPATH,
+so that it can be imported by OMERO.web.
 
 Creating an app
 ---------------
@@ -129,16 +75,6 @@ Create and checkout a new github repository OR manually create a new directory
 -  Enter the name of <your-app>, add description and choose to add
    README.
 
--  Change into the /omeroweb/ directory:
-
-   ::
-
-       # running from build
-       $ cd lib/python/omeroweb/
-
-       # OR: running from source:
-       $ cd components/tools/OmeroWeb/omeroweb
-
 -  Checkout your new repository (into a new directory)
 
    ::
@@ -151,6 +87,15 @@ Create and checkout a new github repository OR manually create a new directory
    ::
 
         $ mkdir <your-app>
+
+Add your app location to your PYTHONPATH
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If your app is not in a directory that's already a module on your PYTHONPATH
+then you need to add it:
+
+::
+
+    $ export PYTHONPATH=$PYTHONPATH:/path/to/your-app
 
 Add the essential files to your app
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/omero/developers/Web/CreateApp.txt
+++ b/omero/developers/Web/CreateApp.txt
@@ -265,6 +265,40 @@ case, it is good practice to create your own templates with common
 components (links, logout etc), so you can make changes to all your
 pages at once. See :doc:`/developers/Web/WritingTemplates` for more info.
 
+App settings
+~~~~~~~~~~~~
+
+You can add settings to your app that allow configuration via the command line
+in the same way as for the base OMERO.web in omeroweb/settings.py.
+The list of CUSTOM_SETTINGS_MAPPINGS in omeroweb/settings.py code is a good
+source for examples of the different data types and parsers you can use.
+
+For example, if you want to create a user-defined setting yourapp.foo,
+that contains a dictionary of key-value pairs, you can add to
+CUSTOM_SETTINGS_MAPPINGS in yourapp/settings.py:
+
+::
+
+    import json
+    CUSTOM_SETTINGS_MAPPINGS = {
+        "omero.web.yourapp.foo": ["FOO", '{"key": "val"}', json.loads]
+    }
+
+From somewhere else in your app, you can then access the settings:
+
+::
+
+    from yourapp import settings
+
+    print settings.FOO
+
+Users can then configure this on the command line as follows:
+
+::
+
+    $ bin/omero config set omero.web.yourapp.foo '{"userkey": "userval"}'
+
+
 OMERO.web top links
 ~~~~~~~~~~~~~~~~~~~
 

--- a/omero/developers/Web/CreateApp.txt
+++ b/omero/developers/Web/CreateApp.txt
@@ -53,12 +53,6 @@ If you want to run OMERO.web from source code, see :doc:`/developers/Web/Editing
 You can place your app anywhere on your PYTHONPATH,
 as long as it can be imported by OMERO.web.
 
-.. note::
-
-   OMERO 5 uses Django 1.6 which has a different project layout from OMERO 4.4. 
-   If you are upgrading your app from 4.4.x you may need to update some import
-   statements. E.g. ``from omeroweb import webgateway`` will become
-   ``import webgateway``.
 
 Creating an app
 ---------------

--- a/omero/developers/Web/CreateApp.txt
+++ b/omero/developers/Web/CreateApp.txt
@@ -50,7 +50,7 @@ movie <movies/omero-4-3/mov/OmeroWebIntro-4.3.mov>`.
 
 If you want to run OMERO.web from source code, see :doc:`/developers/Web/EditingOmeroWeb`.
 
-You can place your app anywhere on your PYTHONPATH,
+You can place your app anywhere on your :envvar:`PYTHONPATH`,
 as long as it can be imported by OMERO.web.
 
 
@@ -91,7 +91,7 @@ Create and checkout a new github repository OR manually create a new directory
 
 Add your app location to your PYTHONPATH
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-If your app is not in a directory that's already a module on your PYTHONPATH
+If your app is not in a directory that is already on your :envvar:`PYTHONPATH`
 then you need to add it:
 
 ::

--- a/omero/developers/Web/EditingOmeroWeb.txt
+++ b/omero/developers/Web/EditingOmeroWeb.txt
@@ -8,14 +8,14 @@ This means that you benefit from the convenience of editing,
 saving and refreshing your browser without any build step.
 
 However, you will still need to build OMERO (or download the release build)
-and setup your PYTHONPATH as described in the install documentation
+and set up your :envvar:`PYTHONPATH` as described in the install documentation
 in order that you have the various dependencies such as Django.
 
 You will then have 2 copies of the OMERO.web code -
 source code under components/tools/OmeroWeb/omeroweb and the server
 build under dist/lib/python/omeroweb.
 
-To setup and run OMERO.web from the source code, you need to 
+To set up and run OMERO.web from the source code, you need to 
 follow a few steps (commands are shown below):
 
 -  Set $OMERO_HOME, so that OMERO.web knows where to find config, write logs etc.
@@ -23,7 +23,7 @@ follow a few steps (commands are shown below):
    .. note:: You should not set $OMERO_HOME on production servers
 
 -  Make sure that the Django libraries that are under the build:
-   dist/lib/python/django are on your PYTHONPATH.
+   dist/lib/python/django are on your :envvar:`PYTHONPATH`.
 -  Remove the built omeroweb folder, otherwise this will get used
    instead of the source omeroweb 
 

--- a/omero/developers/Web/EditingOmeroWeb.txt
+++ b/omero/developers/Web/EditingOmeroWeb.txt
@@ -1,0 +1,60 @@
+Editing OMERO.web
+=================
+
+If you need to make changes to OMERO.web itself, then you
+will want to check out the OMERO source code. You can directly
+edit and run the OMERO.web code.
+This means that you benefit from the convenience of editing,
+saving and refreshing your browser without any build step.
+
+However, you will still need to build OMERO (or download the release build)
+and setup your PYTHONPATH as described in the install documentation
+in order that you have the various dependencies such as Django.
+
+You will then have 2 copies of the OMERO.web code -
+source code under components/tools/OmeroWeb/omeroweb and the server
+build under dist/lib/python/omeroweb.
+
+To setup and run OMERO.web from the source code, you need to 
+follow a few steps (commands are shown below):
+
+-  Set $OMERO_HOME, so that OMERO.web knows where to find config, write logs etc.
+
+   .. note:: You should not set $OMERO_HOME on production servers
+
+-  Make sure that the Django libraries that are under the build:
+   dist/lib/python/django are on your PYTHONPATH.
+-  Make sure the OmeroWeb folder:
+   components/tools/OmeroWeb is on your PYTHONPATH.
+-  Remove the built omeroweb folder, otherwise this will get used
+   instead of the source omeroweb 
+
+   .. note:: You have to do this again if you build the server
+
+-  From the source omeroweb/ folder, manually run the Django development
+   server
+
+   ::
+
+       # Example path to build target or downloaded directory
+       $ export OMERO_HOME = ~/Desktop/OMERO/dist
+
+       # Make sure the Django code etc can be imported
+       $ export PYTHONPATH=$OMERO_HOME/lib/python/:$OMERO_HOME/../components/tools/OmeroWeb:$PYTHONPATH
+       $ cd $OMERO_HOME
+       # need to remove the built omeroweb code so it doesn't get imported
+       $ rm -rf lib/python/omeroweb/
+
+       $ cd ../components/tools/OmeroWeb
+       $ python omeroweb/manage.py runserver
+       Validating models...
+
+       0 errors found
+       December 05, 2013 - 13:39:26
+       Django version 1.6, using settings 'omeroweb.settings'
+       Starting development server at http://127.0.0.1:8000/
+       Quit the server with CONTROL-C.
+
+   .. note:: Default port number is 8000. To specify port, use 
+       E.g: $ python manage.py runserver 0.0.0.0:4080
+

--- a/omero/developers/Web/EditingOmeroWeb.txt
+++ b/omero/developers/Web/EditingOmeroWeb.txt
@@ -24,8 +24,6 @@ follow a few steps (commands are shown below):
 
 -  Make sure that the Django libraries that are under the build:
    dist/lib/python/django are on your PYTHONPATH.
--  Make sure the OmeroWeb folder:
-   components/tools/OmeroWeb is on your PYTHONPATH.
 -  Remove the built omeroweb folder, otherwise this will get used
    instead of the source omeroweb 
 
@@ -40,19 +38,18 @@ follow a few steps (commands are shown below):
        $ export OMERO_HOME = ~/Desktop/OMERO/dist
 
        # Make sure the Django code etc can be imported
-       $ export PYTHONPATH=$OMERO_HOME/lib/python/:$OMERO_HOME/../components/tools/OmeroWeb:$PYTHONPATH
+       $ export PYTHONPATH=$OMERO_HOME/lib/python/:$PYTHONPATH
        $ cd $OMERO_HOME
        # need to remove the built omeroweb code so it doesn't get imported
        $ rm -rf lib/python/omeroweb/
 
-       $ cd ../components/tools/OmeroWeb
-       $ python omeroweb/manage.py runserver
+       $ cd ../components/tools/OmeroWeb/omeroweb
+       $ python manage.py runserver
        Validating models...
 
        0 errors found
-       December 05, 2013 - 13:39:26
-       Django version 1.6, using settings 'omeroweb.settings'
-       Starting development server at http://127.0.0.1:8000/
+       Django version 1.3.1, using settings 'omeroweb.settings'
+       Development server is running at http://127.0.0.1:8000/
        Quit the server with CONTROL-C.
 
    .. note:: Default port number is 8000. To specify port, use 

--- a/omero/developers/index.txt
+++ b/omero/developers/index.txt
@@ -102,6 +102,7 @@ Web
     Web
     Web/CreateApp
     Web/WebclientPlugin
+    Web/EditingOmeroWeb
     Web/WebGateway
     Web/ViewPort
     Web/WritingViews


### PR DESCRIPTION
This PR documents 2 main changes (see https://trac.openmicroscopy.org.uk/ome/ticket/11730)

--rebased-from #581

Same features are in dev_4_4 as develop:
Django apps can be anywhere on PYTHONPATH openmicroscopy/openmicroscopy#1813
App settings openmicroscopy/openmicroscopy#1789

This PR also refactors the CreateApp page to move docs that are not App-specific to a new page.
If creating an app, you shouldn't really need to run OmeroWeb from the source code. Moving this to a new page makes the CreateApp page simpler - but still provides the info for those who need it. The new EditingOmeroWeb page is linked from the Web intro page and the CreateApp page.

--rebased-from #605 
