### PR TITLE
Insert OMERO sidebar template after page TOC sidebar (rebased onto develop)

### DIFF
--- a/omero/conf.py
+++ b/omero/conf.py
@@ -82,7 +82,7 @@ edit_on_github_prefix = 'omero'
 # -- Options for HTML output ---------------------------------------------------
 
 # Custom sidebar templates, maps document names to template names.
-html_sidebars['**'].insert(0, 'globalomerotoc.html')
+html_sidebars['**'].insert(1, 'globalomerotoc.html')
 
 # Add any paths that contain custom themes here, relative to this directory.
 html_theme_path.extend(['themes'])


### PR DESCRIPTION
This is the same as gh-842 but rebased onto develop.

---

Following @pwalczysko suggestions, this PR moves the page contents to the top of lateral sidebar
