### PR TITLE
clients to convert code using 5.0 graphs to 5.1 graphs

### DIFF
--- a/omero/developers/Modules/Delete.txt
+++ b/omero/developers/Modules/Delete.txt
@@ -25,7 +25,9 @@ functionality (see :ticket:`2615` for tickets):
 
 Future releases will continue this work (see :ticket:`2911`) and the
 5.1.0 release of OMERO offers a new implementation of deletion while
-leaving the previous available via a configuration setting.
+leaving the previous available via a property
+:property:`omero.graphs.wrap`. That property is deprecated and will be
+*removed* in OMERO 5.2.
 
 Finality of deletion
 ^^^^^^^^^^^^^^^^^^^^
@@ -47,9 +49,10 @@ Delete behavior (technical)
 Configuring what gets deleted is done using an XML file. The only
 technical specification of delete behavior for version 5.0 of OMERO is
 found in :source:`components/server/resources/ome/services/spec.xml`.
-This file remains available but, since version 5.1, the delete behavior
-defaults to a new :doc:`../Server/ObjectGraphs` implementation that is
-instead configured by
+That file remains available but is deprecated and will be *removed* in
+version 5.2. Since version 5.1, the delete behavior defaults to a new
+:doc:`../Server/ObjectGraphs` implementation that is instead configured
+by
 :source:`components/blitz/resources/ome/services/blitz-graph-rules.xml`.
 
 Delete Image

--- a/omero/developers/Server/GraphsMigration.txt
+++ b/omero/developers/Server/GraphsMigration.txt
@@ -1,0 +1,124 @@
+Using the new 5.1 graph requests
+================================
+
+Migration is required
+---------------------
+
+OMERO 5.1 introduces a new implementation of :doc:`ObjectGraphs` offered
+through the API via :javadoc:`Chgrp2
+<slice2html/omero/cmd/Chgrp2.html>`, :javadoc:`Chown2
+<slice2html/omero/cmd/Chown2.html>`, :javadoc:`Delete2
+<slice2html/omero/cmd/Delete2.html>`, and their superclass
+:javadoc:`GraphModify2 <slice2html/omero/cmd/GraphModify2.html>`. The
+legacy request operations :javadoc:`Chgrp
+<slice2html/omero/cmd/Chgrp.html>`, :javadoc:`Chown
+<slice2html/omero/cmd/Chown.html>`, :javadoc:`Delete
+<slice2html/omero/cmd/Delete.html>`, and their superclass
+:javadoc:`GraphModify <slice2html/omero/cmd/GraphModify.html>`, are now
+deprecated and will be *removed* in OMERO 5.3. *Now* is the time to
+adjust client code accordingly so that the OME team can fix any
+regressions before the release of OMERO 5.3.
+
+
+Target objects
+--------------
+
+For specifying which model objects to operate on, instead of using one
+request for each object through :javadoc:`GraphModify
+<slice2html/omero/cmd/GraphModify.html>`'s ``type`` and ``id`` data
+members, use :javadoc:`GraphModify2
+<slice2html/omero/cmd/GraphModify2.html>`'s ``targetObjects`` which
+allows specification of multiple model object classes, each with an
+unordered list of IDs, all in a single request. To specify a type, no
+longer use ``/``-delimited paths, but instead just the class name, e.g.
+``Image`` instead of ``/Image``. To achieve a root-anchored subgraph
+operation use :javadoc:`SkipHead <slice2html/omero/cmd/SkipHead.html>`
+to wrap your request: for instance, for ``/Image/Pixels/RenderingDef``,
+set the ``SkipHead`` request's ``targetObjects`` to the image(s), and
+set ``startFrom`` to ``RenderingDef``.
+
+
+Translating options
+-------------------
+
+:javadoc:`GraphModify <slice2html/omero/cmd/GraphModify.html>`'s
+``options`` data member has its related analog in :javadoc:`GraphModify2
+<slice2html/omero/cmd/GraphModify2.html>`'s ``childOptions``, an ordered
+list of :javadoc:`ChildOption
+<slice2html/omero/cmd/graphs/ChildOption.html>` instances, each of which
+allows its applicability to annotations to be limited by namespace. Some
+examples:
+
+- To move a dataset with all its images, removing those images from
+  other datasets where necessary, use ``Chgrp2`` with a
+  ``ChildOption``'s ``includeType`` set to ``Image``.
+
+- To delete a dataset without deleting any images at all from it, use
+  ``Delete2`` with a ``ChildOption``'s ``excludeType`` set to ``Image``.
+
+- To delete annotations except for the tags that are in a specific
+  namespace, use ``Delete2`` with a ``ChildOption``'s ``excludeType``
+  set to ``TagAnnotation`` and ``includeNs`` set to that namespace.
+
+:source:`GraphUtil.java
+<components/blitz/src/omero/cmd/graphs/GraphUtil.java>` includes the
+``translateOptions`` method that may give additional insight on how to
+translate the previous style of option. This method too will be removed
+in OMERO 5.3.
+
+
+Examples in Python
+------------------
+
+Move images
+^^^^^^^^^^^
+
+.. code-block:: python
+
+  chgrps = DoAll()
+  chgrps.requests = [Chgrp(type="/Image", id=n, grp=5) for n in [1,2,3]]
+  sf.submit(chgrps)
+
+becomes,
+
+.. code-block:: python
+
+  chgrp = Chgrp2(targetObjects={'Image': [1,2,3]}, groupId=5)
+  sf.submit(chgrp)
+
+
+Delete plate, but not annotations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+  keepAnn = {"/Annotation": "KEEP"}
+  delete = Delete(type="/Plate", id=8, options=keepAnn)
+  sf.submit(delete)
+
+becomes,
+
+.. code-block:: python
+
+  keepAnn = [ChildOption(excludeType=['Annotation'])]
+  delete = Delete2(targetObjects={'Plate': [8]}, childOptions=keepAnn)
+  sf.submit(delete)
+
+
+Delete an image's rendering settings
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+  delete = Delete(type="/Image/Pixels/RenderingDef", id=6)
+  sf.submit(delete)
+
+becomes,
+
+.. code-block:: python
+
+  anchor = {'Image': [6]}
+  targets = ['RenderingDef']
+  delete = SkipHead(targetObjects=anchor, startFrom=targets,
+                    request=Delete2())
+  sf.submit(delete)

