### PR TITLE
Fixing Django doc links (rebased onto dev_5_0)

### DIFF
--- a/common/conf.py
+++ b/common/conf.py
@@ -174,6 +174,7 @@ extlinks = {
     'snapshot' : (cvs_root + '/snapshots/%s', ''),
     'zeroc' : ('http://zeroc.com/%s', ''),
     'zerocdoc' : ('http://doc.zeroc.com/%s', ''),
+    'djangodoc' : ('https://docs.djangoproject.com/en/1.6/%s', ''),
     'doi' : ('http://dx.doi.org/%s', ''),
     }
 

--- a/omero/developers/Web/CSRF.txt
+++ b/omero/developers/Web/CSRF.txt
@@ -8,7 +8,7 @@ application in which they are currently authenticated. For more details see
 
 OMERO.web provides easy-to-use protection against Cross Site Request
 Forgeries, for more information see
-`Django documentation <https://docs.djangoproject.com/en/1.6/ref/contrib/csrf/>`_.
+:djangodoc:`Django documentation <ref/contrib/csrf/>`.
 
 The first defense against CSRF attacks is to ensure that GET requests
 (and other ‘safe’ methods, as defined by 9.1.1 Safe Methods, HTTP 1.1,
@@ -45,12 +45,12 @@ POST, PUT and DELETE. These requests can then be protected as follows:
     <script type="text/javascript" src="{% static "webgateway/js/ome.csrf.js" %}"></script>
 
   For more details see
-  `CSRF for ajax <https://docs.djangoproject.com/en/1.6/ref/contrib/csrf/#ajax>`_.
+  :djangodoc:`CSRF for ajax <ref/contrib/csrf/#ajax>`.
 
 
 The Django framework also offers decorator methods that can help you protect your
 view methods and restrict access to views based on the request method.
-For more details see `Django decorators <https://docs.djangoproject.com/en/1.6/topics/http/decorators/>`_.
+For more details see :djangodoc:`Django decorators <topics/http/decorators/>`.
 
 
 By default OMERO.web provides a built-in view that handles all unsafe incoming

--- a/omero/developers/Web/CreateApp.txt
+++ b/omero/developers/Web/CreateApp.txt
@@ -1,7 +1,7 @@
 Creating an app
 ===============
 
-The Django web site has a very good :djangodoc:`tutorial </intro/tutorial01/>`
+The Django web site has a very good :djangodoc:`tutorial <intro/tutorial01/>`
 to get you familiar with the Django framework. The more you know about
 Django, the easier you will find it working with the OmeroWeb framework.
 One major feature of Django that we do not use in OmeroWeb is the Django
@@ -11,7 +11,7 @@ are empty.
 
 .. note:: Since OMERO 5.0, the web framework uses Django 1.6 instead of Django
     1.3. One important change is the syntax of the
-    :djangodoc:`url template tag </ref/templates/builtins/#std:templatetag-url>`,
+    :djangodoc:`url template tag <ref/templates/builtins/#std:templatetag-url>`,
     which now requires quotes, and will need to be updated for OMERO 4.4 web
     apps moving to OMERO 5.0.
 

--- a/omero/developers/Web/CreateApp.txt
+++ b/omero/developers/Web/CreateApp.txt
@@ -1,9 +1,8 @@
 Creating an app
 ===============
 
-The Django web site has a very good
-`tutorial <https://docs.djangoproject.com/en/dev/intro/tutorial01/>`_ to
-get you familiar with the Django framework. The more you know about
+The Django web site has a very good :djangodoc:`tutorial </intro/tutorial01/>`
+to get you familiar with the Django framework. The more you know about
 Django, the easier you will find it working with the OmeroWeb framework.
 One major feature of Django that we do not use in OmeroWeb is the Django
 database mapping, since all data comes from the OMERO server and is
@@ -12,7 +11,7 @@ are empty.
 
 .. note:: Since OMERO 5.0, the web framework uses Django 1.6 instead of Django
     1.3. One important change is the syntax of the
-    `url template tag <https://docs.djangoproject.com/en/dev/ref/templates/builtins/#std:templatetag-url>`_,
+    :djangodoc:`url template tag </ref/templates/builtins/#std:templatetag-url>`,
     which now requires quotes, and will need to be updated for OMERO 4.4 web
     apps moving to OMERO 5.0.
 

--- a/omero/developers/Web/WritingTemplates.txt
+++ b/omero/developers/Web/WritingTemplates.txt
@@ -26,7 +26,7 @@ Django templates
 
 We use Django templates for the OMERO.web pages. See docs here:
 https://docs.djangoproject.com/en/dev/ref/templates/ and `template
-inheritance <https://docs.djangoproject.com/en/dev/topics/templates/#template-inheritance>`_.
+inheritance <https://docs.djangoproject.com/en/dev/ref/templates/language/#template-inheritance>`_.
 We have designed a number of OMERO.web base templates that you can
 extend. The base templates live in the 'webgateway' app under
 omeroweb/webgateway/templates/webgateway/base. You can use these to make pages

--- a/omero/developers/Web/WritingTemplates.txt
+++ b/omero/developers/Web/WritingTemplates.txt
@@ -25,8 +25,8 @@ Django templates
 ----------------
 
 We use Django templates for the OMERO.web pages. See docs here:
-https://docs.djangoproject.com/en/dev/ref/templates/ and `template
-inheritance <https://docs.djangoproject.com/en/dev/ref/templates/language/#template-inheritance>`_.
+:djangodoc:`templates </ref/templates/>` and
+:djangodoc:`template inheritance </topics/templates/#template-inheritance>`.
 We have designed a number of OMERO.web base templates that you can
 extend. The base templates live in the 'webgateway' app under
 omeroweb/webgateway/templates/webgateway/base. You can use these to make pages

--- a/omero/developers/Web/WritingTemplates.txt
+++ b/omero/developers/Web/WritingTemplates.txt
@@ -25,8 +25,8 @@ Django templates
 ----------------
 
 We use Django templates for the OMERO.web pages. See docs here:
-:djangodoc:`templates </ref/templates/>` and
-:djangodoc:`template inheritance </topics/templates/#template-inheritance>`.
+:djangodoc:`templates <ref/templates/>` and
+:djangodoc:`template inheritance <topics/templates/#template-inheritance>`.
 We have designed a number of OMERO.web base templates that you can
 extend. The base templates live in the 'webgateway' app under
 omeroweb/webgateway/templates/webgateway/base. You can use these to make pages

--- a/omero/sysadmins/unix/install-web.txt
+++ b/omero/sysadmins/unix/install-web.txt
@@ -488,9 +488,9 @@ Customizing your OMERO.web installation
 -  Session cookies:
 
    -  A boolean that determines whether to expire the session when the user
-      closes their browser. See `Django Browser-length sessions vs. persistent
-      sessions documentation 
-      <https://docs.djangoproject.com/en/1.6/topics/http/sessions/#browser-length-vs-persistent-sessions>`_
+      closes their browser.
+      See :djangodoc:`Django Browser-length sessions vs. persistent
+      sessions documentation topics/http/sessions/#browser-length-vs-persistent-sessions>`
       for more details. Default: ``True``.
 
       ::
@@ -509,7 +509,7 @@ Customizing your OMERO.web installation
       store. Stale sessions can cause the store to grow with time. OMERO.web 
       uses by default the OS file system as the session store backend and 
       does not automatically purge stale sessions, see 
-      `Django file-based session documentation <https://docs.djangoproject.com/en/1.6/topics/http/sessions/#using-file-based-sessions>`_
+      :djangodoc:`Django file-based session documentation <topics/http/sessions/#using-file-based-sessions>`
       for more details. It is therefore the responsibility of the OMERO 
       administrator to purge the session cache using the provided management 
       command:
@@ -519,14 +519,14 @@ Customizing your OMERO.web installation
           $ bin/omero web clearsessions
 
       It is recommended to call this command on a regular basis, for example 
-      as a daily cron job, see 
-      `Django clearing the session store documentation  <https://docs.djangoproject.com/en/1.6/topics/http/sessions/#clearing-the-session-store>`_
+      as a daily cron job, see
+      :djangodoc:`Django clearing the session store documentation  <topics/http/sessions/#clearing-the-session-store>`
       for more information.
 
       .. note::
           OMERO.web offers alternative session backends to automatically 
           delete stale data using the cache session store backend, see
-          `Django cached session documentation <https://docs.djangoproject.com/en/1.6/topics/http/sessions/#using-cached-sessions>`_
+          :djangodoc:`Django cached session documentation <topics/http/sessions/#using-cached-sessions>`
           for more details. After installing all the cache prerequisites set the following:
 
           ::

--- a/omero/sysadmins/unix/install-web.txt
+++ b/omero/sysadmins/unix/install-web.txt
@@ -490,7 +490,7 @@ Customizing your OMERO.web installation
    -  A boolean that determines whether to expire the session when the user
       closes their browser.
       See :djangodoc:`Django Browser-length sessions vs. persistent
-      sessions documentation topics/http/sessions/#browser-length-vs-persistent-sessions>`
+      sessions documentation <topics/http/sessions/#browser-length-vs-persistent-sessions>`
       for more details. Default: ``True``.
 
       ::
@@ -520,7 +520,7 @@ Customizing your OMERO.web installation
 
       It is recommended to call this command on a regular basis, for example 
       as a daily cron job, see
-      :djangodoc:`Django clearing the session store documentation  <topics/http/sessions/#clearing-the-session-store>`
+      :djangodoc:`Django clearing the session store documentation <topics/http/sessions/#clearing-the-session-store>`
       for more information.
 
       .. note::

--- a/omero/sysadmins/windows/install-web.txt
+++ b/omero/sysadmins/windows/install-web.txt
@@ -440,8 +440,8 @@ Customizing your OMERO.web installation
           C:\omero_dist>bin\omero web clearsessions
 
       It is recommended to call this command on a regular basis, for example
-      as a Task Scheduler, see 
-      :djangodoc:`Django clearing the session store documentation  <topics/http/sessions/#clearing-the-session-store>`
+      as a Task Scheduler, see
+      :djangodoc:`Django clearing the session store documentation <topics/http/sessions/#clearing-the-session-store>`
       for more information.
 
       .. note::

--- a/omero/sysadmins/windows/install-web.txt
+++ b/omero/sysadmins/windows/install-web.txt
@@ -149,8 +149,8 @@ working with your IIS deployment.
            C:\omero_dist>bin\omero config set omero.web.session_engine
            C:\omero_dist>bin\omero config set omero.web.cache_backend
 
-       If your deployment requires additional cache store please follow 
-       `Django documentation <https://docs.djangoproject.com/en/1.6/topics/cache/>`_
+       If your deployment requires additional cache store please follow
+       :djangodoc:`Django documentation <topics/cache/>`
        for more details.
 
 -  OMERO.web is configured to use FastCGI TCP by default. If you are using a
@@ -410,9 +410,8 @@ Customizing your OMERO.web installation
 -  Session cookies:
 
    -  A boolean that determines whether to expire the session when the user
-      closes their browser. See `Django Browser-length sessions vs. persistent
-      sessions documentation 
-      <https://docs.djangoproject.com/en/1.6/topics/http/sessions/#browser-length-vs-persistent-sessions>`_
+      closes their browser. See :djangodoc:`Django Browser-length sessions vs.
+      persistent sessions documentation  <topics/http/sessions/#browser-length-vs-persistent-sessions>`
       for more details. Default: ``True``.
 
       ::
@@ -427,13 +426,13 @@ Customizing your OMERO.web installation
 
 -  Session engine:
 
-   -  Each session for a logged-in user in OMERO.web is kept in the session
-      store. Stale sessions can cause the store to grow with time. OMERO.web
-      uses by default the OS file system as the session store backend and
+   -  Each session for a logged-in user in OMERO.web is kept in the session 
+      store. Stale sessions can cause the store to grow with time. OMERO.web 
+      uses by default the OS file system as the session store backend and 
       does not automatically purge stale sessions, see
-      `Django file-based session documentation <https://docs.djangoproject.com/en/1.6/topics/http/sessions/#using-file-based-sessions>`_
-      for more details. It is therefore the responsibility of the OMERO
-      administrator to purge the session cache using the provided management
+      :djangodoc:`Django file-based session documentation <topics/http/sessions/#using-file-based-sessions>`
+      for more details. It is therefore the responsibility of the OMERO 
+      administrator to purge the session cache using the provided management 
       command:
 
       ::
@@ -442,15 +441,14 @@ Customizing your OMERO.web installation
 
       It is recommended to call this command on a regular basis, for example
       as a Task Scheduler, see 
-      `Django clearing the session store documentation  <https://docs.djangoproject.com/en/1.6/topics/http/sessions/#clearing-the-session-store>`_
+      :djangodoc:`Django clearing the session store documentation  <topics/http/sessions/#clearing-the-session-store>`
       for more information.
 
       .. note::
           OMERO.web offers alternative session backends to automatically
           delete stale data using the cache session store backend, see
-          `Django cached session documentation <https://docs.djangoproject.com/en/1.6/topics/http/sessions/#using-cached-sessions>`_
-          for more details. After installing all the cache prerequisites set
-          the following:
+          :djangodoc:`Django cached session documentation <topics/http/sessions/#using-cached-sessions>`
+          for more details. After installing all the cache prerequisites set the following:
 
           ::
 

--- a/omero/sysadmins/windows/server-installation.txt
+++ b/omero/sysadmins/windows/server-installation.txt
@@ -719,8 +719,8 @@ then start by
         C:\omero_dist>bin\omero config set omero.web.session_engine
         C:\omero_dist>bin\omero config set omero.web.cache_backend
 
-    If your deployment requires additional cache store please follow 
-    `Django documentation <https://docs.djangoproject.com/en/1.6/topics/cache/>`_
+    If your deployment requires additional cache store please follow
+    :djangodoc:`Django documentation <topics/cache/>`
     for more details.
 
 Once you have deployed and started the server you can use your browser


### PR DESCRIPTION


This is the same as gh-1066 but rebased onto dev_5_0.

----

Existing link was making http://ci.openmicroscopy.org/view/Docs/job/OMERO-5.1-merge-docs/ yellow and when I hunted around, I found the topic was actually on a different page.

cc @aleksandra-tarkowska - if you are happy with this, I'll rebase to dev_5_0 once the build is green.

                    