### PR TITLE
Moving walkthros up a level in TOC

### DIFF
--- a/omero/sysadmins/unix/index.txt
+++ b/omero/sysadmins/unix/index.txt
@@ -6,6 +6,8 @@ Basic UNIX (and UNIX-like platforms) server installation
     :titlesonly:
 
     server-installation
+    server-install-homebrew
+    server-linux-walkthrough
     server-binary-repository
     server-postgresql
     install-web

--- a/omero/sysadmins/unix/server-installation.txt
+++ b/omero/sysadmins/unix/server-installation.txt
@@ -844,8 +844,3 @@ started from the *Open Microscopy Environment* update server. If you
 wish to disable this functionality you should do so now as outlined on
 the :doc:`/sysadmins/UpgradeCheck` page.
 
-.. toctree::
-    :hidden:
-
-    server-linux-walkthrough
-    server-install-homebrew


### PR DESCRIPTION
See https://trello.com/c/TsgYDWGJ/191-server-installation-links
Now we have the installation docs listed in a separate index there is less need to 'hide' the walkthroughs to cut down on clutter. This should make them easier for the relevant people to find and they already have clear text at the top of each page to make sure sysadmins are clear on the content and which doc they need to read for which system.