--- a/omero/developers/Server/ObjectGraphs.txt
+++ b/omero/developers/Server/ObjectGraphs.txt
@@ -8,9 +8,10 @@ Model graph operations
   deleting users' rendering settings for that image, also the links to
   any datasets that the image is in. Version 5.1.0 of the OMERO server
   includes a new algorithm for determining which model objects to act
-  on. Understanding the details of the new implementation substantially
-  assists in debugging or creating server operations that act on the
-  directed graph of model objects.
+  on. Clients should be :doc:`GraphsMigration` because the previous ones
+  will be *removed* in OMERO 5.3. Understanding the details of the new
+  implementation substantially assists in debugging or creating server
+  operations that act on the directed graph of model objects.
 
 Motivation
 ----------
@@ -425,4 +426,5 @@ omero.graphs.wrap false` restores the older implementation, though the
 newer one remains available through its request object classes: for
 instance, :javadoc:`Chgrp <slice2html/omero/cmd/Chgrp.html>` would now
 use the old implementation but :javadoc:`Chgrp2
-<slice2html/omero/cmd/Chgrp2.html>` still offers the new.
+<slice2html/omero/cmd/Chgrp2.html>` still offers the new. That property
+is deprecated and will be *removed* in OMERO 5.2.

--- a/omero/developers/Server/ObjectGraphs.txt
+++ b/omero/developers/Server/ObjectGraphs.txt
@@ -8,7 +8,7 @@ Model graph operations
   deleting users' rendering settings for that image, also the links to
   any datasets that the image is in. Version 5.1.0 of the OMERO server
   includes a new algorithm for determining which model objects to act
-  on. Clients should be :doc:`GraphsMigration` because the previous ones
+  on. Clients should be :doc:`using the new 5.1 graph requests <GraphsMigration>` because the previous ones
   will be *removed* in OMERO 5.3. Understanding the details of the new
   implementation substantially assists in debugging or creating server
   operations that act on the directed graph of model objects.

