### PR TITLE
Travis fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ env:
 
 install: "pip install -q Sphinx"
 
-script: "ant html pdf clean"
+script: "make html pdf clean"


### PR DESCRIPTION
This PR should restore the `SPHINXOPTS` option in the Travis build, effectively failing PRs breaking the build
