### PR TITLE
Use new latest/product5.1 redirects across the board

### DIFF
--- a/common/conf.py
+++ b/common/conf.py
@@ -167,8 +167,8 @@ extlinks = {
     'bf_doc' : (oo_site_root + '/support/bio-formats5/%s', ''),
     'partner_plone' : (oo_site_root + '/products/partner/%s', ''),
     # Downloads
-    'downloads' : (downloads_root + '/latest/omero5/%s', ''),
-    'bf_downloads' : (downloads_root + '/latest/bio-formats5/%s', ''),
+    'downloads' : (downloads_root + '/latest/omero5.1/%s', ''),
+    'bf_downloads' : (downloads_root + '/latest/bio-formats5.1/%s', ''),
     # Help links
     'help' : (help_root + '/%s', ''),
     # Miscellaneous links

--- a/formats/conf.py
+++ b/formats/conf.py
@@ -42,7 +42,7 @@ model_extlinks = {
     'sourcedir' : (bf_github_root + 'tree/'+ branch + '/%s', ''),
     'omero_source' : (omero_github_root + 'blob/'+ branch + '/%s', ''),
     # API
-    'javadoc' : (downloads_root + '/latest/bio-formats/api/%s', ''),
+    'javadoc' : (downloads_root + '/latest/bio-formats5.1/api/%s', ''),
     }
 extlinks.update(model_extlinks)
 

--- a/omero/conf.py
+++ b/omero/conf.py
@@ -79,7 +79,7 @@ omero_extlinks = {
     'commit' : (omero_github_root + 'commit/%s', ''),
     'omedocs' : (doc_github_root + '%s', ''),
     # API links
-    'javadoc' : (downloads_root + '/latest/omero5/api/%s', ''),
+    'javadoc' : (downloads_root + '/latest/omero5.1/api/%s', ''),
     # Miscellaneous links
     'springdoc' : ('http://docs.spring.io/spring/docs/%s', ''),
     }

--- a/omero/themes/globalomerotoc.html
+++ b/omero/themes/globalomerotoc.html
@@ -1,5 +1,5 @@
 <h3><a href="{{ pathto(master_doc) }}">{{ _('OMERO') }}</a></h3>
 {{ toctree()}}
-<a href="http://downloads.openmicroscopy.org/latest/omero5/">{{ _('Downloads') }}</a></br>
+<a href="http://downloads.openmicroscopy.org/latest/omero5.1/">{{ _('Downloads') }}</a></br>
 <a href="//www.openmicroscopy.org/site/products/omero/feature-list">{{ _('Feature List') }}</a></br>
 <a href="//www.openmicroscopy.org/site/about/licensing-attribution">{{ _('Licensing') }}</a>


### PR DESCRIPTION
Note the `latest/{omero/bio-formats}5.1/` redirects currently point at 5.0.3

--rebased-to #945 
