### PR TITLE
document new // separator in omero.fs.repo.path

### DIFF
--- a/omero/sysadmins/fs-upload-configuration.txt
+++ b/omero/sysadmins/fs-upload-configuration.txt
@@ -28,15 +28,15 @@ constraints are:
 * The path components must be :literal:`/`-separated, even on Windows
   systems.
 
-* One of the path component separators must be written as :literal:`//`.
-  There must be at least one path component listed before the
-  :literal:`//` and at least one path component listed after it:
+* A path component separator may be written as :literal:`//` with at
+  least one path component listed after it. In this case:
 
   * The server ensures that the path components preceding the
     :literal:`//` are owned by the :literal:`root` user.
 
   * Any newly created path components following the :literal:`//` are
-    owned by the user who owns the images.
+    owned by the user who owns the images. (This is the case for all
+    newly created path components if no :literal:`//` is used.)
 
 * The path must be unique for each import. It is for this reason that
   the :literal:`%time%` term expands to a time with millisecond


### PR DESCRIPTION
Documents changes effected by https://github.com/openmicroscopy/openmicroscopy/pull/2448 and must not be merged before it.

--rebased-to #783
