### PR TITLE
Update CreateApp docs

### DIFF
--- a/omero/developers/Web/CreateApp.txt
+++ b/omero/developers/Web/CreateApp.txt
@@ -55,7 +55,7 @@ describe how to create a stand-alone git repository for your app, similar to
 If you do not want to use GitHub, simply ignore the GitHub steps below.
 
 The steps below describe setting up a new app. You should choose an
-appropriate name for your app and use it in place of <YOUR-APP> or <your-app> in the
+appropriate name for your app and use it in place of <your-app> in the
 examples below:
 
 
@@ -68,9 +68,9 @@ I usually create a new container for a new app, and add it to my
 
 ::
 
-    $ mkdir YOUR-APP
-    $ cd YOUR-APP
-    $ export PYTHONPATH=$PYTHONPATH:/path/to/YOUR-APP
+    $ mkdir PARENT-APP-DIR
+    $ cd PARENT-APP-DIR
+    $ export PYTHONPATH=$PYTHONPATH:/path/to/PARENT-APP-DIR
 
 
 OR you could simply choose an existing location:

--- a/omero/developers/Web/CreateApp.txt
+++ b/omero/developers/Web/CreateApp.txt
@@ -55,8 +55,30 @@ describe how to create a stand-alone git repository for your app, similar to
 If you do not want to use GitHub, simply ignore the GitHub steps below.
 
 The steps below describe setting up a new app. You should choose an
-appropriate name for your app and use it in place of <your-app> in the
+appropriate name for your app and use it in place of <YOUR-APP> or <your-app> in the
 examples below:
+
+
+Add your app to your PYTHONPATH
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Your app needs to be within a directory that is on your :envvar:`PYTHONPATH`.
+I usually create a new container for a new app, and add it to my
+:envvar:`PYTHONPATH`.
+
+::
+
+    $ mkdir YOUR-APP
+    $ cd YOUR-APP
+    $ export PYTHONPATH=$PYTHONPATH:/path/to/YOUR-APP
+
+
+OR you could simply choose an existing location:
+
+::
+
+    $ cd /somewhere/on/your/pythonpath/
+
 
 Create and checkout a new GitHub repository OR manually create a new directory
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -80,15 +102,9 @@ Create and checkout a new GitHub repository OR manually create a new directory
 
         $ mkdir <your-app>
 
-Add your app location to your PYTHONPATH
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-  In either case, you should now have a directory called ``your-app`` within
+   a directory that is on your :envvar:`PYTHONPATH`.
 
-If your app is not in a directory that is already on your :envvar:`PYTHONPATH`
-then you need to add it:
-
-::
-
-    $ export PYTHONPATH=$PYTHONPATH:/path/to/your-app
 
 Add the essential files to your app
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -99,8 +115,8 @@ Add the essential files to your app
 
    ::
 
-       from django.conf.urls.defaults import *
-       from omeroweb.<your-app> import views
+       from django.conf.urls import *
+       from <your-app> import views
 
        urlpatterns = patterns('django.views.generic.simple',
 
@@ -127,16 +143,15 @@ Add your app to OMERO.web
 This will add your app to the INSTALLED\_APPS, so that URLs are
 registered etc.
 
-::
-
-    $ bin/omero config set omero.web.apps '["<your-app>"]'
-
 .. note::
 
-    You also need to edit omeroweb/urls.py to add your app's urls.py file to
-    the list of "urlpatterns". Again, you should be able to follow the
-    existing examples there. You can also specify at this point the URL under
-    which your app will be found.
+    Here we use single quotes around double quotes, since we are
+    passing a double-quoted string as a json object.
+
+::
+
+    $ bin/omero config append omero.web.apps '"<your-app>"'
+
 
 Now you can view the home-page we created above (NB: you will need to
 restart the OMERO.web server for the config settings to take effect)

--- a/omero/developers/Web/CreateApp.txt
+++ b/omero/developers/Web/CreateApp.txt
@@ -60,7 +60,7 @@ examples below:
 
 
 Add your app to your PYTHONPATH
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Your app needs to be within a directory that is on your :envvar:`PYTHONPATH`.
 I usually create a new container for a new app, and add it to my


### PR DESCRIPTION
Updates the web CreateApp page to address a couple of small issues:
 - previous instructions specified that the app directory itself was on the ```PYTHONPATH``` whereas it should be the parent directory that is on the ```PYTHONPATH```.
 - import statements in the urls.py example don't work with 5.0 OMERO

To test, follow the CreateApp instructions until you have the "Welcome" message at a new app /index.html.
