### PR TITLE
Include LDAP OR docs from Jake Carroll

### DIFF
--- a/omero/sysadmins/server-ldap.txt
+++ b/omero/sysadmins/server-ldap.txt
@@ -152,9 +152,17 @@ filter string. These must be a valid filter in themselves. e.g.
 
 ::
 
+   omero.ldap.user_filter=(|(ou=Queensland Brain Institute)(ou=Ageing Dementia Research))
+
+The "|" operator (read: "OR") above allows members of two organizational units
+to login to OMERO. Expanding the list allows concentric "rings" of more and more
+OU's granular access to OMERO.
+
+::
+
    omero.ldap.group_filter=(&(objectClass=groupOfNames)(mail=omero.flag))
 
-This filter is valid and will cause the filter to only match groups that have
+The "&" operator (read: "AND") produces a filter that will only match groups that have
 the ``mail`` attribute set to the value ``omero.flag``. When combined with
 the ``group_mapping``, the final query would be
 ``(&(&(objectClass=groupOfNames)(mail=omero.flag))(cn=[group name]))``


### PR DESCRIPTION
See http://lists.openmicroscopy.org.uk/pipermail/ome-users/2014-August/004629.html

Rather than reconfigure LDAP to use use [Global Catalogue](https://www.openmicroscopy.org/site/support/omero5/sysadmins/server-ldap.html?highlight=active%20directory#global-catalogue) for Active Directory, it is also possible to use explicit OUs as pointed out by Jake Carroll from UQ.
