### PR TITLE
Adding proper top warning & removing others

### DIFF
--- a/omero/conf.py
+++ b/omero/conf.py
@@ -67,8 +67,12 @@ else:
     devbranch = 'develop'
 
 rst_prolog = """
-This documentation is for OMERO 4.4 and is no longer being updated, to see the documentation for
-the latest release, refer to http:/openmicroscopy.org/site/support/omero/
+.. warning:: This documentation is for OMERO 4.4 and is no longer being updated,
+    to see the documentation for the latest release, refer to
+    http:/openmicroscopy.org/site/support/omero/
+    
+    We will continue to support 4.4 into spring 2015 but you should not develop
+    against this version or use it for new installations.
 """
 
 rst_epilog += """

--- a/omero/developers/index.txt
+++ b/omero/developers/index.txt
@@ -2,13 +2,6 @@
 Developer Documentation
 #######################
 
-.. warning:: With the release of OMERO 5.0, the 4.4.x line has now entered
-    maintenance mode. We will continue to support this version throughout 2014
-    but it will only be updated for major bug fixes, so you may wish to work
-    against the new `5.0 version <http://www.openmicroscopy.org/site/support/omero5/developers/>`_
-    instead.
-
-
 The following documentation is for developers wishing to write OMERO client
 code or extend the OMERO server. Instructions on :downloads:`downloading <>`,
 installation and administering OMERO can be found under the 

--- a/omero/index.txt
+++ b/omero/index.txt
@@ -28,10 +28,6 @@ Additional online resources can be found at:
 OMERO version *4* uses the *June 2012* release of the
 :model_doc:`OME-Model <>`.
 
-.. note:: **With the release of OMERO 5.0, the 4.4.x line has now entered
-    maintenance mode. We will continue to support this version throughout 2014
-    but it will only be updated for major bug fixes.**
-
 .. toctree::
     :maxdepth: 1
     :hidden:

--- a/omero/sysadmins/index.txt
+++ b/omero/sysadmins/index.txt
@@ -2,11 +2,6 @@
 System Administrator Documentation
 ##################################
 
-.. warning:: This documentation is for the OMERO 4.4.x line which, on the
-    release of version 5.0 has now entered maintenance mode. While we will
-    continue to support this version throughout 2014, it will only be updated
-    for major bug fixes.
-
 *****************
 Server Background
 *****************


### PR DESCRIPTION
@kennethgillen was concerned that the 4.4 docs are not all marked clearly enough so I've put the text from the top of each page into a proper warning box and removed the repetitive ones as this will be on every page anyway.

cc @joshmoore @jburel @jrswedlow - I guess the decision on this is somewhat political - is it ok to have a red warning box on a version we are still supporting?
