### PR TITLE
add note for omero.jvmcfg.* setters about admin jvmcfg (rebased from develop)

### DIFF
--- a/omero/sysadmins/server-performance.txt
+++ b/omero/sysadmins/server-performance.txt
@@ -112,7 +112,7 @@ the other services.
 Tips
 ^^^^
 
-View the memory settings that apply to newly started servers.
+View the memory settings that will apply to a newly started server.
 
 ::
 


### PR DESCRIPTION
... readers of that page might not notice that `bin/omero admin jvmcfg` is useful to check the results of their settings changes. Staged at https://www.openmicroscopy.org/site/support/omero5-staging/sysadmins/server-performance.html#tips.

--rebased-from #995
