### PR TITLE
Deprecate omero_client.jar.

### DIFF
--- a/omero/developers/Java.txt
+++ b/omero/developers/Java.txt
@@ -15,9 +15,10 @@ Java bindings available on the classpath.
 The required :file:`.jar` files can be obtained in a number of ways:
 
 * manually from the OME
-  `Artifactory server <http://artifacts.openmicroscopy.org/artifactory>`_. The
-  generators under "Client Settings" can help with obtaining configurations
-  for different build systems.
+  `Artifactory server <http://artifacts.openmicroscopy.org/artifactory>`_. All
+  available artifacts and their POM files can be browsed using the
+  `maven repository
+  <http://artifacts.openmicroscopy.org/artifactory/maven/>`_.
 * using the :file:`OMERO.java` ZIP file downloaded from the
   :downloads:`Java <#java>` section of the OMERO download page.
   The :file:`libs` directory can then be used on the Java classpath (or


### PR DESCRIPTION
This PR aims to clear up the confusion around `omero_client.jar` (see https://www.openmicroscopy.org/community/viewtopic.php?f=6&t=7573).

To test, make sure that the new guidelines are clear and concise.

@sbesson: Do we want to make `OMERO.java.zip` more prominent on the download page?
/cc @joshmoore
