### PR TITLE
Fixing use of :option: for new sphinx

### DIFF
--- a/omero/developers/Cpp.txt
+++ b/omero/developers/Cpp.txt
@@ -48,8 +48,8 @@ matches the version of your server!
 The location of your Ice installation should be automatically detected
 if installed into a standard location. If this is not the case, set
 the location of your Ice installation using the :envvar:`ICE\_HOME`
-environment variable or the :option:`ICE\_HOME` or
-:option:`Ice_SLICE_DIR` :program:`cmake` options for your Ice
+environment variable or the :option:`-DICE\_HOME` or
+:option:`-DIce_SLICE_DIR` :program:`cmake` options for your Ice
 installation (see below). Some possible locations for the |iceversion|
 version of Ice follow. Note these are just examples; you need to
 adjust them for the Ice installation path and version in use on your
@@ -226,76 +226,76 @@ environment variables are commonly needed:
 In addition, :program:`cmake` options may be defined directly when
 running :program:`cmake`. Commonly needed options include:
 
-:option:`CMAKE_PREFIX_PATH`
+:option:`-DCMAKE_PREFIX_PATH`
     Search this location when searching for programs, headers and
     libraries.  Use to search :file:`/usr/local` or :file:`/opt/Ice`,
     for example.  More specific search locations may be specified
-    using :option:`CMAKE_INCLUDE_PATH`, :option:`CMAKE_LIBRARY_PATH`
-    and :option:`CMAKE_PROGRAM_PATH` separately, if required.
+    using :option:`-DCMAKE_INCLUDE_PATH`, :option:`-DCMAKE_LIBRARY_PATH`
+    and :option:`-DCMAKE_PROGRAM_PATH` separately, if required.
 
-:option:`CMAKE_INCLUDE_PATH`
+:option:`-DCMAKE_INCLUDE_PATH`
     Search this location when searching for headers.  Use to include
     :file:`/usr/local/include` or :file:`/opt/Ice/include`, for
     example.
 
-:option:`CMAKE_LIBRARY_PATH`
+:option:`-DCMAKE_LIBRARY_PATH`
     Search this location when searching for libraries.  Use to include
     :file:`/usr/local/lib` or :file:`/opt/Ice/lib`, for example.
 
-:option:`CMAKE_PROGRAM_PATH`
+:option:`-DCMAKE_PROGRAM_PATH`
     Search this location when searching for programs.  Use to include
     :file:`/usr/local/bin` or :file:`/opt/Ice/bin`, for example.
 
-:option:`CMAKE_CXX_FLAGS`
+:option:`-DCMAKE_CXX_FLAGS`
     C++ compiler flags. Use to set any additional linker flags
     desired.
 
-:option:`CMAKE_EXE_LINKER_FLAGS`
+:option:`-DCMAKE_EXE_LINKER_FLAGS`
     Executable linker flags. Use to set any additional linker flags
     desired.
 
-:option:`CMAKE_MODULE_LINKER_FLAGS`
+:option:`-DCMAKE_MODULE_LINKER_FLAGS`
     Loadable module linker flags. Use to set any additional linker
     flags desired.
 
-:option:`CMAKE_SHARED_LINKER_FLAGS`
+:option:`-DCMAKE_SHARED_LINKER_FLAGS`
     Shared library linker flags. Use to set any additional linker
     flags desired.
 
-:option:`CMAKE_VERBOSE_MAKEFILE`
+:option:`-DCMAKE_VERBOSE_MAKEFILE`
     Default to printing all commands executed by make. This may be
     overridden with the make ``VERBOSE`` variable.
 
-:option:`Ice\_HOME`
+:option:`-DIce\_HOME`
     The location of the Ice installation. If this is not sufficient to
     discover the correct binary and library directories, they may
     otherwise be manually specified with the options below. Likewise
     for the :file:`include` and :file:`slice` directories.
 
-:option:`Ice_SLICE2XXX_EXECUTABLE`
+:option:`-DIce_SLICE2XXX_EXECUTABLE`
     Specific location of individual Ice ``slice2xxx`` programs, e.g.
     ``Ice_SLICE2CPP_EXECUTABLE`` for :program:`slice2cpp` or
     ``Ice_SLICE2JAVA_EXECUTABLE`` for :program:`slice2java`. These are
     typically found in ``${ICE_HOME}/bin`` or on the default
-    :option:`PATH`.  These will not normally require setting.
+    :envvar:`PATH`.  These will not normally require setting.
 
