### PR TITLE
Make Ice 3.5.1 default version (rebased onto dev_5_0)

### DIFF
--- a/omero/conf.py
+++ b/omero/conf.py
@@ -59,7 +59,7 @@ rst_epilog += """
 .. |DevelopingOmeroClients| replace:: :doc:`/developers/GettingStarted/AdvancedClientDevelopment`
 .. _Spring: http://spring.io
 .. |previousversion| replace:: %s
-.. |iceversion| replace:: 3.5.0
+.. |iceversion| replace:: 3.5.1
 """ % previousversion
 
 # OMERO-specific extlinks


### PR DESCRIPTION
This is the same as gh-943 but rebased onto dev_5_0.

---

See #938 - default ice version substituted from config is now 3.5.1
