### PR TITLE
changing help link for editor

### DIFF
--- a/omero/users/clients-overview.txt
+++ b/omero/users/clients-overview.txt
@@ -115,7 +115,7 @@ OMERO.editor
 ------------
 
 .. note:: OMERO.editor is no longer actively developed but is still shipped
-    with OMERO releases.
+    with OMERO releases prior to 5.1.
 
 OMERO.editor is an editing tool designed to facilitate recording of
 experimental metadata, for annotation of images in OMERO, where users can


### PR DESCRIPTION
The stand-alone help guide for OMERO.editor has now been removed and is only present in the pdf guide bundles. This PR updates the link in the 5.0.x docs and makes the deprecation note more obvious.

--no-rebase
