### PR TITLE
Add DropBox Windows requirements

### DIFF
--- a/omero/sysadmins/dropbox.txt
+++ b/omero/sysadmins/dropbox.txt
@@ -23,7 +23,7 @@ the following more specific requirements:
 
     -   Linux with kernel 2.6.13 and higher.
     -   Mac OS 10.6 and later.
-    -   Windows XP and Windows Server 2003.
+    -   Windows XP, Vista, 7, Server 2003 and Server 2008.
 
 -   In addition some platforms require further Python packages to be
     available:


### PR DESCRIPTION
The documentation on the versions of Windows supported by DropBox has become out of sync with the actual versions supported. See https://github.com/openmicroscopy/openmicroscopy/pull/2524 This PR should bring things back in line.

--rebased-to #797
