### PR TITLE
11955 loci-tools docs (rebased onto develop)

### DIFF
--- a/contributing/release-process.txt
+++ b/contributing/release-process.txt
@@ -108,8 +108,8 @@ Release components review
 - Test the OMERO.matlab toolbox.
 - Test the OMERO Virtual Appliance.
 - Test the Java Webstart from the deployed server.
-- For Bio-Formats, test the **loci_tools.jar**, the command-line tools and the
-  MATLAB bundle.
+- For Bio-Formats, test the **bioformats_package.jar**, loci_tools.jar,
+  the command-line tools and the MATLAB bundle.
 
 Release rejection
 -----------------

--- a/formats/ome-tiff/tools.txt
+++ b/formats/ome-tiff/tools.txt
@@ -94,7 +94,7 @@ will use are ``xmlvalid`` and ``tiffcomment``.
 - ``tiffcomment`` – extracts the OME-XML block in an OME-TIFF file from the 
   comment in the TIFF's first IFD entry.
 
-All scripts require :file:`loci_tools.jar` to be downloaded into the same 
+All scripts require :file:`bioformats_package.jar` to be downloaded into the same
 directory as the command line tools. Then to validate an OME-XML file 
 :file:`sample.ome` use:
 


### PR DESCRIPTION
This is the same as gh-651 but rebased onto develop.

---

This PR changes the OMERO docs for http://trac.openmicroscopy.org.uk/ome/ticket/11955. See the list of PRs made to the code and build systems under 11955.
