### PR TITLE
Document latest changes to the Homebrew OMERO formula (rebased onto dev_5_0)

### DIFF
--- a/omero/sysadmins/unix/server-install-homebrew.txt
+++ b/omero/sysadmins/unix/server-install-homebrew.txt
@@ -237,6 +237,9 @@ If you have installed Ice 3.3, replace :envvar:`ICE_HOME` by
 Ice 3.4, use
 ``export PYTHONPATH=$(brew --prefix omero)/lib/python:$ICE_HOME/python``.
 
+.. note::
+    If you have a local :file:`.bash_profile` file, it will override your
+    :file:`.profile` configuration file.
 
 .. note::
     On Mac OS X Lion, a version of PostgreSQL is already installed. If you get an error like the following:


### PR DESCRIPTION
This is the same as gh-635 but rebased onto dev_5_0.

---

This PR documents changes brought to the Homebrew formula in ome/homebrew-alt#49
- Ice (3.5) is now the default version installed by `brew install omero`
- Add options to use old 3.3 and 3.4 versions
- Update PYTHONPATH setting in the configuration section

/cc @bramalingam
