### PR TITLE
ticket 10030 fix - contributing file for docs repo (rebased onto develop)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,13 +12,13 @@ a PR.
 
 ## Suggesting a change
 
-* Fork the repository on Github
+* Fork the repository on Github.
 * Create a branch for your work based on the `develop` branch if you want to
   make changes in `/contributing` or `/formats`, or for a future version of
   OMERO, or on the latest `dev_x` e.g. dev_5_0 branch for the current major
   version.
-* Make your commits and open a PR
-* Make sure you explain your changes in the PR description
+* Make your commits and open a PR.
+* Make sure you explain your changes in the PR description.
 
 ## After your PR is open
 


### PR DESCRIPTION
This is the same as gh-757 but rebased onto develop.

---

This adds a CONTRIBUTING.md file which will be pointed out to GH users when they open an issue or PR against this repo.
