### PR TITLE
Adding API doc links to OMERO docs front page

### DIFF
--- a/omero/index.txt
+++ b/omero/index.txt
@@ -20,6 +20,9 @@ Additional online resources can be found at:
 - :downloads:`Downloads <>`
 - :omero_plone:`Features (movie tutorials coming soon)<feature-list>`
 - :omero_plone:`Security Vulnerabilities <secvuln>`
+- OMERO API documentation - :javadoc:`OmeroJava API <>`,
+  :javadoc:`OmeroPy API <epydoc/>`,
+  :javadoc:`OmeroBlitz / Slice API <slice2html/>`
 - ***NEW*** :help:`User help website <>`
 - ***NEW*** :community_plone:`Script sharing service <scripts>`
 - ***NEW*** :partner_plone:`Partner projects to extend OMERO <>`


### PR DESCRIPTION
See https://www.openmicroscopy.org/community/viewtopic.php?f=6&t=7423&p=13878 for context - we had a request to make the generated API docs easier to find.
