### PR TITLE
Schema links

### DIFF
--- a/omero/index.txt
+++ b/omero/index.txt
@@ -29,8 +29,9 @@ Additional online resources can be found at:
 - ***NEW*** `Demo server <http://qa.openmicroscopy.org.uk/registry/demo_account/>`_
   is now available for OMERO 5
 
-OMERO version *5* uses the *June 2013* release of the
-:model_doc:`OME-Model <>`.
+OMERO version *5* uses the :schema_plone:`June 2013 release
+<Documentation/Generated/OME-2013-06/ome.html>` of the :model_doc:`OME Data
+Model <>`.
 
 .. note:: **If you are still using OMERO 4.4.x, you can find all the
     documentation for those releases via our**


### PR DESCRIPTION
The actual schema documentation is difficult to find, this PR adds a link to the generated docs for the current version to the OMERO index page where the schema version is given.
(More links to be added on the develop branch - Model docs don't exist on this branch)

/cc @mtbc
