### PR TITLE
Fix links to Bio-Formats source code post-renaming

### DIFF
--- a/formats/developers/index.txt
+++ b/formats/developers/index.txt
@@ -92,7 +92,7 @@ The following program edits the "image name" metadata value for the file
 given on the command line. It requires the :bf_plone:`Bio-Formats <>` and 
 :doc:`OME-XML Java </ome-xml/java-library>` libraries.
 
-:source:`EditImageName.java <components/bio-formats/utils/EditImageName.java>`
+:source:`EditImageName.java <components/formats-gpl/utils/EditImageName.java>`
 
 As in the ConvertToOmeTiff.java example in :doc:`/ome-tiff/code`, we attach an 
 OME-XML MetadataStore object to the reader to extract OME-XML metadata from 
@@ -107,7 +107,7 @@ write the updated name back into the metadata structure via a call to
 wish to update the first Image.
 
 Lastly, the
-:source:`loci.formats.services.OMEXMLService <components/scifio/src/loci/formats/services/OMEXMLService.java>`
+:source:`loci.formats.services.OMEXMLService <components/formats-api/src/loci/formats/services/OMEXMLService.java>`
 class contains a number of useful methods for working with Bio-Formats
 metadata objects (i.e. MetadataStore and MetadataRetrieve
 implementations), including the getOMEXML method for easily extracting

--- a/formats/ome-tiff/code.txt
+++ b/formats/ome-tiff/code.txt
@@ -44,7 +44,7 @@ The :bf_doc:`Bio-Formats command line
 tools <users/comlinetools/>` include a
 program, tiffcomment, that performs these steps using the
 getComment(String) method of 
-:source:`TiffParser <components/scifio/src/loci/formats/tiff/TiffParser.java>`.
+:source:`TiffParser <components/formats-bsd/src/loci/formats/tiff/TiffParser.java>`.
 You can produce a nicely formatted OME-XML string from an OME-TIFF file
 with:
 
@@ -74,7 +74,7 @@ user to alter the comments on the command line, and writes updated
 comments back to the files. It requires the
 :bf_plone:`Bio-Formats library <>`.
 
-:source:`EditTiffComment.java <components/bio-formats/utils/EditTiffComment.java>`
+:source:`EditTiffComment.java <components/formats-gpl/utils/EditTiffComment.java>`
 
 The comment string is acquired using ``new TiffParser(f).getComment()``, and
 updated with 
@@ -104,7 +104,7 @@ The following program converts the files given on the command line into
 OME-TIFF format. It requires the :bf_plone:`Bio-Formats <>` and :doc:`OME-XML
 Java </ome-xml/java-library>` libraries.
 
-:source:`ConvertToOmeTiff.java <components/bio-formats/utils/ConvertToOmeTiff.java>`
+:source:`ConvertToOmeTiff.java <components/formats-gpl/utils/ConvertToOmeTiff.java>`
 
 The code functions by creating an ImageReader for reading the input
 files' image planes sequentially, and an OMETiffWriter for writing the

--- a/formats/ome-tiff/data.txt
+++ b/formats/ome-tiff/data.txt
@@ -13,7 +13,7 @@ Artificial datasets
 -------------------
 
 All datasets in the following table were :source:`artificially
-generated <components/scifio/src/loci/formats/tools/MakeTestOmeTiff.java>`
+generated <components/formats-bsd/src/loci/formats/tools/MakeTestOmeTiff.java>`
 with each plane labeled according to its dimensional position for easy
 testing. Each one consists of a single OME-TIFF file (2013-06 schema
 version) containing every constituent image plane. For an example of an

--- a/formats/ome-xml/java-library.txt
+++ b/formats/ome-xml/java-library.txt
@@ -33,7 +33,7 @@ Usage
 
 Refer to the :javadoc:`online API documentation <>`, specifically the
 ome.xml.\* packages. For an example of usage, see the
-:source:`Screen Plate Well unit test <components/scifio/test/loci/formats/utests/SPWModelMock.java>`.
+:source:`Screen Plate Well unit test <components/formats-bsd/test/loci/formats/utests/SPWModelMock.java>`.
 
 The OMENode is the root ("OME") node of the OME-XML. Each XML element
 has its own node type (e.g. "Image" has ImageNode) with its own


### PR DESCRIPTION
This commit should update the source code links to point at the new
formats-bsd, formats-gpl and formats-api folders of the Bio-Formats repository

--no-rebase
