### PR TITLE
Drop --use-mirrors from .travis.yml (rebased onto develop)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ python:
 env:
   - SPHINXOPTS="-W"
 
-install: "pip install -q Sphinx --use-mirrors"
+install: "pip install -q Sphinx"
 
 script: "make html latexpdf"


### PR DESCRIPTION
This is the same as gh-647 but rebased onto develop.

---
