### PR TITLE
Adding 5.0.4 to OMERO version history

### DIFF
--- a/omero/users/history.txt
+++ b/omero/users/history.txt
@@ -4,9 +4,11 @@ OMERO version history
 5.0.4 (September 2014)
 ----------------------
 
-This is a bug-fix release for the Java 8 issues. You also need to upgrade your
-OMERO server if you want to take advantage of further improvements in
-Bio-Formats support for ND2 files.
+This is a bug-fix release for the Java 8 issues. It also features a fix for
+uploading masks in OMERO.matlab.
+
+You need to upgrade your OMERO server if you want to take advantage of
+further improvements in Bio-Formats support for ND2 files.
 
 5.0.3 (August 2014)
 -------------------


### PR DESCRIPTION
Seemed silly to do on develop first so I'll rebase this in the other direction. Version history assuming the OMERO.web fixes don't make it into the release - will need amending if they make it after all.
