### PR TITLE
adding ip6 pg_hba.conf connection line (rebased onto dev_5_0)

### DIFF
--- a/omero/sysadmins/unix/server-postgresql.txt
+++ b/omero/sysadmins/unix/server-postgresql.txt
@@ -117,6 +117,8 @@ address (``127.0.0.1``) as follows:
     # TYPE  DATABASE    USER        CIDR-ADDRESS          METHOD
     # IPv4 local connections:
     host    all         all         127.0.0.1/32          md5
+    # IPv6 local connections:
+    host    all         all         ::1/128               md5
 
 .. note:: 
     The other lines that are in your ``pg_hba.conf`` are important


### PR DESCRIPTION
This is the same as gh-961 but rebased onto dev_5_0.

---

adding the ip6 equivalent - my first installs on CentOS I missed this, and was baffled why the DB connection was failing - it didn't help that this wasn't in the docs.
