### PR TITLE
OMERO developer setup 

### DIFF
--- a/omero/developers/installation.txt
+++ b/omero/developers/installation.txt
@@ -64,11 +64,26 @@ Additional dependencies are necessary for building the server and clients:
 
     pip install Genshi
 
-Finally, some environment variables need to be properly set up before building
+- Ice Python and Java development packages may need to be explicitly installed
+  on Linux.
+
+Finally, some environment variables may need to be set up before building
 the server:
 
-- :envvar:`SLICEPATH` must point at the :file:`slice` directory of the Ice
-  installation.
+- If the system slice files cannot be found you must set :envvar:`SLICEPATH`
+  to point to the :file:`slice` directory of the Ice installation.
+
+For example, on CentOS 6 the following should be sufficient to run the default
+build::
+
+    yum install java-1.7.0-openjdk-devel python-genshi python-setuptools \
+        ice-servers ice-python-devel ice-java-devel ice-c++-devel
+
+    export SLICEPATH=/usr/share/Ice-3.5.1/slice
+
+On Ubuntu 14.04::
+
+    apt-get install openjdk-7-jdk python-genshi python-setuptools zeroc-ice
 
 Once all the dependencies and environment variables are set up, you can build
 the server using::


### PR DESCRIPTION
This PR is meant to address https://trello.com/c/sb3mPUwV/190-developer-setup-docs-walkthrough and various reports about missing information for developers.

Major changes are the following:
- all the advanced Git configuration is stripped from the developer documentation and now should live exclusively on the contributing documentation
- a link to the contributing documentation is added for people wanting to contribute
- a placeholder is added to list the OMERO build dependencies (libraries, envvars)
- the main build commands are listed on the page a link to the advanced build system page

Additional points to discuss:
- which additional build libraries/envvars would be required?
- should we add an alternate way of getting the source code using the OMERO source code zip from the downloads page? Note the latter does not include the Bio-Formats versioning yet.
- should `Installing OMERO` be renamed as `Building OMERO` ?

/cc @manics @mtbc @rleigh-dundee @hflynn @kennethgillen 
