### PR TITLE
Added warning about web plugins to upgrade docs

### DIFF
--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -67,6 +67,13 @@ show nothing.
 which has been significantly stream-lined. See :ref:`search-reindexing`
 for more information.
 
+Web Plugin Updates
+^^^^^^^^^^^^^^^^^^
+OMERO.web plugins are very closely integrated into the webclient. For this
+reason, it is possible that an update of OMERO will cause issues with an older
+version of a plugin. It is best when updating the server to also install any
+available plugin updates according to their own documentation.
+
 Troubleshooting
 ^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
@dpwrussell has added a general warning about updating web plugins if there are updates available when updating OMERO. I have justified it by detailing that the plugins are very closely integrated with the web client.
