### PR TITLE
Webtest removal develop

### DIFF
--- a/omero/developers/Web.txt
+++ b/omero/developers/Web.txt
@@ -43,7 +43,7 @@ Web apps
 ^^^^^^^^
 
 The OMERO.web framework consists of several Django apps denoted by
-folders named 'web....'. These include webgateway and webtest, as
+folders named 'web....'. These include webgateway, as
 discussed above, as well as released tools (webadmin, webclient) and
 other apps in development:
 
@@ -59,9 +59,10 @@ other apps in development:
         A web services interface, providing rendered images and
         data. See :doc:`/developers/Web/WebGateway`.
 
-    webtest
-        A sample app for testing, that can also be used as a basis
-        for creating your own app.
+Additional apps can be easily added to your OMERO.web deployment.
+One example is the `webtest app <https://github.com/openmicroscopy/webtest/>`_
+that contains several code samples mentioned in the following pages.
+You will find install instructions on the webtest app page itself.
 
 Getting started
 ---------------
@@ -83,7 +84,7 @@ Quick example - webtest
 
 This tiny example gives you a feel for how the OMERO.web framework gets data
 from OMERO and displays it on a web page. You can find this and other examples
-in the 'webtest' app.
+in the `webtest <https://github.com/openmicroscopy/webtest/>`_ app.
 
 There are 3 parts to each page: url, view and template. For example, this code
 below is for generating an HTML page of a Dataset (see screen-shot). If you

--- a/omero/developers/Web/CreateApp.txt
+++ b/omero/developers/Web/CreateApp.txt
@@ -176,7 +176,9 @@ under /omeroweb/<your-app>/templates/<your-app>/
 .. note::
 
    note that /<your-app>/ appears twice in that path (need an extra folder
-   under templates). This example can be found in webtest.
+   under templates).
+
+The following example can be found in the `webtest <https://github.com/openmicroscopy/webtest/>`_ app.
 
 -  **urls.py**
 

--- a/omero/developers/Web/WebclientPlugin.txt
+++ b/omero/developers/Web/WebclientPlugin.txt
@@ -4,7 +4,7 @@ Webclient Plugins
 The webclient UI can be configured to include content from other web apps.
 This allows you to extend the webclient UI with your own functionality.
 This is used by the :partner_plone:`webtagging app <omero.webtagging>`
-and there are also some examples in the webtest app.
+and there are also some examples in the `webtest <https://github.com/openmicroscopy/webtest/>`_ app.
 
 
 Currently you can add content in the following locations:
@@ -158,8 +158,8 @@ plugin element. Plugin lists are:
 
 - :property:`omero.web.ui.right_plugins`
 
-The OMERO.webclient does not include any center plugins by default, so if you
-only want to add a single plugin to the center, you can simply do:
+Use the OMERO command line interface to add the plugin to the appropriate
+list.
 
 ::
 

--- a/omero/developers/Web/WritingTemplates.txt
+++ b/omero/developers/Web/WritingTemplates.txt
@@ -152,8 +152,9 @@ Here is a full list of the templates under
 Webtest examples
 ^^^^^^^^^^^^^^^^
 
-You can find examples of how to extend the base templates in the webtest
-application. Look under ``omeroweb/webtest/templates/webtest/webgateway``.
+You can find examples of how to extend the base templates in the 
+`webtest <https://github.com/openmicroscopy/webtest/>`_
+application. Look under ``webtest/templates/webtest/webgateway``.
 View live at <your-server-name>/webtest/webgateway_templates/base_header/>
 
 The link is to an example that extends base\_header.html and

--- a/omero/developers/Web/WritingTemplates.txt
+++ b/omero/developers/Web/WritingTemplates.txt
@@ -154,8 +154,9 @@ Webtest examples
 
 You can find examples of how to extend the base templates in the 
 `webtest <https://github.com/openmicroscopy/webtest/>`_
-application. Look under ``webtest/templates/webtest/webgateway``.
-View live at <your-server-name>/webtest/webgateway_templates/base_header/>
+application within the ``webtest/templates/webtest/webgateway`` directory.
+If you install the webtest app, you can view the template examples
+live at <your-server-name>/webtest/webgateway_templates/base_header/>
 
 The link is to an example that extends base\_header.html and
 contains links to all the other webtest examples. These pages indicate

--- a/omero/developers/Web/WritingViews.txt
+++ b/omero/developers/Web/WritingViews.txt
@@ -36,7 +36,7 @@ connection to OMERO.
 
         @login_required()     NOT  @login_required    # this will give you strange error messages
 
-A simple example of @login\_required() usage (in webtest/views.py). Note
+A simple example of @login\_required() usage (in `webtest/views.py <https://github.com/openmicroscopy/webtest/blob/master/views.py>`_). Note
 the Blitz Gateway connection "conn" retrieved by @login\_required() is
 passed to the function via the optional parameter ``conn=None``.
 


### PR DESCRIPTION
This is the same as #1054 rebased onto develop.

This updates various mentions of webtest in the docs, to point at the new webtest app https://github.com/openmicroscopy/webtest/

Also updates omero.web.config to use append (wasn't supported when these docs were written).

--rebased-from #1054
