### PR TITLE
Modify the root of the main OME CI server to use ci.openmicroscopy.org (rebased onto develop)

### DIFF
--- a/common/conf.py
+++ b/common/conf.py
@@ -118,7 +118,7 @@ bf_github_root = github_root + user + '/bioformats/'
 doc_github_root = github_root + user + '/ome-documentation/'
 
 # Variables used to define Jenkins extlinks
-jenkins_root = 'http://hudson.openmicroscopy.org.uk'
+jenkins_root = 'http://ci.openmicroscopy.org'
 jenkins_job_root = jenkins_root + '/job'
 jenkins_view_root = jenkins_root + '/view'
 


### PR DESCRIPTION
This is the same as gh-609 but rebased onto develop.

---
