### PR TITLE
Update IIS app pool setting doc (fix #12504). (rebased onto dev_5_0)

### DIFF
--- a/omero/sysadmins/windows/install-web.txt
+++ b/omero/sysadmins/windows/install-web.txt
@@ -111,12 +111,13 @@ working with your IIS deployment.
 -  The :guilabel:`Advanced Settings...` for the application pool
    assigned to your default site require modification using the *IIS Manager* as follows:
 
-      - :guilabel:`Enable 32-bit Applications` - OMERO.web and ISAPI WSGI
-        are 32-bit applications on Windows at present. If you are attempting
-        to run OMERO.web on a 64-bit version of Windows, you must enable 32-bit compatibility.
-      - :guilabel:`Idle Time-out (minutes)` - to stop the worker process from
-        suspending during inactivity periods, this setting needs to be
-        changed to 0.
+   - :guilabel:`Enable 32-bit Applications` - OMERO.web and ISAPI WSGI
+     are 32-bit applications on Windows at present. If you are attempting
+     to run OMERO.web on a 64-bit version of Windows, you must enable 32-bit
+     compatibility.
+   - :guilabel:`Idle Time-out (minutes)` - to stop the worker process from
+     suspending during inactivity periods, this setting needs to be
+     changed to 0.
 
 .. figure:: /images/installation-images/IIS7ApplicationPool.png
    :align: center


### PR DESCRIPTION
This is the same as gh-974 but rebased onto dev_5_0.

---

This PR fixes http://trac.openmicroscopy.org.uk/ome/ticket/12504. Updating the setting according to the doc will guarantee no sleep for the app pool workers.
