### PR TITLE
Add more detail on pytest markers

### DIFF
--- a/omero/developers/testing.txt
+++ b/omero/developers/testing.txt
@@ -430,10 +430,10 @@ to rebuild or restart the server. A few basic options are shown below.
 
 To make use of the more advanced options available in `pytest` that are not
 accessible using :program:`setup.py test`, the :program:`py.test` script can
-be used directly. To use this `PYTHONPATH` must contain the path to the OMERO
-Python libraries, see :doc:`/developers/Python`. Alternatively, the `pytest`
-plugin `pytest-pythonpath <http://pypi.python.org/pypi/pytest-pythonpath/>`_
-can be used to add paths to `PYTHONPATH` specifically for `pytest`.
+be used directly. To use this :envvar:`PYTHONPATH` must contain the path to
+the OMERO Python libraries, see |BlitzGateway|. Alternatively, the `pytest`
+plugin `pytest-pythonpath <http://pypi.python.org/pypi/pytest-pythonpath/>`__
+can be used to add paths to :envvar:`PYTHONPATH` specifically for `pytest`.
 
 .. program:: py.test
 


### PR DESCRIPTION
Tis PR adds a section to the developer testing docs on `pytest` markers. This supports the work in https://github.com/openmicroscopy/openmicroscopy/pull/3214
