### PR TITLE
Add documentation for new OME-help-release job

### DIFF
--- a/contributing/ci-docs.txt
+++ b/contributing/ci-docs.txt
@@ -85,7 +85,7 @@ independent of the current OMERO/Bio-Formats version.
 		* :term:`OME-help-staging`
 
 	- 	* Publish OME help documentation
-		* :term:`OME-helpf-release`
+		* :term:`OME-help-release`
 
 Configuration
 ^^^^^^^^^^^^^


### PR DESCRIPTION
This should provide a description the new http://ci.openmicroscopy.org/view/Docs/job/OME-help-release/ job to be used for help publication.

/cc @hflynn @gusferguson 

--no-rebase
