### PR TITLE
Custom web login 11961 (rebased onto develop)

### DIFF
--- a/omero/sysadmins/unix/install-web.txt
+++ b/omero/sysadmins/unix/install-web.txt
@@ -528,3 +528,22 @@ Customizing your OMERO.web installation
       ::
 
           $ bin/omero config set omero.web.apps '["<app name>"]'
+
+-  Customizing webclient login page:
+
+   -  You can customize the webclient login page with your own logo.
+      Logo images should ideally be 150 pixels high or less and will appear above
+      the OMERO logo.
+
+   -  To use an image that is already hosted elsewhere:
+
+      ::
+
+          $ bin/omero config set omero.web.login_logo "http://www.openmicroscopy.org/site/logo.jpg"
+
+   -  Alternatively, you can replace the placeholder custom_login_logo.png with a different image
+      of the same name. within the static files of your OMERO.web deployment at:
+
+      ::
+
+          path/to/static/webclient/image/custom_login_logo.png

--- a/omero/sysadmins/unix/install-web.txt
+++ b/omero/sysadmins/unix/install-web.txt
@@ -535,15 +535,8 @@ Customizing your OMERO.web installation
       Logo images should ideally be 150 pixels high or less and will appear above
       the OMERO logo.
 
-   -  To use an image that is already hosted elsewhere:
+   -  You will need to host the image somewhere else and link to it with
 
       ::
 
           $ bin/omero config set omero.web.login_logo "http://www.openmicroscopy.org/site/logo.jpg"
-
-   -  Alternatively, you can replace the placeholder custom_login_logo.png with a different image
-      of the same name. within the static files of your OMERO.web deployment at:
-
-      ::
-
-          path/to/static/webclient/image/custom_login_logo.png

--- a/omero/sysadmins/windows/install-web.txt
+++ b/omero/sysadmins/windows/install-web.txt
@@ -384,3 +384,15 @@ Customizing your OMERO.web installation
       ::
 
           C:\omero_dist>bin\omero config set omero.web.apps '["<app name>"]'
+
+-  Customizing webclient login page:
+
+   -  You can customize the webclient login page with your own logo.
+      Logo images should ideally be 150 pixels high or less and will appear above
+      the OMERO logo.
+
+   -  You will need to host the image somewhere else and link to it with
+
+      ::
+
+          C:\omero_dist>bin\omero config set omero.web.login_logo 'http://www.openmicroscopy.org/site/logo.jpg'


### PR DESCRIPTION
This is the same as gh-774 but rebased onto develop.

---

This documents changes in https://github.com/openmicroscopy/openmicroscopy/pull/2461

My only question is exactly what is required when replacing the png after web deployment.
When I tried this with my local nginx deployment, it seemed to cache the original png for a while (even after browser refresh).
