### PR TITLE
Fix hardcoded links to Javadocs in the developer documentation (rebased onto develop)

### DIFF
--- a/omero/developers/Server/Permissions.txt
+++ b/omero/developers/Server/Permissions.txt
@@ -433,8 +433,8 @@ current user on the object:
 
 - :javadoc:`canAnnotate() <slice2html/omero/model/Permissions.html#canAnnotate>`
 - :javadoc:`canDelete() <slice2html/omero/model/Permissions.html#canDelete>`
-- :javadoc:`canEdit <slice2html/omero/model/Permissions.html#canEdit>`
-- :javadoc:`canLink <slice2html/omero/model/Permissions.html#canLink>`
+- :javadoc:`canEdit() <slice2html/omero/model/Permissions.html#canEdit>`
+- :javadoc:`canLink() <slice2html/omero/model/Permissions.html#canLink>`
 
 Troubleshooting permissions issues
 ----------------------------------


### PR DESCRIPTION
This is the same as gh-619 but rebased onto develop.

---

This was noticed while building the  5.1 docs jobs and does not need to be rebased onto `dev_4_4`.

All links to the Javadocs should now use the correct environment variable to build the URL. To test this PR, check the links are valid in the corresponding OMERO docs merge build.
