### PR TITLE
Add --devel option to install the OMERO 5 via Homebrew

### DIFF
--- a/omero/sysadmins/unix/server-install-homebrew.txt
+++ b/omero/sysadmins/unix/server-install-homebrew.txt
@@ -118,18 +118,18 @@ simple Homebrew install is sufficient, e.g.
 
     $ brew tap homebrew/science
     $ brew tap ome/alt
-    $ brew install omero
+    $ brew install omero --devel
 
 This should install OMERO along with most of the non-Python requirements.
 
 The default version of Ice installed by the OMERO formula is Ice 3.5. To
 install OMERO with Ice 3.4, use::
 
-	$ brew install omero --with-ice34
+	$ brew install omero --devel --with-ice34
 
 or to install OMERO with Ice 3.3, use::
 
-	$ brew install omero --with-ice33
+	$ brew install omero --devel --with-ice33
 
 Additional installation options can be listed using the ``info`` command:
 


### PR DESCRIPTION
This PR fixes an issue reported in https://www.openmicroscopy.org/community/viewtopic.php?f=6&p=13350#p13332

Until we archive the OMERO 4.4 Homebrew formula, the OMERO 5 formula needs be installed by passing the `--devel` option (see http://ci.openmicroscopy.org/job/OME-5.0-merge-homebrew/).
