### PR TITLE
Remove brew deps in favor of brew install --only-dependencies (rebased onto develop)

### DIFF
--- a/omero/sysadmins/unix/server-install-homebrew.txt
+++ b/omero/sysadmins/unix/server-install-homebrew.txt
@@ -146,7 +146,7 @@ install the OMERO dependencies:
 
     $ brew tap homebrew/science
     $ brew tap ome/alt
-    $ brew install `brew deps omero`
+    $ brew install --only-dependencies omero
 
 The default version of Ice installed by the OMERO formula is currently Ice 3.5.
 


### PR DESCRIPTION
This is the same as gh-960 but rebased onto develop.

---

As reported by @kennethgillen, the current command to install OMERO dependencies only does not work properly with dependency options. This commit uses the Homebrew option for installing formulas with dependencies.
