### PR TITLE
Adding link to import scenarios to cli import doc

### DIFF
--- a/omero/users/command-line-import.txt
+++ b/omero/users/command-line-import.txt
@@ -76,3 +76,6 @@ arguments to the importer.
 Sample :file:`config/importer.config` INI file:
 
 .. literalinclude:: /downloads/cli/import.config
+
+.. seealso:: :doc:`/sysadmins/import-scenarios`
+


### PR DESCRIPTION
Spotted that none of the new import docs were linked from the user guide for the command line import - this overview seemed better than throwing folks straight into 'in-place' import info.
