### PR TITLE
Removing build commands 'only work for UNIX' from README (rebased onto dev_5_0)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -158,8 +158,6 @@ Top-level build command
 The top-level directory Makefile also defines targets for building the
 OMERO documentation (as the contributing and formats documentation sets have
 been removed on this branch and are only maintained on the develop branch).
-Note that the following commands currently work under UNIX-like platforms
-only.
 
 To clean the build directories of any previous builds, use one of::
 


### PR DESCRIPTION
This is the same as gh-747 but rebased onto dev_5_0.

---

I missed that @rleigh-dundee had left this sentence in the README on #744

To be rebased on dev_5_0 once #746 is merged.