--- a/omero/developers/Server/ObjectGraphs.txt
+++ b/omero/developers/Server/ObjectGraphs.txt
@@ -8,10 +8,11 @@ Model graph operations
   deleting users' rendering settings for that image, also the links to
   any datasets that the image is in. Version 5.1.0 of the OMERO server
   includes a new algorithm for determining which model objects to act
-  on. Clients should be :doc:`using the new 5.1 graph requests <GraphsMigration>` because the previous ones
-  will be *removed* in OMERO 5.3. Understanding the details of the new
-  implementation substantially assists in debugging or creating server
-  operations that act on the directed graph of model objects.
+  on. Clients should be :doc:`using the new 5.1 graph requests
+  <GraphsMigration>` because the previous ones will be *removed* in
+  OMERO 5.3. Understanding the details of the new implementation
+  substantially assists in debugging or creating server operations that
+  act on the directed graph of model objects.
 
 Motivation
 ----------

--- a/omero/developers/index.txt
+++ b/omero/developers/index.txt
@@ -157,6 +157,7 @@ of the supported languages.
     Modules/TempFileManager
     Modules/ExceptionHandling
     logging
+    Server/GraphsMigration
 
 
 ******************

--- a/omero/developers/whatsnew.txt
+++ b/omero/developers/whatsnew.txt
@@ -32,6 +32,6 @@ in OMERO 5.2 and :javadoc:`Chgrp <slice2html/omero/cmd/Chgrp.html>`,
 :javadoc:`Chown <slice2html/omero/cmd/Chown.html>`, :javadoc:`Delete
 <slice2html/omero/cmd/Delete.html>`, and :javadoc:`GraphModify
 <slice2html/omero/cmd/GraphModify.html>`, will be *removed* in OMERO
-5.3. OMERO 5.1 users should thus be :doc:`Server/GraphsMigration` so
+5.3. OMERO 5.1 users should thus be :doc:`using the new 5.1 graph requests <Server/GraphsMigration>` so
 that problems may be detected and corrected before the deprecated
 features are removed.

--- a/omero/developers/whatsnew.txt
+++ b/omero/developers/whatsnew.txt
@@ -32,6 +32,6 @@ in OMERO 5.2 and :javadoc:`Chgrp <slice2html/omero/cmd/Chgrp.html>`,
 :javadoc:`Chown <slice2html/omero/cmd/Chown.html>`, :javadoc:`Delete
 <slice2html/omero/cmd/Delete.html>`, and :javadoc:`GraphModify
 <slice2html/omero/cmd/GraphModify.html>`, will be *removed* in OMERO
-5.3. OMERO 5.1 users should thus be :doc:`using the new 5.1 graph requests <Server/GraphsMigration>` so
-that problems may be detected and corrected before the deprecated
-features are removed.
+5.3. OMERO 5.1 users should thus be :doc:`using the new 5.1 graph
+requests <Server/GraphsMigration>` so that problems may be detected and
+corrected before the deprecated features are removed.

--- a/omero/developers/whatsnew.txt
+++ b/omero/developers/whatsnew.txt
@@ -1,54 +1,37 @@
-What's new for OMERO 5
-======================
+What's new for OMERO 5.1
+========================
 
-OMERO 5.0 introduces the OMERO.fs (file system) changes needed to stop data
-duplication on import. Files are now imported and stored in their original
-format, preserving file names and directory structures, and reducing storage
-requirements. These changes, coupled with updates to :bf_doc:`Bio-Formats <>`
-and the clients, improve the way OMERO handles complex multidimensional
-datasets.
+OMERO 5.1 introduces units and some other stuff that others **will**
+write about.
 
