### PR TITLE
fix URL for Lucene Index Toolbox (rebased from develop)

### DIFF
--- a/omero/developers/Modules/Search.txt
+++ b/omero/developers/Modules/Search.txt
@@ -253,5 +253,5 @@ it is possible to extract more information specific to your site.
     :doc:`/developers/Search/FileParsers`,
     `Query Parser Syntax <http://lucene.apache.org/core/3_6_0/queryparsersyntax.html>`_,
 
-    ` Luke <http://www.getopt.org/luke/>`_
+    ` Luke <https://code.google.com/p/luke/>`_
         a Java application which you can download and point at your ``/OMERO/FullText`` directory to get a better feeling for Lucene queries.


### PR DESCRIPTION
The URL for Luke has moved.

Staged at https://www.openmicroscopy.org/site/support/omero5-staging/developers/Modules/Search.html.

--rebased-from #1077