### PR TITLE
Restore build system on the main developers documentation index (rebased onto develop)

### DIFF
--- a/omero/developers/index.txt
+++ b/omero/developers/index.txt
@@ -44,6 +44,7 @@ Introduction to OMERO
 
     whatsnew
     installation
+    build-system
     GettingStarted
     testing
 

--- a/omero/developers/installation.txt
+++ b/omero/developers/installation.txt
@@ -161,10 +161,3 @@ To install the dependencies required to run the OMERO.server on Linux
 or Mac OS X, take a look at the
 :doc:`/sysadmins/unix/server-installation` or the
 :doc:`/sysadmins/unix/server-install-homebrew` sections.
-
-.. toctree::
-    :maxdepth: 1
-    :titlesonly:
-
-    build-system
-


### PR DESCRIPTION
This is the same as gh-831 but rebased onto develop.

---

Reported by @ximenesuk during a previous review, this change should re-expose the Build system page on the main index page of the OMERO developers documentation.
