### PR TITLE
Further clarification of in-place on Windows.

### DIFF
--- a/omero/sysadmins/in-place-import.txt
+++ b/omero/sysadmins/in-place-import.txt
@@ -57,7 +57,7 @@ handle in-place importing.
 Someone wanting to perform an in-place import **MUST** have:
 
 * a regular OMERO account
-* an |OS|-account with access to `bin/omero`
+* an |OS|-account with access to :file:`bin/omero`
 * read access to the location of the data
 * **write** access to the :doc:`ManagedRepository
   </developers/ManagedRepository/ManagedRepository>`


### PR DESCRIPTION
This PR explicitly enumerates what in-place functionality is and isn't available under Windows. It aims to fix the issue discovered by @manics (5.0.3 testing spreadsheet, row 29).
Care will have to be taken when rebasing, as the `.. note` element won't be present on `develop`.

To test: please make sure if the limitations are clear enough.

\cc @manics, @joshmoore, @pwalczysko, @mtbc, @rleigh-dundee, @sbesson
