### PR TITLE
Session engine update

### DIFF
--- a/omero/sysadmins/windows/install-web.txt
+++ b/omero/sysadmins/windows/install-web.txt
@@ -131,13 +131,14 @@ working with your IIS deployment.
 
        C:\omero_dist>bin\omero web iis
 
-   .. note::  As OMERO.web 5 is based on Django 1.6, ``omero.web.session_engine`` and ``omero.web.cache_backend`` should be unset.
+   .. note::  As OMERO.web 5 is based on Django 1.6,
+       ``omero.web.session_engine`` and ``omero.web.cache_backend`` should be
+       unset.
+    
+       ::
 
-   ::
-
-       C:\omero_dist>bin\omero config set omero.web.session_engine
-       C:\omero_dist>bin\omero config set omero.web.cache_backend
-
+           C:\omero_dist>bin\omero config set omero.web.session_engine
+           C:\omero_dist>bin\omero config set omero.web.cache_backend
 
 Using the lightweight development server
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/omero/sysadmins/windows/server-installation.txt
+++ b/omero/sysadmins/windows/server-installation.txt
@@ -710,12 +710,15 @@ turn debugging on, in order that static files can be served by Django:
     C:\OMERO.server> bin\omero config set omero.web.application_server development
     C:\OMERO.server> bin\omero config set omero.web.debug True
 
-.. note::  As OMERO.web 5 is based on Django 1.6, ``omero.web.session_engine`` and ``omero.web.cache_backend`` should be unset.
+.. note::  As OMERO.web 5 is based on Django 1.6,
+    ``omero.web.session_engine`` and ``omero.web.cache_backend`` should be
+    unset.
+    
+    ::
 
-::
+        C:\omero_dist>bin\omero config set omero.web.session_engine
+        C:\omero_dist>bin\omero config set omero.web.cache_backend
 
-    C:\omero_dist>bin\omero config set omero.web.session_engine
-    C:\omero_dist>bin\omero config set omero.web.cache_backend
 
 then start by
 


### PR DESCRIPTION
this PR removes setting SESSION_ENGINE from OMERO.web config on Windows. That is not longer needed as from Django 1.5 that bug has been fixed, see https://code.djangoproject.com/ticket/20308