-:option:`Ice_INCLUDE_DIR`
+:option:`-DIce_INCLUDE_DIR`
     Location of Ice headers. This is typically ``${ICE_HOME}/include``
     or on the default include search path.  This will not normally
     require setting.
 
-:option:`Ice_SLICE_DIR`
+:option:`-DIce_SLICE_DIR`
     Location of Ice slice interface definitions. This is typically
     ``${ICE_HOME}/slice``. Use for installations where
-    :option:`ICE\_HOME` does not contain :file:`slice` or situations
-    where you wish to build without setting :option:`ICE\_HOME`. Note
+    :option:`-DICE\_HOME` does not contain :file:`slice` or situations
+    where you wish to build without setting :option:`-DICE\_HOME`. Note
     that when building using :program:`build.py`, rather than building
     directly with :program:`cmake`, the :envvar:`SLICEPATH`
     environment variable should be used instead (the :program:`ant`
     build can't use the :program:`cmake` variables since it only runs
     :program:`cmake` after a full build of the Java server).
 
-:option:`Ice_<C>_LIBRARIES`
+:option:`-DIce_<C>_LIBRARIES`
     Specific libraries for Ice component ``<C>``, where ``<C>`` is the
     uppercased name of the Ice component, e.g. ``ICE`` for the ``Ice``
     component, ``ICEUTIL`` for the ``IceUtil`` component or
@@ -303,7 +303,7 @@ running :program:`cmake`. Commonly needed options include:
     typically found in ``${ICE_HOME}/lib`` or on the default library
     search path. These will not normally require setting.
 
-:option:`Ice_DEBUG`
+:option:`-DIce_DEBUG`
     Set to ON to print detailed diagnostics about the detected Ice
     installation. Use if there are any problems finding Ice.
 

--- a/omero/developers/testing.txt
+++ b/omero/developers/testing.txt
@@ -85,7 +85,7 @@ Individual test groups
 
 To run individual OmeroJava test groups (or comma-separated sets of groups)
 of tests, the :option:`-DGROUPS` parameter can be used together with the
-:option:`test` target
+``test`` target
 
 ::
 
@@ -96,7 +96,7 @@ Individual tests
 ^^^^^^^^^^^^^^^^
 
 Alternatively, you can run individual tests which you may currently be
-working on. This can be done by using the :option:`test` option. For example:
+working on. This can be done using the ``test`` target. For example:
 
 ::
 
@@ -108,8 +108,8 @@ Individual test class methods
 
 Individual OmeroJava test class methods (or a comma-separated list of
 methods) can be run using the :option:`-DMETHODS` parameter together with
-the :option:`test` target. The test method must be provided in the fully
-qualified name form (:option:`package.class.method`).
+the ``test`` target. The test method must be provided in the fully
+qualified name form (:option:`-Dpackage.class.method`).
 
 ::
 
@@ -131,7 +131,7 @@ See :ref:`writing-python-tests` for more information on this.
 Failing tests
 ^^^^^^^^^^^^^
 
-The :option:`test.with.fail` ant property is set to ``false`` by default,
+The ``test.with.fail`` ant property is set to ``false`` by default,
 which prevents test failures from failing the build. However, it can instead
 be set to ``true`` to allow test failures to fail the build. For example:
 
@@ -140,7 +140,7 @@ be set to ``true`` to allow test failures to fail the build. For example:
     ./build.py -Dtest.with.fail=true integration
 
 Some components might provide individual targets for specific tests (e.g.
-OmeroJava provides the :option:`broken` target for running broken tests).
+OmeroJava provides the ``broken`` target for running broken tests).
 The :file:`build.xml` file is the reference in each component.
 
 Writing Java tests

--- a/omero/sysadmins/grid.txt
+++ b/omero/sysadmins/grid.txt
@@ -401,7 +401,7 @@ Ice.MessageSizeMax
 ^^^^^^^^^^^^^^^^^^
 
 Ice imposes an upper limit on all method invocations. This limit,
-:option:`Ice.MessageSizeMax`, is configured in your application descriptor
+``Ice.MessageSizeMax``, is configured in your application descriptor
 (e.g. :source:`templates.xml <etc/grid/templates.xml>`)
 and configuration files (e.g.
 :source:`ice.config <etc/ice.config>`). The setting must


### PR DESCRIPTION
The version of sphinx has been updated on jenkins, breaking the docs because we don't use `:option:` as it wants. This should make the build green again.
