### PR TITLE
Travis fix (rebased onto develop)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ env:
 
 install: "pip install -q Sphinx"
 
-script: "ant html pdf clean"
+script: "make html pdf clean"


### PR DESCRIPTION
This is the same as gh-808 but rebased onto develop.

---

This PR should restore the `SPHINXOPTS` option in the Travis build, effectively failing PRs breaking the build
