### PR TITLE
Adding Graphviz to Docs repo readme (rebased onto develop)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,13 @@ To add the MacTeX fonts system-wide:
 * Navigate to ``/usr/local/texlive/2013/texmf-dist/fonts/opentype/public/tex-gyre``
   and click ``Open``. (Type ``/usr/local`` to get there initially.)
 
+Graphviz
+--------
+
+The Contributing documentation now requires you to install
+`Graphviz <http://www.graphviz.org/Home.php>`_ to build the
+diagrams.
+
 Structure and organization
 ==========================
 


### PR DESCRIPTION
This is the same as gh-692 but rebased onto develop.

---

Documents need for Graphviz to build contributing docs following merge of #683 

/cc @sbesson

--no-rebase
