### PR TITLE
Fixing source code link to BF docs

### DIFF
--- a/formats/ome-xml/java-library.txt
+++ b/formats/ome-xml/java-library.txt
@@ -48,6 +48,6 @@ Source code
 
 The OME-XML Java library is an open source project—the source code is
 freely accessible via our Git repository. See 
-:bf_doc:`these instructions <developers/source-code.html>` for details on accessing 
-the code.
+:bf_doc:`these instructions <developers/building-bioformats.html>` for details
+on accessing the code.
 


### PR DESCRIPTION
FORMATS-merge build was yellow because Roger's update to the BF docs was released and the source code info has moved to a new page.

This should make the build green again.
