### PR TITLE
Add LDAP error message explanation.

### DIFF
--- a/omero/sysadmins/server-ldap.txt
+++ b/omero/sysadmins/server-ldap.txt
@@ -174,8 +174,8 @@ inside your OMERO installation directory.
 Some of the property values are passed directly to the underlying LDAP library
 (`Spring LDAP <http://projects.spring.io/spring-ldap/>`_), which in turn makes
 use of the Java API. OMERO does not modify the error messages thrown by the
-library or the API, so please consult the appropriate docs to diagnose any
-low-level problems.
+library or by Java, so please consult the appropriate documentation to diagnose
+any low-level problems.
  
 .. note::
 


### PR DESCRIPTION
This is a change that should make clear that besides error messages thrown by OMERO, there is a set of Spring- and Java-specific messages that have to be looked up in external sources (i.e. Spring API docs and Java API docs). See https://www.openmicroscopy.org/community/viewtopic.php?f=4&t=7426#p14069.
