### PR TITLE
Making API doc links point at release version (rebased onto develop)

### DIFF
--- a/omero/conf.py
+++ b/omero/conf.py
@@ -79,7 +79,7 @@ omero_extlinks = {
     'omedocs' : (doc_github_root + '%s', ''),
     # Jenkins links
     'omerojob' : (omero_job_root + '/%s', ''),
-    'javadoc' : (omero_job_root + '/javadoc/%s', ''),
+    'javadoc' : (downloads_root + '/latest/omero5/api/%s', ''),
     'virtualjob' : (virtual_job_root + '/%s', ''),
     # Miscellaneous links
     'springdoc' : ('http://docs.spring.io/spring/docs/%s', ''),


### PR DESCRIPTION
This is the same as gh-765 but rebased onto develop.

---

API doc links currently point at the CI builds in Jenkins. This PR makes them point at the release version as linked from the downloads page.

To test, the links are on the front/index page of the staging docs -https://www.openmicroscopy.org/site/support/omero5-staging/

Cc @jburel @sbesson
