### PR TITLE
Adding repo cloning to 'using git' guide

### DIFF
--- a/contributing/source-code.txt
+++ b/contributing/source-code.txt
@@ -56,6 +56,11 @@ Most OME development is currently happening on GitHub, therefore it is highly
 suggested that you become familiar with how it works, if not create an account
 for yourself.
 
+.. note:: There is extensive guidance on the :doc:`using-git` page and the
+    following examples assume you have set up your account using "gh" for your
+    personal repositories and "origin" as the official repositories as
+    described there.
+
 Start by cloning the official repository for the project you want to work with
 e.g.::
 

--- a/contributing/using-git.txt
+++ b/contributing/using-git.txt
@@ -152,7 +152,7 @@ you would like to check in .git/config:
 
 ::
 
-    git config remotes.default "ome team origin gh official chris ola will jm colin elwood"
+    git config remotes.default "ome team origin gh official chris ola will jm colin"
 
 Now, ``git remote update`` will check the above list of repositories.
 


### PR DESCRIPTION
Adding a nice simple explanation of getting the repos set up in the first place for my own benefit (because I do it so infrequently I always forget how and have to ask @sbesson !) and getting rid of the ridiculous amount of extra indenting in this file.

--no-rebase
