### PR TITLE
Update auto-generated properties

### DIFF
--- a/omero/sysadmins/config.txt
+++ b/omero/sysadmins/config.txt
@@ -58,7 +58,8 @@ editor.
 
 .. note::
     Please use the **escape sequence** ``\"`` for nesting double quotes (e.g.
-    ``"[\"foo\", \"bar\"]"``) or wrap with ``'`` (e.g. ``'["foo", "bar"]'``).
+    ``"[\"foo\", \"bar\"]"``) or wrap with ``'`` (e.g. ``'["foo",
+    "bar"]'``).
 
 Examples of doing this are on the main :doc:`Unix <unix/server-installation>`
 and :doc:`Windows <windows/server-installation>` pages, as well as the
@@ -110,7 +111,7 @@ Default: `omero`
 omero.db.patch
 ^^^^^^^^^^^^^^
 
-Default: `9`
+Default: `10`
 
 .. property:: omero.db.poolsize
 

--- a/omero/users/history.txt
+++ b/omero/users/history.txt
@@ -1,6 +1,30 @@
 OMERO version history
 =====================
 
+5.1.0-m1 (October 2014)
+-----------------------
+
+Developer preview release - 1 of 3 development milestones being released in
+the lead up to 5.1.0. **Only intended as a developer preview for updating code
+before the full public release of 5.1.0. Use at your own risk**.
+
+Model changes include:
+
+-  channel value has changed from an int to a float
+-  acquisitionDate on Image is now optional
+-  Pixels and WellSample types are no longer annotatable
+-  the following types are now annotatable: Detector, Dichroic, Filter,
+   Instrument, LightSource, Objective, Shape
+-  introduction of a "Map" type which permits storing key-value pairs, and a
+   Map annotation type which allows linking a Map on any annotatable object
+
+Other changes that may affect developers include:
+
+-  strict flake8'ing of all Python code
+-  C++ build is now based on CMake and is hopefully much more user-friendly
+-  new APIs: SendEmail and DiskUsage
+-  the password table now has a "changed" field
+
 5.0.5 / 4.4.12 (September 2014)
 -------------------------------
 


### PR DESCRIPTION
Repository: openmicroscopy/ome-documentation
Already up-to-date.

Generated by build [OMERO-5.1-latest-docs-autogen#179](http://ci.openmicroscopy.org/job/OMERO-5.1-latest-docs-autogen/179/).

---

--no-rebase
