### PR TITLE
move %time% template expansion term to only user-owned (rebased from dev_5_0)

### DIFF
--- a/omero/sysadmins/fs-upload-configuration.txt
+++ b/omero/sysadmins/fs-upload-configuration.txt
@@ -105,10 +105,6 @@ For any directory in the template path
   expands to the current day number in the month, zero-padded, for
   example :literal:`04`
 
-:literal:`%time%`
-  expands to the current time, in hours, minutes, seconds, milliseconds,
-  for example :literal:`13-49-07.727`
-
 :literal:`%sessionId%`
   expands to the session's numerical ID
 
@@ -121,6 +117,10 @@ For user-owned directories only
 
 These expansion terms may not precede :literal:`//` in the template
 path.
+
+:literal:`%time%`
+  expands to the current time, in hours, minutes, seconds, milliseconds,
+  for example :literal:`13-49-07.727`
 
 :literal:`%hash%`
   expands to an eight-digit hexadecimal hash code that is constant for


### PR DESCRIPTION
Documents changes by https://github.com/openmicroscopy/openmicroscopy/pull/2792 and is staged at http://www.openmicroscopy.org/site/support/omero5.1-staging/sysadmins/fs-upload-configuration.html.

--rebased-from #860
