### PR TITLE
Use new latest/product5.0 redirects across the board

### DIFF
--- a/common/conf.py
+++ b/common/conf.py
@@ -167,8 +167,8 @@ extlinks = {
     'bf_doc' : (oo_site_root + '/support/bio-formats5/%s', ''),
     'partner_plone' : (oo_site_root + '/products/partner/%s', ''),
     # Downloads
-    'downloads' : (downloads_root + '/latest/omero5/%s', ''),
-    'bf_downloads' : (downloads_root + '/latest/bio-formats5/%s', ''),
+    'downloads' : (downloads_root + '/latest/omero5.0/%s', ''),
+    'bf_downloads' : (downloads_root + '/latest/bio-formats5.0/%s', ''),
     # Help links
     'help' : (help_root + '/%s', ''),
     # Miscellaneous links

--- a/omero/conf.py
+++ b/omero/conf.py
@@ -70,7 +70,7 @@ omero_extlinks = {
     'commit' : (omero_github_root + 'commit/%s', ''),
     'omedocs' : (doc_github_root + '%s', ''),
     # API links
-    'javadoc' : (downloads_root + '/latest/omero5/api/%s', ''),
+    'javadoc' : (downloads_root + '/latest/omero5.0/api/%s', ''),
     # Miscellaneous links
     'springdoc' : ('http://docs.spring.io/spring/docs/%s', ''),
     }

--- a/omero/themes/globalomerotoc.html
+++ b/omero/themes/globalomerotoc.html
@@ -1,5 +1,5 @@
 <h3><a href="{{ pathto(master_doc) }}">{{ _('OMERO') }}</a></h3>
 {{ toctree()}}
-<a href="http://downloads.openmicroscopy.org/latest/omero5/">{{ _('Downloads') }}</a></br>
+<a href="http://downloads.openmicroscopy.org/latest/omero5.0/">{{ _('Downloads') }}</a></br>
 <a href="//www.openmicroscopy.org/site/products/omero/feature-list">{{ _('Feature List') }}</a></br>
 <a href="//www.openmicroscopy.org/site/about/licensing-attribution">{{ _('Licensing') }}</a>


### PR DESCRIPTION
All `latest` links should still be pointing at the right downloads pages/Javadoc...

--rebased-from #944 
