### PR TITLE
Using right redirects for 5 downloads

### DIFF
--- a/common/conf.py
+++ b/common/conf.py
@@ -162,8 +162,8 @@ extlinks = {
     'bf_doc' : (oo_site_root + '/support/bio-formats5/%s', ''),
     'partner_plone' : (oo_site_root + '/products/partner/%s', ''),
     # Downloads
-    'downloads' : (downloads_root + '/latest-develop/omero/%s', ''),
-    'bf_downloads' : (downloads_root + '/latest-develop/bio-formats/%s', ''),
+    'downloads' : (downloads_root + '/latest/omero5/%s', ''),
+    'bf_downloads' : (downloads_root + '/latest/bio-formats5/%s', ''),
     # Help links
     'help' : (help_root + '/%s', ''),
     # Miscellaneous links

--- a/omero/themes/globalomerotoc.html
+++ b/omero/themes/globalomerotoc.html
@@ -1,5 +1,5 @@
 <h3><a href="{{ pathto(master_doc) }}">{{ _('OMERO') }}</a></h3>
 {{ toctree()}}
-<a href="http://downloads.openmicroscopy.org/latest-develop/omero/">{{ _('Downloads') }}</a></br>
+<a href="http://downloads.openmicroscopy.org/latest/omero5/">{{ _('Downloads') }}</a></br>
 <a href="//www.openmicroscopy.org/site/products/omero/feature-list">{{ _('Feature List') }}</a></br>
 <a href="//www.openmicroscopy.org/site/about/licensing-attribution">{{ _('Licensing') }}</a>


### PR DESCRIPTION
Updating redirects we use for the downloads page which were agreed earlier today. With apologies to @joshmoore who tried to tell me before that /latest-develop/ was going to be thoroughly confusing!

To test, check that all the downloads links on https://www.openmicroscopy.org/site/support/omero5-staging/ go to the 5-rc1 downloads pages. These redirects will be updated to point at 5.0.0 when we release.

cc/ @sbesson @qidane
