### PR TITLE
adjust createdb commands to specify Unicode databases

### DIFF
--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -286,7 +286,7 @@ want to restore a database backup. To do so, create a new database,
 
 .. parsed-literal::
 
-    $ createdb -h localhost -U postgres -O **db_user** omero_from_backup
+    $ createdb -h localhost -U postgres -E UTF8 -O **db_user** omero_from_backup
 
 restore the previous archive into this new database,
 

--- a/omero/sysadmins/unix/server-install-homebrew.txt
+++ b/omero/sysadmins/unix/server-install-homebrew.txt
@@ -244,7 +244,7 @@ Start the PostgreSQL server.
 
 ::
 
-    $ initdb /usr/local/var/postgres
+    $ initdb -E UTF8 /usr/local/var/postgres
     $ brew services start postgresql
     $ pg_ctl -D /usr/local/var/postgres/ -l /usr/local/var/postgres/server.log start
 

--- a/omero/sysadmins/unix/server-install-homebrew.txt
+++ b/omero/sysadmins/unix/server-install-homebrew.txt
@@ -248,14 +248,15 @@ Start the PostgreSQL server.
     $ brew services start postgresql
     $ pg_ctl -D /usr/local/var/postgres/ -l /usr/local/var/postgres/server.log start
 
-Create a user, a database and add the PL/pgSQL language to your database.
+Create a user, a database and, if using PostgreSQL 8.4, add the PL/pgSQL
+language to your database.
 
 ::
 
     $ createuser -P -D -R -S db_user
     Enter password for new role:       # db_password
     Enter it again:       # db_password
-    $ createdb -O db_user omero_database
+    $ createdb -E UTF8 -O db_user omero_database
     $ createlang plpgsql omero_database
 
 Check to make sure the database has been created.

--- a/omero/sysadmins/unix/server-installation.txt
+++ b/omero/sysadmins/unix/server-installation.txt
@@ -533,7 +533,7 @@ For the purposes of this guide, the following dummy data is used::
 
 -  Create a database for OMERO to reside in::
 
-      $ sudo -u postgres createdb -O db_user omero_database
+      $ sudo -u postgres createdb -E UTF8 -O db_user omero_database
 
 -  Add the PL/pgSQL language to your database::
 

--- a/omero/sysadmins/unix/walkthrough/setup_postgres.sh
+++ b/omero/sysadmins/unix/walkthrough/setup_postgres.sh
@@ -2,7 +2,7 @@
 
 echo "CREATE USER $OMERO_DB_USER PASSWORD '$OMERO_DB_PASS'" | \
     su - postgres -c psql
-su - postgres -c "createdb -O '$OMERO_DB_USER' '$OMERO_DB_NAME'"
+su - postgres -c "createdb -E UTF8 -O '$OMERO_DB_USER' '$OMERO_DB_NAME'"
 
 # If you are using PostgreSQL 8.4 you must run:
 #su - postgres -c "createlang plpgsql '$OMERO_DB_NAME'"


### PR DESCRIPTION
https://trello.com/c/Fv1HZVfs/779-virt-microscope-pg-9-for-testing reveals the need for a UTF8-encoded database for OMERO since 5.1 patch 12.

PostgreSQL 8.4 references can be updated once version prerequisites suggested via http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-January/004982.html are approved, so for now they are left alone.

--no-rebase