### PR TITLE
Windows 64-bit python 11899 (rebased onto develop)

### DIFF
--- a/omero/sysadmins/windows/server-installation.txt
+++ b/omero/sysadmins/windows/server-installation.txt
@@ -123,8 +123,6 @@ the latest release number and A and B stand for the Python version, for example
 
 .. _windows_additional_libraries:
 
-.. _windows_additional_libraries:
-
 Additional libraries
 """"""""""""""""""""
 


### PR DESCRIPTION
This is the same as gh-661 but rebased onto develop.

---

Clarify the Windows install doc to say 64 bit python does work.

If you want to try this for yourself (I tested this on a clean Windows 7 Virtualbox image) and can't be bothered to download everything copies of the binaries used are in `ome:team/simon/windows/python_64bit_omero/`

See https://trac.openmicroscopy.org.uk/ome/ticket/11899#comment:14 for more details.
