### PR TITLE
Always link to latest 4 download page

### DIFF
--- a/common/conf.py
+++ b/common/conf.py
@@ -140,7 +140,7 @@ extlinks = {
     'bf_doc' : (oo_site_root + '/support/bio-formats4/%s', ''),
     'partner_plone' : (oo_site_root + '/products/partner/%s', ''),
     # Downloads
-    'downloads' : (downloads_root + '/omero/%s', ''),
+    'downloads' : (downloads_root + '/latest/omero4/%s', ''),
     # Help links
     'help' : (help_root + '/%s', ''),
     # Miscellaneous links

--- a/omero/themes/globalomerotoc.html
+++ b/omero/themes/globalomerotoc.html
@@ -1,5 +1,5 @@
 <h3><a href="{{ pathto(master_doc) }}">{{ _('OMERO') }}</a></h3>
 {{ toctree()}}
-<a href="http://downloads.openmicroscopy.org/omero/">{{ _('Downloads') }}</a></br>
+<a href="http://downloads.openmicroscopy.org/latest/omero4/">{{ _('Downloads') }}</a></br>
 <a href="//www.openmicroscopy.org/site/products/omero/feature-list">{{ _('Feature List') }}</a></br>
 <a href="//www.openmicroscopy.org/site/about/licensing-attribution">{{ _('Licensing') }}</a>


### PR DESCRIPTION
4.4.10 docs currently link to the OMERO downloads folder. This changes the links to always land on the latest version 4 release download page.
