### PR TITLE
Adding link to secvuln on sysadmin security page

### DIFF
--- a/omero/sysadmins/server-security.txt
+++ b/omero/sysadmins/server-security.txt
@@ -18,10 +18,10 @@ client including:
 -  Escaping and bind variable use in all SQL interactions performed via
    Hibernate
 
-The OMERO team treats the security of all components with care and
-attention. If you have a security issue to report please do not hesitate
-to contact us using any one of the mechanisms found on the
-:community_plone:`community <>` page.
+.. note:: The OMERO team treats the security of all components with care and
+    attention. If you have a security issue to report, please do not hesitate
+    to contact us using our private, secure mailing list as described on the
+    :secvuln:`security vulnerabilities <>` page.
 
 Firewall configuration
 ----------------------


### PR DESCRIPTION
See https://trello.com/c/xV9zo9RJ/212-security-vulnerabilities
Adding pointer to security vulnerability page to sysadmin security page now we have a private channel for this rather than directing people at the public mailing lists and forums.

Will rebase now as it is a minor change and I'm re-releasing all the docs on Thursday for the blog menu update anyway.
