### PR TITLE
Ldap.txt: cleanup and update column names.

### DIFF
--- a/omero/developers/Server/Ldap.txt
+++ b/omero/developers/Server/Ldap.txt
@@ -14,13 +14,16 @@ The LDAP plugin follows these steps:
 
 #. Sysadmin configures properties mapping users and groups from LDAP to
    OMERO.
-#. Once LDAP is enabled, any OMERO user who has a non-null ``dn`` in the
-   ``password`` table will have their password checked against LDAP and
-   **not** against OMERO (changing the password via OMERO is *not* supported).
-   This functionality is provided by the :doc:`/developers/Server/PasswordProvider`.
+#. Once LDAP is enabled, any OMERO user who has a value of ``true`` in the
+   ``ldap`` column of the ``experimenter`` table will have their password
+   checked against LDAP and **not** against OMERO (changing the password via
+   OMERO is *not* supported). This functionality is provided by the
+   :doc:`/developers/Server/PasswordProvider`. The :abbr:`DN (Distinguished
+   Name)` is not stored in the OMERO DB and is retrieved from the LDAP server
+   on each user login.
 #. If there is no OMERO user for a given name, the LDAP plugin will use
-   :property:`omero.ldap.user_filter` and :property:`omero.ldap.user_mapping` to look
-   for a valid user:
+   :property:`omero.ldap.user_filter` and
+   :property:`omero.ldap.user_mapping` to look for a valid user:
 
    #. The ``user_mapping`` property is of the form:
       ``omeName=<ldap attribute>;firstName=<ldapAttribute>;…``
@@ -35,11 +38,13 @@ The LDAP plugin follows these steps:
 
 #. **If** the search returns a **single** LDAP user, then an OMERO user will
    be created with all properties mapped according to
-   :property:`omero.ldap.user_mapping`.
+   :property:`omero.ldap.user_mapping` and the ``ldap`` property set to
+   ``true``.
 #. Then the user will be placed in groups according to the value of
-   :property:`omero.ldap.new_user_group`, which are created if necessary. Details
-   of the various options can be found under :doc:`/sysadmins/server-ldap`.
-   Each option is handled by a different ``NewUserGroupBean`` implementation.
+   :property:`omero.ldap.new_user_group`, which are created if necessary.
+   Details of the various options can be found under
+   :doc:`/sysadmins/server-ldap`. Each option is handled by a different
+   ``NewUserGroupBean`` implementation.
 
 NewUserGroupBean.java
 ---------------------
@@ -62,9 +67,11 @@ package are:
 .. seealso:: 
 
     :doc:`/sysadmins/unix/server-installation`
-        Instructions for installing OMERO.server on UNIX and UNIX-like platforms
+        Instructions for installing OMERO.server on UNIX and UNIX-like
+        platforms
 
     :doc:`/sysadmins/windows/server-installation`
         Instructions for installing OMERO.server on Windows platforms
-    
+
     :doc:`/sysadmins/server-security`
+        General instructions on server security


### PR DESCRIPTION
This change goes in hand with https://github.com/openmicroscopy/openmicroscopy/pull/3119. It updates
the description of the logic used for LDAP user lookup and mentions
the new column in the "experimenter" table.

--no-rebase