-- :doc:`logging` and :doc:`Server/Properties` have been updated to explain the
-  new logging configuration in OMERO.fs.
-
-- :doc:`Modules/Delete` has been updated to explain how OMERO 5 handles
-  deleting multi-file images and image sets and to clarify the finality of
-  deletion.
-
-- :doc:`Server/FS` has been updated to give an overview of the OMERO.fs
-  project, and further details of the
-  :doc:`ManagedRepository/ManagedRepository` are being added.
-
-- :doc:`OMERO.web <Web>` has been upgraded to Django 1.6, requiring Python
-  2.6.5 or later. This enables more flexibility for developing new web
-  apps and plugins. All the :doc:`OMERO.web documentation <index>` has been
-  updated to reflect these changes.
-
-- :doc:`scripts/index` and :doc:`scripts/matlab-scripts` have been updated to 
-  reflect that MATLAB and Jython scripts are now supported natively.
-
-- Guidance for getting more involved with OME, and contributing to both OMERO
-  and Bio-Formats, has been moved to our new
-  :devs_doc:`Contributing Developer Documentation <>` section so it is easier
-  to find. It has also been updated to better explain our development
-  processes.
-
-- :doc:`Python` describes additions to the BlitzGateway API to support Filesets.
+- :doc:`Server/ObjectGraphs` explains how the new graph operations of
+  :javadoc:`omero::cmd <slice2html/omero/cmd.html>` are implemented.
 
 
 Breaking changes
 ----------------
 
