### PR TITLE
SELinux walkthrough fixes

### DIFF
--- a/omero/sysadmins/unix/server-linux-walkthrough.txt
+++ b/omero/sysadmins/unix/server-linux-walkthrough.txt
@@ -98,3 +98,16 @@ start OMERO and OMERO.web automatically:
   <walkthrough/setup_omero_daemon_centos6.sh>`
 | :download:`omero-init.d <walkthrough/omero-init.d>`
 | :download:`omero-web-init.d <walkthrough/omero-web-init.d>`
+
+
+SELinux
+-------
+
+If you are running a system with SELinux enabled (for example, it is
+`enabled by default on CentOS6 <http://wiki.centos.org/HowTos/SELinux>`_)
+and are unable to access OMERO.web via Nginx you may need to adjust the
+security policy:
+
+.. literalinclude:: walkthrough/setup_nginx_centos6_selinux.sh
+
+| :download:`setup_nginx_centos6_selinux.sh <walkthrough/setup_nginx_centos6_selinux.sh>`

--- a/omero/sysadmins/unix/walkthrough/install-centos6.sh
+++ b/omero/sysadmins/unix/walkthrough/install-centos6.sh
@@ -13,6 +13,7 @@ cp settings.env setup_omero_ice35.sh ~omero
 su - omero -c "bash -eux setup_omero_ice35.sh"
 
 bash -eux setup_nginx_centos6.sh
+bash -eux setup_nginx_centos6_selinux.sh
 
 #If you don't want to use the init.d scripts you can start OMERO manually:
 #su - omero -c "OMERO.server/bin/omero admin start"

--- a/omero/sysadmins/unix/walkthrough/setup_nginx_centos6_selinux.sh
+++ b/omero/sysadmins/unix/walkthrough/setup_nginx_centos6_selinux.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ $(getenforce) != Disabled ]; then
+    yum -y install policycoreutils-python
+    setsebool -P httpd_read_user_content 1
+    setsebool -P httpd_enable_homedirs 1
+    semanage port -a -t http_port_t -p tcp 4080
+fi


### PR DESCRIPTION
Recent CentOS6 and external Nginx versions may result in SELinux blocking communication between Nginx and OMERO.web. https://www.openmicroscopy.org/community/viewtopic.php?f=5&t=7697&start=40#p15219

Should be rebased in time for the 5.0.7 release

Testing: You'll need a CentOS6 VM with SELinux enabled.