### PR TITLE
Backwards compatability instructions for web plugins (rebased onto dev_5_0)

### DIFF
--- a/omero/developers/Web/WebclientPlugin.txt
+++ b/omero/developers/Web/WebclientPlugin.txt
@@ -232,29 +232,29 @@ Documentation of plugin options
    -  obj_id: This is the ID of the first selected object, E.g. 123
 
 
-OMERO4 Backwards Compatability
+OMERO 4.4.x backwards compatability
 -------------------------------------
 
-If an OMERO5 plugin also needs to work for OMERO4 installations then there are
+If an OMERO 5 plugin also needs to work for OMERO 4.4.x installations then there are
 three considerations that need to be made.
 
-URLs in Templates
+URLs in templates
 ~~~~~~~~~~~~~~~~~
 
-The url tag has `changed in django 1.6
+The ``url`` tag has `changed in django 1.6
 <https://docs.djangoproject.com/en/dev/releases/1.5/#overview>`_ from
-``{% url myview %}`` to ``{% url 'myview' %}``. In order for your OMERO4
+``{% url myview %}`` to ``{% url 'myview' %}``. In order for your OMERO 4.4.x
 install to understand the new syntax then it is simply a matter of adding
 ``{% load url from future %}`` to the top of the template file. By using the
-new style syntax and the and the ``{% load url from future %}`` the template
-will be valid in both OMERO4 and OMERO5. The ``{% load url from future %}``
-line does no harm when being used on django 1.6.
+new style syntax and the ``{% load url from future %}`` the template
+will be valid in both OMERO 4.4.x and OMERO 5. The ``{% load url from future %}``
+line does no harm when used on django 1.6.
 
 URL imports
 ~~~~~~~~~~~
 
-The import statement required to get the url and patterns objects in the
-plugin's urls.py has changed as well. The following import can be used to
+The import statement required to get the URL and patterns objects in the
+plugin's :file:`urls.py` has changed as well. The following import can be used to
 import from the correct place dependant on which django version is present.
 
 ::
@@ -266,11 +266,11 @@ import from the correct place dependant on which django version is present.
         from django.conf.urls import *
 
 
-Plugin Settings
+Plugin settings
 ~~~~~~~~~~~~~~~
 
-In OMERO4 (with the older django) it was possible to manipulate settings in
-the plugin's settings.py like so:
+In OMERO 4.4.x (with the older django) it was possible to manipulate settings in
+the plugin's :file:`settings.py` like so:
 
 ::
 
@@ -282,12 +282,12 @@ the plugin's settings.py like so:
         ["Auto Tag", "webtagging/auto_tag_init.js.html", "auto_tag_panel"]
     )
 
-This is no longer possible in OMERO5 with django 1.6 and it is necessary to
+This is no longer possible in OMERO 5 with django 1.6 and it is necessary to
 use ``omero config set`` to change this setting as documented here:
 :ref:`Plugin Installation <plugin-installation-label>`.
 
 In order to preserve the old functionalty on OMERO4 servers the plugin's
-settings.py can be changed to:
+:file:`settings.py` can be changed to:
 
 ::
 
@@ -302,7 +302,7 @@ settings.py can be changed to:
             ["Auto Tag", "webtagging/auto_tag_init.js.html", "auto_tag_panel"]
         )
 
-This will only take effect on OMERO4 servers so remember to document that
-with OMERO5 the config will need to be modified by the person doing the
+This will only take effect on OMERO 4.4.x servers so remember to document that
+with OMERO 5 the config will need to be modified by the person doing the
 installation.
 


### PR DESCRIPTION
This is the same as gh-608 but rebased onto dev_5_0.

---

Documented how to make a web plugin for OMERO5 that preserves OMERO4 compatibility.
