### PR TITLE
Remove unnecessary SLICEPATH on CentOS for developers

### DIFF
--- a/omero/developers/installation.txt
+++ b/omero/developers/installation.txt
@@ -79,8 +79,6 @@ build::
     yum install java-1.7.0-openjdk-devel python-genshi python-setuptools \
         ice-servers ice-python-devel ice-java-devel ice-c++-devel
 
-    export SLICEPATH=/usr/share/Ice-3.5.1/slice
-
 On Ubuntu 14.04::
 
     apt-get install openjdk-7-jdk python-genshi python-setuptools zeroc-ice


### PR DESCRIPTION
With https://github.com/openmicroscopy/openmicroscopy/pull/2978 being merged in the upstream repository, `SLICEPATH` should not be required anymore for developers building OMERO on CentOS.

/cc @rleigh-dundee @manics 

--no-rebase
