### PR TITLE
change TeX Gyre font package so XeLaTeX can find it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ before_install:
   - sudo apt-get update
 
   - sudo apt-get -y install texlive-latex-base texlive-latex-recommended texlive-xetex
-  - sudo apt-get -y install texlive-latex-extra texlive-fonts-recommended tex-gyre
+  - sudo apt-get -y install texlive-latex-extra texlive-fonts-recommended fonts-texgyre
 
   - sudo fc-cache -rsfv
   - fc-list


### PR DESCRIPTION
`fonts-texgyre` supersedes earlier `tex-gyre` in including extra material that helps to make fonts findable by XeLaTeX; this PR makes the Travis configuration a better hint about what to install to build our documentation locally on systems like Debian jessie. To test, make sure that the PDF documentation is still properly generated. (Really, Travis is the main tester here, and that seems happy.)

cc @rleigh-dundee
