### PR TITLE
Clarify fastcgi (rebased onto develop)

### DIFF
--- a/omero/sysadmins/unix/install-web.txt
+++ b/omero/sysadmins/unix/install-web.txt
@@ -85,11 +85,17 @@ Using FastCGI (Unix/Linux)
 Once you have installed a FastCGI capable web server, configuration of
 OMERO.web is quite straightforward.
 
--  Choose between FastCGI TCP (recommended) or FastCGI (advanced):
+-  OMERO.web is configured to use FastCGI TCP by default. If you are using a
+   non-standard web server configuration you may wish to change this before
+   generating your web server configuration:
 
    ::
 
        $ bin/omero config set omero.web.application_server "fastcgi" / "fastcgi-tcp"
+
+   The default `fastcgi-tcp` option uses a TCP connection for communication
+   between OMERO.web and your web server; `fastcgi` uses a file based socket
+   and will require you to manage the file permissions on it.
 
 -  By default OMERO.web expects to be run from the root URL of the web
    server. It can be configured to run from a sub-directory, for example
@@ -104,6 +110,7 @@ OMERO.web is quite straightforward.
    file will depend on your system, please refer to your web server's manual.
    Apache and nginx configurations can be automatically generated for you by
    OMERO.web, see** :ref:`apache_configuration` **or** :ref:`nginx_configuration`.
+
 
 .. _apache_configuration:
 

--- a/omero/sysadmins/windows/install-web.txt
+++ b/omero/sysadmins/windows/install-web.txt
@@ -92,12 +92,6 @@ steps is required to get the `ISAPI
 WSGI <http://code.google.com/p/isapi-wsgi/>`_ handler for OMERO.web
 working with your IIS deployment.
 
--  Choose between FastCGI TCP (recommended) or FastCGI (advanced):
-
-   ::
-
-       C:\omero_dist>bin\omero config set omero.web.application_server "fastcgi" / "fastcgi-tcp"
-
 -  Ensure that the ISAPI for IIS options are installed
 -  Download and install `an ISAPI
    WSGI Installer <http://code.google.com/p/isapi-wsgi/downloads/list>`_ (we
@@ -145,6 +139,13 @@ working with your IIS deployment.
        If your deployment requires additional cache store please follow 
        `Django documentation <https://docs.djangoproject.com/en/1.6/topics/cache/>`_
        for more details.
+
+-  OMERO.web is configured to use FastCGI TCP by default. If you are using a
+   non-standard web server configuration you may wish to change this:
+
+   ::
+
+       C:\omero_dist>bin\omero config set omero.web.application_server "fastcgi" / "fastcgi-tcp"
 
 
 Using the lightweight development server


### PR DESCRIPTION
This is the same as gh-838 but rebased onto develop.

---

Based on https://www.openmicroscopy.org/community/viewtopic.php?f=5&t=7550
it seems there's some confusion on setting `omero.web.application_server` https://www.openmicroscopy.org/site/support/omero5/sysadmins/unix/install-web.html#quick-start. According to @chris-allan the default setting should work, so there's no need to set it.

Note I'm not sure what the situation is with Windows/IIS.
