### PR TITLE
adding logout to the filter

### DIFF
--- a/omero/developers/Web/PublicData.txt
+++ b/omero/developers/Web/PublicData.txt
@@ -40,12 +40,13 @@ Here is how to go about setting this up on your OMERO.web install:
 
         $ bin/omero config set omero.web.public.url_filter '/my_web_public'
 
-    To enable public access to view images in a public group in the webclient
-    while still preventing data manipulation, use the following command:
+    To enable public access to view images in a public group in the webclient,
+    while still being able to access the login page and preventing data
+    manipulation, use the following command:
 
     ::
 
-        $ bin/omero config set omero.web.public.url_filter '^/(?!webadmin|webclient/action/\w+|webclient/annotate_(file|tags|comment))'
+        $ bin/omero config set omero.web.public.url_filter '^/(?!webadmin|webclient/logout/|webclient/action/\w+|webclient/annotate_(file|tags|comment))'
 
     If you simply want to enable the image viewer, making sure all data stays
     secure you would use:


### PR DESCRIPTION
as indicated in http://lists.openmicroscopy.org.uk/pipermail/ome-users/2014-November/004914.html

To test. Setup public user with a following filter

```
$ bin/omero config set omero.web.public.url_filter '^/(?!webadmin|webclient/logout/|webclient/action/\w+|webclient/annotate_(file|tags|comment))'
```
1. Go to http://host/webclient. There will be no login page. You will be redirected directly to the public user data.
2. Click logout, you should be redirected to login page.
3. Log in as regular user. You should see own data.
4. Log out again. You should be redirect to public user data.
