### PR TITLE
Add documentation of server foregrounding. (rebased onto develop)

### DIFF
--- a/omero/sysadmins/command-line-interface.txt
+++ b/omero/sysadmins/command-line-interface.txt
@@ -133,6 +133,15 @@ is set to use that database, you are ready to start your server using the
 
     $ bin/omero admin start
 
+.. note::
+
+    :omerocmd:`admin start` and :omerocmd:`admin restart` provide a useful
+    debugging and maintenance option called :option:`--foreground`. Using
+    this option allows for starting the server up in the foreground, that is
+    without creating a daemon on UNIX-like systems or service on Windows.
+    During the lifetime of the server, the prompt from which it was launched
+    will be blocked.
+
 Server diagnostics
 ^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
This is the same as gh-924 but rebased onto develop.

---

@mtbc was not aware of the existence of the --foreground
option. Hence it makes sense to expose it in the docs.
