### PR TITLE
Clarify location and group for DropBox imports.

### DIFF
--- a/omero/sysadmins/dropbox.txt
+++ b/omero/sysadmins/dropbox.txt
@@ -60,9 +60,9 @@ Experimenters can add subdirectories under their named directory for
 convenience. Copying or moving a file of an importable file type into a
 named directory or nested subdirectory will initiate an automatic import
 of that file for that user. Multi-file formats will be imported after
-the last required file of a set is copied into the directory. Images will be
-imported as ``Orphaned images``; images and plates will be imported into the
-group the user was last logged into.
+the last required file of a set is copied into the directory. Images and
+plates will be imported into the group the user was last logged into, with
+images placed into ``Orphaned images``.
 
 Acquisition systems can then be configured to drop a user's images into
 a given DropBox.


### PR DESCRIPTION
This minor change follows a comment in a forum post http://www.openmicroscopy.org/community/viewtopic.php?f=4&t=7484

The only query was whether it should be done within the paragraph as in this PR or made stronger as a Note. I prefer it as it is but if it anyone feels it needs more emphasis then I'm happy to do that.
