### PR TITLE
switch Jenkins links to be through secure connection (rebased from develop)

### DIFF
--- a/common/conf.py
+++ b/common/conf.py
@@ -123,7 +123,7 @@ bf_github_root = github_root + user + '/bioformats/'
 doc_github_root = github_root + user + '/ome-documentation/'
 
 # Variables used to define Jenkins extlinks
-jenkins_root = 'http://ci.openmicroscopy.org'
+jenkins_root = 'https://ci.openmicroscopy.org'
 jenkins_job_root = jenkins_root + '/job'
 jenkins_view_root = jenkins_root + '/view'
 


### PR DESCRIPTION
Now our CI links in our docs should be `https:` URIs.
--rebased-from #1016
