### PR TITLE
Adding preview note to 5.1 docs for pre-release

### DIFF
--- a/omero/conf.py
+++ b/omero/conf.py
@@ -44,9 +44,12 @@ else:
     release = 'UNKNOWN'
 
 rst_prolog = """
-**This documentation is a PREVIEW for the as-yet unreleased OMERO 5.1. It is provided
-for the benefit of developers and should be considered a work in progress until the
-public release.**
+.. warning:: **This documentation is a PREVIEW for the as-yet unreleased OMERO 5.1. It is provided
+    for the benefit of developers and should be considered a work in progress until the
+    public release.** Please refer to the documentation for the `latest OMERO 5.0.x
+    version <http://www.openmicroscopy.org/site/support/omero5/>`_ or the
+    :legacy_plone:`previous versions <>` page to find documentation for the
+    OMERO version you are using.
 """
 
 rst_epilog += """

--- a/omero/sysadmins/index.txt
+++ b/omero/sysadmins/index.txt
@@ -2,12 +2,6 @@
 System Administrator Documentation
 ##################################
 
-.. note:: This documentation is a PREVIEW for the as-yet unreleased OMERO 5.1
-    series. Please refer to the documentation for the `latest OMERO 5.0.x
-    version <http://www.openmicroscopy.org/site/support/omero5/>`_ or the
-    :legacy_plone:`previous versions <>` page to find documentation for your
-    server version.
-
 *****************
 Server Background
 *****************


### PR DESCRIPTION
In preparation for a 'preview' release of the docs - adding a warning note to make it clear these are not for general use if anyone happens across them

cc @joshmoore @sbesson

--no-rebase