-Breaking changes to the OMERO model and API were intentionally kept to
-a minimum. New methods and fields were added which you may want to make
-use of in your clients. There was, however, one breaking change.
-
-The definition of one of the `OriginalFile` model object properties has
-changed: `sha1` which used to contain the SHA1 hash (or checksum) of the file
-is now two properties: `hash` for the hash of the file, and `hasher`, an
-enumeration of type `omero.model.ChecksumAlgorithm` that describes which
-algorithm was used, for instance `SHA1-160`. When `RawFileStore.save()` is
-called on a file with `hasher` set, it will set the file's `hash` property to
-the correct value.
-
-See the :ref:`FS documentation <fs_checksums>` for more information.
+The API's request operations :javadoc:`Chgrp
+<slice2html/omero/cmd/Chgrp.html>`, :javadoc:`Chown
+<slice2html/omero/cmd/Chown.html>`, :javadoc:`Delete
+<slice2html/omero/cmd/Delete.html>`, and their superclass
+:javadoc:`GraphModify <slice2html/omero/cmd/GraphModify.html>`, are now
+deprecated. They are replaced by :javadoc:`Chgrp2
+<slice2html/omero/cmd/Chgrp2.html>`, :javadoc:`Chown2
+<slice2html/omero/cmd/Chown2.html>`, :javadoc:`Delete2
+<slice2html/omero/cmd/Delete2.html>`, and their superclass
+:javadoc:`GraphModify2 <slice2html/omero/cmd/GraphModify2.html>`. To
+allow each deprecated request to be implemented by its corresponding
+replacement, a partial API compatibility layer is included in OMERO 5.1
+and is activated by default through the new configuration property
+:property:`omero.graphs.wrap`. If the new request implementations
+introduce regressions, setting that property to ``false`` will
+reactivate the implementations from OMERO 5.0. However, the
+configuration property :property:`omero.graphs.wrap` will be *removed*
+in OMERO 5.2 and :javadoc:`Chgrp <slice2html/omero/cmd/Chgrp.html>`,
+:javadoc:`Chown <slice2html/omero/cmd/Chown.html>`, :javadoc:`Delete
+<slice2html/omero/cmd/Delete.html>`, and :javadoc:`GraphModify
+<slice2html/omero/cmd/GraphModify.html>`, will be *removed* in OMERO
+5.3. OMERO 5.1 users should thus be :doc:`Server/GraphsMigration` so
+that problems may be detected and corrected before the deprecated
+features are removed.

--- a/omero/sysadmins/whatsnew.txt
+++ b/omero/sysadmins/whatsnew.txt
@@ -1,42 +1,17 @@
-What's new for OMERO 5
-======================
+What's new for OMERO 5.1
+========================
 
-From a sysadmin's point of view, the introduction of OMERO.fs as part of
-version 5.0 means that files are now stored on the server in their original
-format, preserving file names and directory structures. Therefore, the import
-process does not duplicate pixel data and storage requirements are roughly
-halved in comparison with a 4.4 import including archiving the original files.
-Combined with the new file integrity report, you should be confident that once
-a successful import has taken place, storing the original files outside of
-OMERO is no longer necessary as your users can always download their data in
-its original format if they need to.
+From a sysadmin's point of view, here is some introductory / overview
+text.
 
-- :doc:`server-upgrade` has been updated to explain the server upgrade
-  process from 4.4.x to OMERO 5, and also to describe the introduction of
-  password salting support.
+- :doc:`server-upgrade` has **not yet** been updated to explain the
+  server upgrade process from OMERO 5.0 to OMERO 5.1.
 
-- :doc:`fs-upload-configuration` has been added to explain the server-side FS
-  workflow for importing files.
+- :doc:`system-requirements` has been updated to reflect **various
+  things yet to be finalized**.
 
-- :doc:`dropbox` has been reworked to clarify the distinction between OMERO.fs
-  and OMERO.dropbox.
-
-- :doc:`system-requirements` has been updated to reflect that running
-  OMERO.web on your server now requires Python 2.6.5 or later.
-
-- :doc:`troubleshooting` has been updated to guide you through what to do if
-  you are getting search errors, and how to adjust the :doc:`config` to take
-  advantage of improvements to the server indexing system for 5.0.0.
-
-- :doc:`server-performance` provides further tips for tuning your installation,
-  though now with the :ref:`automatic memory settings <jvm_memory_settings>`,
-  this may be less necessary.
-
-- :doc:`import-scenarios` and :doc:`in-place-import` documentation has been
-  added to explain the new ways of importing data enabled by the change in
-  server-side workflow.
-
-- :doc:`server-webstart-codesigning` has been added to explain
-  the requirement for code-signing the webstart version of OMERO.insight.
-  Official releases of OMERO.server are code-signed, instructions for using
-  OMERO.insight webstart with a custom build are included.
+- A new configuration property :property:`omero.graphs.wrap` allows
+  switching back to the old server code for moving and deleting data. If
+  a regression with the new code requires changing this setting, ensure
+  that a bug is filed with the OME team so it can be fixed before this
+  configuration property is *removed* in OMERO 5.2.

--- a/omero/users/whatsnew.txt
+++ b/omero/users/whatsnew.txt
@@ -1,27 +1,12 @@
-What's new for OMERO 5
-======================
+What's new for OMERO 5.1
+========================
 
-From a user's perspective, OMERO 5 mostly alters the way import looks in
-OMERO.insight. Your files are now uploaded on to the OMERO.server in their
-original format which means you can always export them in this format. We have
-also introduced checksums to confirm if your file has been correctly uploaded
-so that you can have confidence that no corruption has occurred on import and
-your files are safely stored. In combination, these changes mean that you no
-longer need to store duplicates of your data outside of OMERO, for example if
-you require the original format for some of your data analysis.
+From a user's perspective, OMERO 5.1 introduces units and some other
+stuff that others **will** write about.
 
-- :help:`Importing data guide <importing-data-5.html>` has been updated to
-  illustrate the new workflow.
+- Moving and deleting data is now faster.
 
-- :doc:`command-line-import` has also been updated to reflect the new 
-  functionality.
+- There is **going to be** a new :help:`Getting Started guide
+  <getting-started-5.html>` for OMERO 5.1.
 
-- There is a new :help:`Getting Started guide <getting-started-5.html>`
-  for OMERO 5.0.
-
-- :doc:`command-line-interface` has been updated to document a new plugin
-  which allows you to list, create, and import tags and tag sets from the
-  command line.
-
-.. note:: :doc:`demo-server` **is now available for OMERO 5.**
-
+.. note:: :doc:`demo-server` **is now available for OMERO 5.1.**


### PR DESCRIPTION
The 5.0 graphs API is deprecated. This documentation tells users to migrate to the 5.1 API and gives some information about how.

As 5.2 and 5.3 are released, 5.0 graphs information can be removed from documentation: for graphs, 5.1 and 5.2 are transitional.

Mostly staged at http://www.openmicroscopy.org/site/support/omero5.1-staging/developers/whatsnew.html and http://www.openmicroscopy.org/site/support/omero5.1-staging/developers/Server/GraphsMigration.html.

--no-rebase