### PR TITLE
Unix/Linux installation: Update requirements (rebased onto develop)

### DIFF
--- a/omero/sysadmins/fs-upload-configuration.txt
+++ b/omero/sysadmins/fs-upload-configuration.txt
@@ -68,14 +68,6 @@ The restrictions are grouped into named sets:
 :literal:`UNIX optional`
         prohibits names beginning with :literal:`.` or :literal:`-`
 
-:literal:`local required`
-        corresponds to `Windows required` under Microsoft Windows
-        and to `UNIX required` under Linux and Mac OS X
-
-:literal:`local optional`
-        corresponds to `Windows optional` under Microsoft Windows
-        and to `UNIX optional` under Linux and Mac OS X
-
 These rules are applied to each separate path component of the file
 name on the client's system. So, for instance, an upload of a file
 :literal:`/tmp/myfile.tif` from a Linux system would satisfy the

--- a/omero/sysadmins/server-backup-and-restore.txt
+++ b/omero/sysadmins/server-backup-and-restore.txt
@@ -1,3 +1,5 @@
+.. _server_backup:
+
 OMERO.server backup and restore
 ===============================
 

--- a/omero/sysadmins/system-requirements.txt
+++ b/omero/sysadmins/system-requirements.txt
@@ -100,4 +100,16 @@ OpenGL versions of OMERO.insight
     These are suggested requirements based on limited testing. Your
     mileage may vary. Any OpenGL 1.3 capable card *should* work.
 
+Client configuration
+====================
 
+When performing some operations the clients make use of temporary file
+storage and log directories. By default these files are stored below
+the users HOME directory in ``$HOME/omero/tmp``, ``$HOME/omero/log``
+and ``$HOME/omero/sessions`` (resp. ``$HOME\omero\tmp``,
+``$HOME\omero\log`` and ``$HOME\omero\sessions``). If your home
+directory is stored on a network, possibly NFS mounted (or similar),
+then these temporary files are being written and read over the
+network. This can slow access down.  The :envvar:`OMERO_TEMPDIR`
+environment variable may used to set the directory used for temporary
+files, for example on fast local storage.

--- a/omero/sysadmins/unix/server-postgresql.txt
+++ b/omero/sysadmins/unix/server-postgresql.txt
@@ -9,7 +9,9 @@ version and that it is installed and configured correctly.
 Ensuring you have a valid PostgreSQL version
 --------------------------------------------
 
-For OMERO |version|, PostgreSQL 8.4 or higher is required.
+For OMERO |version|, PostgreSQL version 8.4 or later is required;
+version 9.1 or later is recommended.  Make sure you are using a
+`supported version <http://www.postgresql.org/support/versioning/>`_.
 
 You can check which version of PostgreSQL you have installed with any of
 the following commands:
@@ -23,44 +25,19 @@ the following commands:
        $ createdb -V
        createdb (PostgreSQL) 9.1.4
        
-If your default PostgreSQL installation is version 8.3 or earlier, you
-will need to upgrade to a more up-to-date version. We suggest the
-installer from `EnterpriseDB <http://www.enterprisedb.com/>`_. Versions
-8.4, 9.0 and 9.1 are known to work with OMERO |version|; 9.1 is recommended.
+If your existing PostgreSQL installation is version 8.3 or earlier,
+you must upgrade to a more up-to-date version.  Before upgrading, stop
+the OMERO server and then perform a full dump of the database using
+:program:`pg_dump`.  See the :ref:`server_backup` section for further
+details.
 
-
-Compatibility matrix
-~~~~~~~~~~~~~~~~~~~~
-
-Versions of PostgreSQL which are compatible with OMERO are shown in
-the table below.
-
-.. tabularcolumns:: |l|l|l|l|l|
-
-========== =============== =============== =============== ==============
-PostgreSQL OMERO 4.1       OMERO 4.2       OMERO 4.3       OMERO 4.4
-========== =============== =============== =============== ==============
-7.4        YES             NO :term:`[1]`  NO :term:`[1]`  NO :term:`[4]`
-8.1        YES             NO :term:`[3]`  NO :term:`[1]`  NO :term:`[4]`
-8.2        YES             YES             NO :term:`[3]`  NO :term:`[4]`
-8.3        YES             YES             YES             NO :term:`[4]`
-8.4        YES             YES             YES             YES
-9.x        YES :term:`[2]` YES :term:`[2]` YES :term:`[2]` YES
-========== =============== =============== =============== ==============
-
-.. glossary::
-
-    [1]
-        Not suggested; see :ticket:`4902`
-
-    [2]
-        Configuration may be necessary; see :ticket:`5662`
-
-    [3]
-        Not suggested; see :ticket:`5861`
-
-    [4]
-        Unsupported; see :ticket:`7813`
+If using a Linux distribution-provided PostgreSQL server, upgrading to
+a newer version of the the distribution will usually make a newer
+version of PostgreSQL available.  If the database was not migrated to
+the new version automatically, restore your backup after installing,
+configuring and starting the new version of the database server.
+If a PostgreSQL server was not provided by your system, `EnterpriseDB
+<http://www.enterprisedb.com/>`_ provide an installer.
 
 
 Checking PostgreSQL port listening status


### PR DESCRIPTION
This is the same as gh-712 but rebased onto develop.

---
- Update Debian/Ubuntu docs to match what's provided by current releases (package names and versions) and update the Java installation notes to default to the least insecure and best supported option
- Update Java requirements
- Update Python requirements (minor rewording)
- Update Ice requirements
- Update environment variables

See the commit logs for further details of each.  The primary correction here is to remove `ICE_HOME` in the installation instructions given that it's neither used nor required.  It also corrects a number of inaccuracies and errors in the default set of environment variables documented to be required.  Most were useless, some are required under certain circumstances; this is all cleaned up and explained.

For PostgreSQL, I've updated the version details to be current, and dropped the legacy compatibility matrix, which served little real purpose for users installing/upgrading to a current version.  The matrix is retained in an updated form, but could be removed entirely if desired.

I moved a paragraph of the server installation into the client docs since it was nothing to do with installing the server.  There may be a better place for it.
