### PR TITLE
Fix Windows paths error found by Javier Colmeiro (rebased onto develop)

### DIFF
--- a/omero/developers/Cpp.txt
+++ b/omero/developers/Cpp.txt
@@ -71,7 +71,7 @@ to adjust them for the Ice installation path and version in use.
 
    .. parsed-literal::
 
-       set ICE_HOME=C:\Ice-|iceversion|
+       set ICE_HOME=C:\\Ice-|iceversion|
 
 Users of a package manager will also need to set :envvar:`ICE\_HOME`
 if the Ice paths are not automatically detected correctly.  The


### PR DESCRIPTION
This is the same as gh-698 but rebased onto develop.

---

Compare the last bullet point of https://www.openmicroscopy.org/site/support/omero5/developers/Cpp.html#preparing-to-build to https://www.openmicroscopy.org/site/support/omero5-staging/developers/Cpp.html#preparing-to-build
