### PR TITLE
Re-working OMERO sysadmin index page

### DIFF
--- a/omero/sysadmins/advanced-install.txt
+++ b/omero/sysadmins/advanced-install.txt
@@ -1,0 +1,13 @@
+Installing additional features
+==============================
+
+.. toctree::
+    :maxdepth: 2
+    :titlesonly:
+
+    server-tables
+    omeromovie
+    installing-scripts
+    grid
+
+    

--- a/omero/sysadmins/index.txt
+++ b/omero/sysadmins/index.txt
@@ -25,93 +25,56 @@ Server Background
     system-requirements
     server-setup-examples
     limitations
+    server-permissions
 
-******************************
-Basic UNIX Server Installation
-******************************
+***********************************
+Server Installation and Maintenance
+***********************************
 
-This chapter contains the instructions to install OMERO.server on
-UNIX & UNIX-like platforms.
-
-.. toctree::
-    :maxdepth: 1
-    :titlesonly:
-
-    unix/server-installation
-    unix/server-binary-repository
-    unix/server-postgresql
-    unix/install-web
-
-*********************************
-Basic Windows Server Installation
-*********************************
-
-This chapter contains the instructions to install OMERO.server on 
-Windows platforms.
+This chapter contains instructions for installing OMERO.server, and for
+troubleshooting, backing-up, and upgrading your server installation.
 
 .. toctree::
     :maxdepth: 1
     :titlesonly:
 
-    windows/server-installation
-    windows/server-binary-repository
-    windows/server-postgresql
-    windows/install-web
-    windows/service-tools
-
-****************************
-Advanced Server Installation
-****************************
-
-.. toctree::
-    :maxdepth: 2
-    :titlesonly:
-
+    unix/index
+    windows/index
+    maintenance
+    advanced-install
     troubleshooting
-    server-security
-    server-advanced-configuration
-    server-ldap
-    server-tables
-    omeromovie
-    installing-scripts
 
-*************************
-Data Import Options
-*************************
+*******************************
+Optimizing Server Configuration
+*******************************
+
+This chapter discusses the options for configuring OMERO.server for optimum
+performance and security.
 
 .. toctree::
     :maxdepth: 2
     :titlesonly:
 
+    server-security
+    server-ldap
+    server-advanced-configuration
+    search
+    server-webstart-codesigning
+    omero-home-prefix
+
+***********************
+Data Import and Storage
+***********************
+
+This chapter contains details of how OMERO.fs allows you to import and store
+data with OMERO 5.
+
+.. toctree::
+    :maxdepth: 2
+    :titlesonly:
+
+    dropbox
     import-scenarios
     in-place-import
     fs-upload-configuration
 
-******************
-Server Maintenance
-******************
-
-.. toctree::
-    :maxdepth: 2
-    :titlesonly:
-
-    server-backup-and-restore
-    server-upgrade
-    UpgradeCheck
-    command-line-interface
-    search
-
-
-***************
-Advanced topics
-***************
-
-.. toctree::
-    :maxdepth: 2
-    :titlesonly:
-
-    server-permissions
-    dropbox
-    grid
-    omero-home-prefix
-    server-webstart-codesigning

--- a/omero/sysadmins/maintenance.txt
+++ b/omero/sysadmins/maintenance.txt
@@ -1,0 +1,12 @@
+Upgrading and maintenance
+=========================
+
+.. toctree::
+    :maxdepth: 2
+    :titlesonly:
+
+    command-line-interface
+    server-backup-and-restore
+    server-upgrade
+    UpgradeCheck
+    

--- a/omero/sysadmins/server-permissions.txt
+++ b/omero/sysadmins/server-permissions.txt
@@ -1,7 +1,7 @@
-Permissions overview
-====================
+Groups and permissions system
+=============================
 
-In the 4.4 release of OMERO, the groups and permissions system has been
+In the 4.4 release of OMERO, the groups and permissions system was
 revamped to allow users to share data with more control. **Users can now
 move data between groups that they are a member of**.
 
@@ -17,7 +17,7 @@ OMERO server. The degree to which their data is available to other
 members of the group depends on the permissions settings for that
 group. Whenever a user logs on to an OMERO server, they are connected
 under one of their groups. All data they import and any work that is
-done is assigned to the current group, however now in 4.4 the user can
+done is assigned to the current group, however the user can now
 easily copy their data into another group.
 
 Users

--- a/omero/sysadmins/unix/index.txt
+++ b/omero/sysadmins/unix/index.txt
@@ -1,0 +1,11 @@
+Basic UNIX (and UNIX-like platforms) server installation
+========================================================
+
+.. toctree::
+    :maxdepth: 1
+    :titlesonly:
+
+    server-installation
+    server-binary-repository
+    server-postgresql
+    install-web

--- a/omero/sysadmins/windows/index.txt
+++ b/omero/sysadmins/windows/index.txt
@@ -1,0 +1,12 @@
+Basic Windows server installation
+=================================
+
+.. toctree::
+    :maxdepth: 1
+    :titlesonly:
+
+    server-installation
+    server-binary-repository
+    server-postgresql
+    install-web
+    service-tools


### PR DESCRIPTION
As requested by Petr, a reworking of the sysadmin index page to make the configuration pages easier to find and the whole page shorter so people can more quickly identify which link they need to follow. 
