### PR TITLE
Updating insight contributing file (rebased onto develop)

### DIFF
--- a/omero/developers/Insight/Contributing.txt
+++ b/omero/developers/Insight/Contributing.txt
@@ -69,7 +69,7 @@ Jenkins
 
 The OME project currently uses Jenkins_ (formerly known as hudson) as a
 continuous integration server available :jenkins:`here <>`. OMERO.insight is
-built as part of the "OMERO" job. See the
+built as part of the "OMERO" jobs. See the
 :devs_doc:`contributing developer continuous integration </ci-omero.html>`
 documentation for full details.
 


### PR DESCRIPTION
This is the same as gh-736 but rebased onto develop.

---

Updates http://www.openmicroscopy.org/site/support/omero5/developers/Insight/Contributing.html to remove out-of-date stuff and point people at the new contributing documentation.
