### PR TITLE
Changing Windows Ice download link to 3.4 (rebased onto develop)

### DIFF
--- a/omero/sysadmins/windows/server-installation.txt
+++ b/omero/sysadmins/windows/server-installation.txt
@@ -77,9 +77,9 @@ Ice (3.3.x or 3.4.x)
 
 
 Windows installers of Ice can be found on the :zeroc:`ZeroC download
-page <download.html>` and will be called something like :file:`Ice-3.4.2.msi`
-(for Ice 3.4.2). If you plan to develop for C++, be sure to read the
-instructions on the |OmeroCpp| page.
+page <download_3_4_2.html>` and will be called something like 
+:file:`Ice-3.4.2.msi` (for Ice 3.4.2). If you plan to develop for C++, be sure 
+to read the instructions on the |OmeroCpp| page.
 
 Users have reported that under certain conditions installing Ice in the
 default location (:file:`C:\\Program Files`) might break the Windows


### PR DESCRIPTION
This is the same as gh-631 but rebased onto develop.

---

See https://trac.openmicroscopy.org.uk/ome/ticket/11899
