### PR TITLE
Server upgrade bugfix (rebased onto dev_5_0)

### DIFF
--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -78,8 +78,9 @@ directory, you are safe to follow the following upgrade procedure:
 
     $ cd ..
     $ mv OMERO.server OMERO.server-old
-    $ unzip |OMEROserverzip|
-    $ cp OMERO.server-old/etc/grid/config.xml |OMEROserverzip|/etc/grid
+    $ unzip OMERO.server-|release|-ice3x-byy.zip
+    $ ln -s OMERO.server-|release|-ice3x-byy OMERO.server
+    $ cp OMERO.server-old/etc/grid/config.xml OMERO.server/etc/grid
 
 .. note::
     ``ice3x`` and ``byy`` **need to be replaced** by the appropriate Ice 
@@ -107,7 +108,7 @@ From a |previousversion|.x server
 
 .. parsed-literal::
 
-    $ cd |OMEROserverzip|
+    $ cd OMERO.server
     $ psql -h localhost -U **db_user** **omero_database** < sql/psql/OMERO\ |version|\_\_0/OMERO\ |previousversion|\_\_0.sql
     Password for user **db_user**:
     ...
@@ -128,7 +129,7 @@ From a 5.0.0-beta1 server
 
 .. parsed-literal::
 
-    $ cd |OMEROserverzip|
+    $ cd OMERO.server
     $ psql -h localhost -U **db_user** **omero_database** < sql/psql/OMERO\ |version|\_\_0/OMERO\ |version|\DEV\_\_6.sql
     Password for user **db_user**:
     ...
@@ -217,7 +218,7 @@ Restart your database
 
    .. parsed-literal::
 
-       $ cd |OMEROserverzip|
+       $ cd OMERO.server
        $ bin/omero admin start
 
 -  If anything goes wrong, please send the output of
@@ -252,9 +253,6 @@ and configure your server to use it.
 ::
 
     $ bin/omero config set omero.db.name omero_from_backup
-
-
-.. |OMEROserverzip| replace:: OMERO.server-|release|-ice3x-byy.zip
 
 .. seealso::
     


### PR DESCRIPTION
This is the same as gh-604 but rebased onto dev_5_0.

---

This PR fixes a bug in the server upgrade page reported by @dpwrussell. As part of this fix, this PR addresses one of the suggestions in https://trac.openmicroscopy.org.uk/ome/ticket/10463, namely symlinking the new server. This will also greatly simplify subsequent upgrade steps with `$ cd OMERO.server`.
