### PR TITLE
Improve server-template description in advanced configuration (rebased onto develop)

### DIFF
--- a/omero/sysadmins/server-advanced-configuration.txt
+++ b/omero/sysadmins/server-advanced-configuration.txt
@@ -206,6 +206,6 @@ connect to OMERO.
 Extending OMERO
 ---------------
 
-Finally, if configuration does not suffice, there are also options to
+Finally, if configuration does not suffice, there are also options for
 extending OMERO with your own code. These are described on the
 development site under |ExtendingOmero|.

--- a/omero/sysadmins/unix/server-installation.txt
+++ b/omero/sysadmins/unix/server-installation.txt
@@ -431,7 +431,7 @@ since it would prevent starting the server on some sites' test instance but
 for production use a setting higher than 512MB is **highly** recommended.
 
 To increase the JVM memory settings, you need to edit the
-:file:`etc/grid/templates.xml` file under the OMERO.server directory..
+:file:`etc/grid/templates.xml` file under the OMERO.server directory.
 
 It is highly recommended to increase the ``BlitzTemplate`` default JVM memory
 settings from ``-Xmx512M`` to ``-Xmx2048M`` and from ``XX:MaxPermSize=128m``

--- a/omero/sysadmins/windows/server-installation.txt
+++ b/omero/sysadmins/windows/server-installation.txt
@@ -696,7 +696,7 @@ using::
 
 	:ref:`gridconfiguration`
 		Section of the advanced server configuration documentation describing
-		:file:`etc/grid/templates.xml`.
+		:file:`etc\grid\templates.xml`.
 
 OMERO.web and administration
 ----------------------------


### PR DESCRIPTION
This is the same as gh-646 but rebased onto develop.

---

Related to http://www.openmicroscopy.org/community/viewtopic.php?f=4&t=7400, this PR:
- uses the `seealso` markup in the Unix/Windows installation pages to increase visibility of the Advanced configuration
- reviews headings, code blocks and configuration files markup in the `Advanced configuration` page
- adds a paragraph about the JVM memory settings of individual server templates
