### PR TITLE
Updating Till Photonics website link

### DIFF
--- a/formats/ome-tiff/index.txt
+++ b/formats/ome-tiff/index.txt
@@ -45,7 +45,7 @@ OME-TIFF is supported by:
 * `PerkinElmer <http://www.perkinelmer.com/>`_
 * `Scientific Volume Imaging B.V. <http://www.svi.nl/>`_
 * `Strand Life Sciences <http://www.strandls.com>`_
-* `TILL Photonics GmbH <http://www.till-photonics.com/>`_
+* `TILL Photonics GmbH, now FEI Munich <http://www.fei.com/>`_
 
 Public image repositories allowing image downloads as OME-TIFF
 --------------------------------------------------------------


### PR DESCRIPTION
Till Photonics has been bought out and their website appears to have been taken down this week. This updates the link to the same now used by the Bio-Formats docs.

To test, go to https://www.openmicroscopy.org/site/support/ome-model-staging/ome-tiff/index.html
