### PR TITLE
adding ip6 connection line to pg_hba.conf

### DIFF
--- a/omero/sysadmins/windows/server-postgresql.txt
+++ b/omero/sysadmins/windows/server-postgresql.txt
@@ -83,6 +83,8 @@ address (``127.0.0.1``) as follows:
     # TYPE  DATABASE    USER        CIDR-ADDRESS          METHOD
     # IPv4 local connections:
     host    all         all         127.0.0.1/32          md5
+    # IPv6 local connections:
+    host    all         all         ::1/128               md5
 
 .. note:: 
     The other lines that are in your ``pg_hba.conf`` are important


### PR DESCRIPTION
I was following the docs on my original CentOS installs, where the IP6 local connection was being tried and failing, since this was missing from the docs.
