### PR TITLE
Clarify documentation for the FLIM OME-TIFF sample

### DIFF
--- a/formats/developers/6d-7d-and-8d-storage.txt
+++ b/formats/developers/6d-7d-and-8d-storage.txt
@@ -230,5 +230,5 @@ FLIM
 
 :schema_plone:`FLIM-modulo-sample.ome.tiff <Samples/2013-06/FLIM-modulo-sample.ome.tiff>`
 
-Two channels each recorded at eight histogram bins.
+Two channels each recorded at two timepoints and eight histogram bins.
 


### PR DESCRIPTION
FLIM-modulo-sample.ome.tiff has SizeC set to 2 and SizeT set to
16 (2 timepoints x 8 bins).  When imported, there should be 2 C x 2 T x 8t.

/cc @sbesson, @imunro
