### PR TITLE
Workaround argparse help formatter dash limitation (rebased onto dev_5_0)

### DIFF
--- a/omero/autogen_docs
+++ b/omero/autogen_docs
@@ -17,7 +17,7 @@ $WORKSPACE/OMERO.server/bin/omero config parse --rst | sed "s|$WORKSPACE|/home/o
 
 echo "Generating ldap setdn usage page"
 mkdir -p omero/downloads/ldap
-(cd $WORKSPACE/OMERO.server && bin/omero ldap setdn -h) | sed "s|$WORKSPACE|/home/omero|" > omero/downloads/ldap/setdn.out
+(cd $WORKSPACE/OMERO.server && bin/omero ldap setdn -h) > omero/downloads/ldap/setdn.out
 
 echo "Generating advanced CLI help"
 $WORKSPACE/OMERO.server/bin/omero import --advanced-help 2> advanced-help.txt || echo "Dumped"

--- a/omero/autogen_docs
+++ b/omero/autogen_docs
@@ -17,7 +17,7 @@ $WORKSPACE/OMERO.server/bin/omero config parse --rst | sed "s|$WORKSPACE|/home/o
 
 echo "Generating ldap setdn usage page"
 mkdir -p omero/downloads/ldap
-$WORKSPACE/OMERO.server/bin/omero ldap setdn -h | sed "s|$WORKSPACE|/home/omero|" > omero/downloads/ldap/setdn.out
+(cd $WORKSPACE/OMERO.server && bin/omero ldap setdn -h) | sed "s|$WORKSPACE|/home/omero|" > omero/downloads/ldap/setdn.out
 
 echo "Generating advanced CLI help"
 $WORKSPACE/OMERO.server/bin/omero import --advanced-help 2> advanced-help.txt || echo "Dumped"


### PR DESCRIPTION

This is the same as gh-1085 but rebased onto dev_5_0.

----

First PR against the auto-generation script noticed while reviewing https://github.com/snoopycrimecop/ome-documentation/commit/b7a2a8555b0c08cbf5ce9c3b2ae7d59e8d4445d7#diff-fb1c64548e4bb9a6bc9dca21ffd8dae4R1. 

The argparse native help formatter splits paths on dashes. This has direct implications on the CI infrastructure where job names are separated by dashes and the path replacement logic is broken. This commit works around this limitation by running the `bin/omero ` command locally and not substituting the path to the server.

To test this PR, check the `develop/merge/autogen` branch of https://github.com/snoopycrimecop/openmicroscopy especially the `setdn.out` file changes.


                