### PR TITLE
Removing IDelete api link as service deleted

### DIFF
--- a/omero/developers/Modules/Api.txt
+++ b/omero/developers/Modules/Api.txt
@@ -47,9 +47,6 @@ Service Level 1 (direct database and Hibernate connections)
 -  ContainerService:
    :javadoc:`API <slice2html/omero/api/IContainer.html>`
    for loading Project, Dataset and Image hierarchies.
--  DeleteService:
-   :javadoc:`API <slice2html/omero/api/IDelete.html>`
-   for deleting objects asynchronously (delete queue).
 -  LdapService:
    :source:`src <components/common/src/ome/api/ILdap.java>`,
    :javadoc:`API <slice2html/omero/api/ILdap.html>`


### PR DESCRIPTION
This is showing up as a broken link in the release docs build for m2 because IDelete was removed on https://github.com/openmicroscopy/openmicroscopy/pull/3142
I don't know if there should be a replacement here @jburel ?

--no-rebase
