### PR TITLE
Document client requirements for in-place import on Windows. (rebased onto develop)

### DIFF
--- a/omero/sysadmins/in-place-import.txt
+++ b/omero/sysadmins/in-place-import.txt
@@ -74,16 +74,8 @@ Posix systems (Unix, Linux, OS X).
 
 .. note::
 
-  Supporting in-place import in Windows required breaking compatibility
-  with the 5.0.2 patch release by introducing active file handle closing
-  logic. This code is disabled by default, and needs to be activated
-  through the client-side ``omero.import.active_close`` setting:
-
-  ``C:\set JAVA_OPTS=-Domero.import.active_close=true``
-
-  This must be done from the same Command Prompt window from which the
-  in-place import will commence. Be aware that ``ln_rm`` on Windows does not
-  automatically remove image files after import.
+  In-place import is available on Windows, but be aware that ``ln_rm`` does
+  not automatically remove image files after import.
 
 For soft linking with :literal:`--transfer=ln_s` it has been noticed
 that some plate imports run rather more slowly than usual. Other


### PR DESCRIPTION
This is the same as gh-866 but rebased onto develop.

---

This PR updates the documentation and explains what option needs to be used to get in-place import working on Windows. It also mentions the limitations of `ln_rm`. It is a direct result of https://github.com/openmicroscopy/openmicroscopy/pull/2242#commits-pushed-a394dd6.

/cc @joshmoore
