### PR TITLE
Document new integration jobs

### DIFF
--- a/contributing/ci-omero.txt
+++ b/contributing/ci-omero.txt
@@ -637,7 +637,7 @@ Jenkins.
 		   :term:`OMERO-5.1-breaking-integration-broken`,
 		   :term:`OMERO-5.1-breaking-integration-java`,
 		   :term:`OMERO-5.1-breaking-integration-python`,
-		   :term:`OMERO-5.1-breaking-integration-web`,
+		   :term:`OMERO-5.1-breaking-integration-web`
 
 	:jenkinsjob:`OMERO-5.1-breaking-integration-broken`
 


### PR DESCRIPTION
This PR documents the recent changes brought to the OMERO.web integration test framework by @chris-allan. The nex layout of the integration suite is described with the new collection jobs and extra information is added regarding the location of the test results.

--depends-on https://github.com/openmicroscopy/openmicroscopy/pull/2319
--depends-on https://github.com/openmicroscopy/openmicroscopy/pull/2349
--no-rebase
