### PR TITLE
Removing build commands 'only work for UNIX' from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -168,8 +168,7 @@ Top-level build command
 -----------------------
 
 The top-level directory Makefile also defines targets for building all the
-OMERO, Contributing, and Model and Formats sets of documentation at once. Note
-that the following commands currently work under UNIX-like platforms only.
+OMERO, Contributing, and Model and Formats sets of documentation at once.
 
 To clean the build directories of any previous builds, use one of::
 


### PR DESCRIPTION
I missed that @rleigh-dundee had left this sentence in the README on #744

To be rebased on dev_5_0 once #746 is merged.
