### PR TITLE
Adding out-of-date banner to 4.4 docs

### DIFF
--- a/omero/conf.py
+++ b/omero/conf.py
@@ -66,6 +66,11 @@ else:
     release = 'UNKNOWN'
     devbranch = 'develop'
 
+rst_prolog = """
+This documentation is for OMERO 4.4 and is no longer being updated, to see the documentation for
+the latest release, refer to http:/openmicroscopy.org/site/support/omero/
+"""
+
 rst_epilog += """
 .. |OmeroPy| replace:: :doc:`/developers/Python`
 .. |OmeroCpp| replace:: :doc:`/developers/Cpp`


### PR DESCRIPTION
As mentioned on https://trello.com/c/AmB1db6W/57-5-0-3-documentation-fixes - google is linking to 4.4 docs. This adds text to the top of every page to make clear that these docs are not being updated anymore and to point people at the current docs (using our redirected address so this does not need to be updated if we decide to default to linking to 5.1 docs when we release it).

See https://www.openmicroscopy.org/site/support/omero4-staging/ to review
