### PR TITLE
Variable names in example are swapped (rebased onto develop)

### DIFF
--- a/omero/developers/command-line-interface.txt
+++ b/omero/developers/command-line-interface.txt
@@ -62,8 +62,8 @@ the CLI commands can be redirected and piped together. For example, the
 following set of commands creates a dataset and a project and links them
 together::
 
-   $ project=$(bin/omero obj new Dataset name=dataset-1)
-   $ dataset=$(bin/omero obj new Project name=plate-1)
+   $ dataset=$(bin/omero obj new Dataset name=dataset-1)
+   $ project=$(bin/omero obj new Project name=plate-1)
    $ bin/omero obj new ProjectDatasetLink parent=$project child=$dataset
 
 Extensions


### PR DESCRIPTION
This is the same as gh-1023 but rebased onto develop.

---

The `project` and `dataset` variable names are swapped.
