### PR TITLE
Document the Python integration library

### DIFF
--- a/omero/developers/testing.txt
+++ b/omero/developers/testing.txt
@@ -89,18 +89,6 @@ explicitly via:
 
 Results are placed in ``components/<component>/target/reports``.
 
-Individual test groups
-""""""""""""""""""""""
-
-To run individual OmeroJava test groups (or comma-separated sets of groups)
-of tests, the :option:`-DGROUPS` parameter can be used together with the
-``test`` target
-
-::
-
-    ./build.py -f components/tools/OmeroJava/build.xml test -DGROUPS=integration
-
-
 Individual tests
 """"""""""""""""
 
@@ -127,6 +115,18 @@ qualified name form (:option:`-Dpackage.class.method`).
 ::
 
     ./build.py -f components/tools/OmeroJava/build.xml test -DMETHODS=integration.chgrp.AnnotationMoveTest.testMoveTaggedImage
+
+Individual test groups
+""""""""""""""""""""""
+
+To run individual OmeroJava test groups (or comma-separated sets of groups)
+of tests, the :option:`-DGROUPS` parameter can be used together with the
+``test`` target
+
+::
+
+    ./build.py -f components/tools/OmeroJava/build.xml test -DGROUPS=integration
+
 
 Using Eclipse to run tests
 """""""""""""""""""""""""""

--- a/omero/developers/testing.txt
+++ b/omero/developers/testing.txt
@@ -462,14 +462,13 @@ To write and run Python tests you first need to install `pytest`:
 
 For more information on writing tests in general see `<http://pytest.org>`_.
 
-OMERO.py
-""""""""
-
 Similar to the OmeroJava tests, the tests under
-:sourcedir:`components/tools/OmeroPy/test` will be the starting point
+:sourcedir:`components/tools/OmeroPy/test`,
+:sourcedir:`components/tools/OmeroFS/test` and
+:sourcedir:`components/tools/OmeroWeb/test` will be the starting point
 for most Python-client developers coming to OMERO. Integration tests should
-be placed under :sourcedir:`components/tools/OmeroPy/test/integration`.
-The file names must begin with `test_` for the tests to be found by `pytest`.
+be placed under the :file:`integration` subfolders. The file names must begin
+with `test_` for the tests to be found by `pytest`.
 
 ::
 
@@ -488,3 +487,44 @@ The file names must begin with `test_` for the tests to be found by `pytest`.
         ec = client.getSession().getAdminService().getEventContext()
         assert ec, "No EventContext!"
 
+
+Using the Python test library
+"""""""""""""""""""""""""""""
+
+The :source:`OMERO Python test library <components/tests/python/library/__init__.py>`
+defines an abstract ``ITest`` class that implements the connection set up as
+well as many functionalities shared amongst all Python integration tests.
+
+Each concrete instance of the ``ITest`` will initiate a connection to the
+server specified by the :envvar:`ICE_CONFIG` environment variable at the
+``setup_class()`` level and two basic clients/sessions will be created and
+shared by all test methods of this class:
+
+- ``self.root`` is a client for the root user
+- ``self.client`` is a client for a new user created at the class setup.
+  ``self.sf``, ``self.update`` and ``self.query`` are shortcuts to this client
+  session, update service and query service.
+
+::
+
+  from library import ITest
+
+  class TestExample(ITest):
+      def testSimple():
+          ec = self.sf.getAdminService().getEventContext()
+          assert ec, "No EventContext!"
+
+New clients can be instantiated by individual tests using the
+``ITest.new_client()`` or ``ITest.new_client_and_user()`` methods::
+
+      def testNewClient():
+          new_client = self.new_user_and_client()
+          ec = new_client.getSession().getAdminService().getEventContext()
+          assert ec, "No EventContext!"
+
+Images can be imported using the ``ITest.importSingleImage()`` or
+``ITest.importSingleImageWithCompanion()`` or ``ITest.importMIF()`` methods::
+
+      def testNewClient():
+	      images = self.importMIF(2)
+	      assert len(images) == 2

--- a/omero/developers/testing.txt
+++ b/omero/developers/testing.txt
@@ -500,7 +500,7 @@ Using the Python test library
 
 The :source:`OMERO Python test library <components/tests/python/library/__init__.py>`
 defines an abstract ``ITest`` class that implements the connection set up as
-well as many functionalities shared amongst all Python integration tests.
+well as many methods shared amongst all Python integration tests.
 
 Each concrete instance of the ``ITest`` will initiate a connection to the
 server specified by the :envvar:`ICE_CONFIG` environment variable at the
@@ -574,3 +574,7 @@ New Django test clients can be instantiated by individual tests using the
           new_user = self.new_user()
           omeName = new_user.omeName.val
           new_django_client = self.new_django_client(omeName, omeName)
+
+.. seealso::
+  :source:`test_simple.py <components/tools/OmeroWeb/test/integration/test_simple.py>`
+     Example test class using the OMERO.web test library methods

--- a/omero/developers/testing.txt
+++ b/omero/developers/testing.txt
@@ -5,8 +5,12 @@ The following guidelines apply to tests in both the Java and Python test
 components. However, some of the presented options apply to only one or the
 other.
 
+Running tests
+-------------
+
+
 Running unit tests
-------------------
+^^^^^^^^^^^^^^^^^^
 
 The unit testing framework is fairly simple. Only methods which contain
 logic written within OMERO are tested. This means that framework
@@ -31,7 +35,7 @@ see :ref:`writing-python-tests`. Also note that some Python tests are excluded
 by default, see :ref:`using-markers-in-python-tests` for more details.
 
 Running integration tests
--------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Integration testing is a bit more complex because of the reliance on a
 database, which is not easily mockable. All Hibernate-related classes
@@ -61,7 +65,7 @@ Most likely the first settings that will have to be put there will be
 ``omero.user`` and ``omero.pass``.
 
 Running all tests
-^^^^^^^^^^^^^^^^^
+"""""""""""""""""
 
 To run all the integration tests, use
 
@@ -74,7 +78,7 @@ Note that some Python tests are excluded by default,
 see :ref:`using-markers-in-python-tests` for more details.
 
 Component tests
-^^^^^^^^^^^^^^^
+"""""""""""""""
 
 Running an integration test suite for an individual component can be done
 explicitly via:
@@ -86,7 +90,7 @@ explicitly via:
 Results are placed in ``components/<component>/target/reports``.
 
 Individual test groups
-^^^^^^^^^^^^^^^^^^^^^^
+""""""""""""""""""""""
 
 To run individual OmeroJava test groups (or comma-separated sets of groups)
 of tests, the :option:`-DGROUPS` parameter can be used together with the
@@ -98,7 +102,7 @@ of tests, the :option:`-DGROUPS` parameter can be used together with the
 
 
 Individual tests
-^^^^^^^^^^^^^^^^
+""""""""""""""""
 
 Alternatively, you can run individual tests which you may currently be
 working on. This can be done using the ``test`` target. For example:
@@ -108,8 +112,12 @@ working on. This can be done using the ``test`` target. For example:
     ./build.py -f components/tools/OmeroJava/build.xml test -DTEST=integration/AdminTest
     ./build.py -f components/tools/OmeroPy/build.xml test -DTEST=test/integration/test_admin.py
 
+Running Java tests
+^^^^^^^^^^^^^^^^^^
+
 Individual test class methods
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+"""""""""""""""""""""""""""""
+
 
 Individual OmeroJava test class methods (or a comma-separated list of
 methods) can be run using the :option:`-DMETHODS` parameter together with
@@ -120,113 +128,8 @@ qualified name form (:option:`-Dpackage.class.method`).
 
     ./build.py -f components/tools/OmeroJava/build.xml test -DMETHODS=integration.chgrp.AnnotationMoveTest.testMoveTaggedImage
 
-
-.. _using-markers-in-python-tests:
-
-Using markers in OmeroPy tests
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Tests under OmeroPy can be included or excluded according to markers defined in the tests.
-This can be done by using the :option:`-DMARK` option. For example, to run all the
-integration tests marked as ``broken``:
-
-::
-
-    ./build.py -f components/tools/OmeroPy/build.xml integration -DMARK=broken
-
-By default tests marked as ``long_running`` and ``broken`` are excluded and so
-the following two builds are equivalent:
-
-::
-
-    ./build.py -f components/tools/OmeroPy/build.xml integration
-    ./build.py -f components/tools/OmeroPy/build.xml integration -DMARK="not (long_running or broken)"
-
-In order to run **all** tests, including ``long_running`` and ``broken``,
-an empty marker must be used:
-
-::
-
-    ./build.py -f components/tools/OmeroPy/build.xml integration -DMARK=
-
-See :ref:`writing-python-tests` and :ref:`running-python-tests-directly`
-for more information on this.
-
-Failing tests
-^^^^^^^^^^^^^
-
-The ``test.with.fail`` ant property is set to ``false`` by default,
-which prevents test failures from failing the build. However, it can instead
-be set to ``true`` to allow test failures to fail the build. For example:
-
-::
-
-    ./build.py -Dtest.with.fail=true integration
-
-Some components might provide individual targets for specific tests (e.g.
-OmeroJava provides the ``broken`` target for running broken tests).
-The :file:`build.xml` file is the reference in each component.
-
-Writing Java tests
-------------------
-
-For more information on writing tests in general see `<http://testng.org>`_.
-For a test to be an "integration" test, place it in the "integration"
-TestNG group. If a test is temporarily broken, add it to the "broken" group:
-
-::
-
-    @Test(groups = {"integration", "broken"}
-    public void testMyStuff() {
-
-    }
-
-Tests should be of the **Acceptance Test** form. The ticket number
-for which a test is being written should be added in the TestNG annotation:
-
-::
-
-    @Test(groups = "ticket:60")
-
-This works at either the method level (see :source:`SetsAndLinksTest.java
-<components/model/test/ome/model/utests/SetsAndLinksTest.java>`)
-or the class level (see :source:`UniqueResultTest.java
-<components/server/test/ome/server/itests/query/UniqueResultTest.java>`).
-
-OmeroJava
-^^^^^^^^^
-
-The tests under :sourcedir:`components/tools/OmeroJava/test` will be the
-starting point for most Java-client developers coming to OMERO. An example
-skeleton for an integration test looks similar to
-
-::
-
-    @Test(groups = "integration")
-    public class MyTest {
-
-      omero.client client;
-
-      @BeforeClass
-      protected void setup() throws Exception {
-        client = new omero.client();
-        client.createSession();
-      }
-
-      @AfterClass
-      protected void tearDown() throws Exception {
-        client.closeSession();
-      }
-
-      @Test
-      public void testSimple() throws Exception {
-        client.getSession().getAdminService().getEventContext();
-      }
-
-    }
-
 Using Eclipse to run tests
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+"""""""""""""""""""""""""""
 
 To facilitate importing OMERO components into Eclipse, there are
 :file:`.project` and :file:`.classpath-template` files stored in each
@@ -264,22 +167,14 @@ is then used in the Eclipse :file:`.classpath` files.
 If Eclipse ever gets out of sync after the first build,
 :command:`./build.py build-eclipse` can be used to quickly synchronize.
 
-TestNG plugin
-^^^^^^^^^^^^^
 
 A prerequisite of running unit and integration tests in the Eclipse UI is
 having the TestNG plug-in installed and working (help available on the
 `TestNG site <http://testng.org/doc/eclipse.html>`_).
 
-Unit tests
-^^^^^^^^^^
-
 Running the unit tests under Eclipse requires no extra settings and is as
 easy as navigating to the package or class context menu :guilabel:`Run As`
 or :guilabel:`Debug As`, then selecting :guilabel:`TestNG`.
-
-Integration tests
-^^^^^^^^^^^^^^^^^
 
 Integration tests require the :envvar:`ICE_CONFIG` environment variable to
 be available for the Eclipse-controlled JVM. This can be done by editing
@@ -288,9 +183,6 @@ Configurations window, the :guilabel:`Environment` tab needs to be selected.
 After clicking :guilabel:`New`, :envvar:`ICE_CONFIG` can be defined as a
 path to the :file:`ice.config` file. This setting needs to be defined per
 package, class or method.
-
-Debugging a running OMERO instance
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 By using the "debug" target from templates.xml, it is possible to have
 OMERO listen on port 8787 for a debugging connection.
@@ -312,47 +204,11 @@ values are arbitrary and can be changed locally.
 - If you take too much time examining your threads, your calls may
   throw timeout exceptions.
 
-.. _writing-python-tests:
-
-Writing Python tests
---------------------
-
-To write and run Python tests you first need to install `pytest`:
-
-::
-
-    pip install pytest
-
-For more information on writing tests in general see `<http://pytest.org>`_.
-
-OmeroPy
-^^^^^^^
-
-Similar to the OmeroJava tests, the tests under
-:sourcedir:`components/tools/OmeroPy/test` will be the starting point
-for most Python-client developers coming to OMERO. Integration tests should
-be placed under :sourcedir:`components/tools/OmeroPy/test/integration`.
-The file names must begin with `test_` for the tests to be found by `pytest`.
-
-::
-
-    import omero
-
-    class TestExample(object)
-
-      def setup_method(self, method):
-        client = new omero.client()
-        client.createSession()
-
-      def teardown_method(self, method):
-        client.closeSession()
-
-      def testSimple():
-        ec = client.getSession().getAdminService().getEventContext()
-        assert ec, "No EventContext!"
+Running Python tests
+^^^^^^^^^^^^^^^^^^^^
 
 Markers
-^^^^^^^
+"""""""
 
 Methods, classes and functions can be decorated with `pytest` markers to allow for
 the selection of tests. `pytest` provides some predefined markers and markers can
@@ -401,11 +257,38 @@ There are a small number of custom markers defined:
       def testIntermittent():
           self.somePotentiallyIntermittentCall()
 
+.. _using-markers-in-python-tests:
+
+Using markers in OmeroPy tests
+""""""""""""""""""""""""""""""
+
+Tests under OmeroPy can be included or excluded according to markers defined in the tests.
+This can be done by using the :option:`-DMARK` option. For example, to run all the
+integration tests marked as ``broken``:
+
+::
+
+    ./build.py -f components/tools/OmeroPy/build.xml integration -DMARK=broken
+
+By default tests marked as ``long_running`` and ``broken`` are excluded and so
+the following two builds are equivalent:
+
+::
+
+    ./build.py -f components/tools/OmeroPy/build.xml integration
+    ./build.py -f components/tools/OmeroPy/build.xml integration -DMARK="not (long_running or broken)"
+
+In order to run **all** tests, including ``long_running`` and ``broken``,
+an empty marker must be used:
+
+::
+
+    ./build.py -f components/tools/OmeroPy/build.xml integration -DMARK=
 
 .. _running-python-tests-directly:
 
 Running tests directly
-^^^^^^^^^^^^^^^^^^^^^^
+""""""""""""""""""""""
 
 When writing tests it can be more convenient, flexible and powerful to run the
 tests from :sourcedir:`components/tools/OmeroPy` using
@@ -491,3 +374,117 @@ add paths to :envvar:`PYTHONPATH` specifically for `pytest`.
         py.test --help
 
 and `<http://pytest.org/latest/usage.html>`_ for more help in running tests.
+
+Failing tests
+^^^^^^^^^^^^^
+
+The ``test.with.fail`` ant property is set to ``false`` by default,
+which prevents test failures from failing the build. However, it can instead
+be set to ``true`` to allow test failures to fail the build. For example:
+
+::
+
+    ./build.py -Dtest.with.fail=true integration
+
+Some components might provide individual targets for specific tests (e.g.
+OmeroJava provides the ``broken`` target for running broken tests).
+The :file:`build.xml` file is the reference in each component.
+
+Writing tests
+-------------
+
+Writing Java tests
+^^^^^^^^^^^^^^^^^^
+
+For more information on writing tests in general see `<http://testng.org>`_.
+For a test to be an "integration" test, place it in the "integration"
+TestNG group. If a test is temporarily broken, add it to the "broken" group:
+
+::
+
+    @Test(groups = {"integration", "broken"}
+    public void testMyStuff() {
+
+    }
+
+Tests should be of the **Acceptance Test** form. The ticket number
+for which a test is being written should be added in the TestNG annotation:
+
+::
+
+    @Test(groups = "ticket:60")
+
+This works at either the method level (see :source:`SetsAndLinksTest.java
+<components/model/test/ome/model/utests/SetsAndLinksTest.java>`)
+or the class level (see :source:`UniqueResultTest.java
+<components/server/test/ome/server/itests/query/UniqueResultTest.java>`).
+
+The tests under :sourcedir:`components/tools/OmeroJava/test` will be the
+starting point for most Java-client developers coming to OMERO. An example
+skeleton for an integration test looks similar to
+
+::
+
+    @Test(groups = "integration")
+    public class MyTest {
+
+      omero.client client;
+
+      @BeforeClass
+      protected void setup() throws Exception {
+        client = new omero.client();
+        client.createSession();
+      }
+
+      @AfterClass
+      protected void tearDown() throws Exception {
+        client.closeSession();
+      }
+
+      @Test
+      public void testSimple() throws Exception {
+        client.getSession().getAdminService().getEventContext();
+      }
+
+    }
+
+
+.. _writing-python-tests:
+
+Writing Python tests
+^^^^^^^^^^^^^^^^^^^^
+
+To write and run Python tests you first need to install `pytest`:
+
+::
+
+    pip install pytest
+
+For more information on writing tests in general see `<http://pytest.org>`_.
+
+OMERO.py
+""""""""
+
+Similar to the OmeroJava tests, the tests under
+:sourcedir:`components/tools/OmeroPy/test` will be the starting point
+for most Python-client developers coming to OMERO. Integration tests should
+be placed under :sourcedir:`components/tools/OmeroPy/test/integration`.
+The file names must begin with `test_` for the tests to be found by `pytest`.
+
+::
+
+    import omero
+
+    class TestExample(object)
+
+      def setup_method(self, method):
+        client = new omero.client()
+        client.createSession()
+
+      def teardown_method(self, method):
+        client.closeSession()
+
+      def testSimple():
+        ec = client.getSession().getAdminService().getEventContext()
+        assert ec, "No EventContext!"
+

--- a/omero/developers/testing.txt
+++ b/omero/developers/testing.txt
@@ -207,64 +207,15 @@ values are arbitrary and can be changed locally.
 Running Python tests
 ^^^^^^^^^^^^^^^^^^^^
 
-Markers
-"""""""
-
-Methods, classes and functions can be decorated with `pytest` markers to allow for
-the selection of tests. `pytest` provides some predefined markers and markers can
-be simply defined as they are used. However, to centralize the use of custom
-markers they should be defined in :sourcedir:`components/tools/pytest.ini`.
-To view all available markers the :option:`--markers` option can be used with
-:program:`setup.py test` or :program:`py.test` as detailed in
-:ref:`running-python-tests-directly`.
-
-There are a small number of custom markers defined:
-
-.. glossary::
-
-    `long_running`
-        Used to mark tests as long running. These are tests that typically take
-        10 minutes or more and are excluded from the daily integration builds.
-
-    `broken`
-        Used to mark broken tests. These are tests that fail consistently with no
-        obvious quick fix. Broken tests are excluded from the main integration builds
-        and instead are run in a separate daily build. `broken` markers should have a
-        reason, an associated Trac ticket number or both. If there are multiple
-        associated tickets then a comma-separated list should be used.
-
-    `intermittent`
-        Used to mark tests that fail intermittently. `intermittent` markers should
-        have a reason, an associated Trac ticket number or both. If there are
-        multiple associated tickets then a comma-separated list should be used. Tests
-        marked as intermittent are included in the daily integration builds.
-
-::
-
-    import pytest
-
-    class TestExample2(object)
-
-      @pytest.mark.broken(reason="Asserting false", ticket="12345,67890")
-      def testBroken():
-          assert False, "Bound to fail"
-
-      @pytest.mark.long_running
-      def testLongRunning():
-          self.somePotentiallyLongCall()
-
-      @pytest.mark.intermittent(reason="Occasionally times out", ticket="98765")
-      def testIntermittent():
-          self.somePotentiallyIntermittentCall()
-
 .. _using-markers-in-python-tests:
 
 Using markers in OmeroPy tests
 """"""""""""""""""""""""""""""
 
-Tests under OmeroPy can be included or excluded according to markers defined in the tests.
-This can be done by using the :option:`-DMARK` option. For example, to run all the
-integration tests marked as ``broken``:
+Tests under OmeroPy can be included or excluded according to markers defined
+in the tests.
+This can be done by using the :option:`-DMARK` option. For example, to run all
+the integration tests marked as ``broken``:
 
 ::
 
@@ -284,6 +235,9 @@ an empty marker must be used:
 ::
 
     ./build.py -f components/tools/OmeroPy/build.xml integration -DMARK=
+
+.. seealso::
+	:ref:`marking-python-tests`
 
 .. _running-python-tests-directly:
 
@@ -487,6 +441,59 @@ with `test_` for the tests to be found by `pytest`.
         ec = client.getSession().getAdminService().getEventContext()
         assert ec, "No EventContext!"
 
+.. _marking-python-tests:
+
+Marking OmeroPy tests
+"""""""""""""""""""""
+
+Methods, classes and functions can be decorated with `pytest` markers to allow
+for the selection of tests. `pytest` provides some predefined markers and
+markers can be simply defined as they are used. However, to centralize the use
+of custom markers they should be defined in
+:sourcedir:`components/tools/pytest.ini`.
+
+To view all available markers the :option:`--markers` option can be used with
+:program:`setup.py test` or :program:`py.test` as detailed in
+:ref:`running-python-tests-directly`.
+
+There are a small number of custom markers defined:
+
+.. glossary::
+
+    `long_running`
+        Used to mark tests as long running. These are tests that typically take
+        10 minutes or more and are excluded from the daily integration builds.
+
+    `broken`
+        Used to mark broken tests. These are tests that fail consistently with no
+        obvious quick fix. Broken tests are excluded from the main integration builds
+        and instead are run in a separate daily build. `broken` markers should have a
+        reason, an associated Trac ticket number or both. If there are multiple
+        associated tickets then a comma-separated list should be used.
+
+    `intermittent`
+        Used to mark tests that fail intermittently. `intermittent` markers should
+        have a reason, an associated Trac ticket number or both. If there are
+        multiple associated tickets then a comma-separated list should be used. Tests
+        marked as intermittent are included in the daily integration builds.
+
+::
+
+  import pytest
+
+  class TestExample2(object):
+
+      @pytest.mark.broken(reason="Asserting false", ticket="12345,67890")
+      def testBroken():
+          assert False, "Bound to fail"
+
+      @pytest.mark.long_running
+      def testLongRunning():
+          self.somePotentiallyLongCall()
+
+      @pytest.mark.intermittent(reason="Occasionally times out", ticket="98765")
+      def testIntermittent():
+          self.somePotentiallyIntermittentCall()
 
 Using the Python test library
 """""""""""""""""""""""""""""

--- a/omero/developers/testing.txt
+++ b/omero/developers/testing.txt
@@ -497,8 +497,8 @@ well as many functionalities shared amongst all Python integration tests.
 
 Each concrete instance of the ``ITest`` will initiate a connection to the
 server specified by the :envvar:`ICE_CONFIG` environment variable at the
-``setup_class()`` level and two basic clients/sessions will be created and
-shared by all test methods of this class:
+``setup_class()`` level. Two basic clients/sessions are created by
+``ITest.setup_class()`` and shared by all test methods of this class:
 
 - ``self.root`` is a client for the root user
 - ``self.client`` is a client for a new user created at the class setup.
@@ -514,6 +514,14 @@ shared by all test methods of this class:
           ec = self.sf.getAdminService().getEventContext()
           assert ec, "No EventContext!"
 
+New user and groups can be instantiated by individual tests using the
+``ITest.new_user()`` and ``ITest.new_group()`` methods::
+
+      def testNewGroupOwner():
+          new_group = self.new_group(perms='rwa---')
+          new_owner = self.new_use(group=new_group, owner=True)
+          assert new_owner.id.val, "No EventContext!"
+
 New clients can be instantiated by individual tests using the
 ``ITest.new_client()`` or ``ITest.new_client_and_user()`` methods::
 
@@ -526,5 +534,36 @@ Images can be imported using the ``ITest.importSingleImage()`` or
 ``ITest.importSingleImageWithCompanion()`` or ``ITest.importMIF()`` methods::
 
       def testNewClient():
-	      images = self.importMIF(2)
-	      assert len(images) == 2
+          images = self.importMIF(2)
+          assert len(images) == 2
+
+Writing OMERO.web tests
+"""""""""""""""""""""""
+
+For OMERO.web integration tests, the :source:`OMERO.web test library <components/tools/OmeroWeb/test/integration/weblibrary.py>`
+defines an abstract ``IWebTest`` class that inherits from ``ITest`` and
+also implements Django clients at the class setup using the
+:djangodoc:`Django testing tools <topics/testing/tools>`.
+
+On top of the elements created by ``ITest.setup_class()``, the ``IWebTest``
+class creates:
+
+- ``self.django_root_client`` is a Django test client for the root user
+- ``self.django_client`` is a client for the new user created at the class
+  setup.
+
+::
+
+  from weblibrary import IWebTest
+
+  class TestExample(IWebTest):
+      def testSimple():
+          self.django_client.post('/login/', {'username': 'john'})
+
+New Django test clients can be instantiated by individual tests using the
+``IWebTest.new_django_client()`` method::
+
+      def testNewDjangoClient():
+          new_user = self.new_user()
+          omeName = new_user.omeName.val
+          new_django_client = self.new_django_client(omeName, omeName)

--- a/omero/developers/testing.txt
+++ b/omero/developers/testing.txt
@@ -577,5 +577,4 @@ New Django test clients can be instantiated by individual tests using the
 
 .. seealso::
     :source:`test_simple.py <components/tools/OmeroWeb/test/integration/test_simple.py>`
-
         Example test class using the OMERO.web test library methods

--- a/omero/developers/testing.txt
+++ b/omero/developers/testing.txt
@@ -576,5 +576,5 @@ New Django test clients can be instantiated by individual tests using the
           new_django_client = self.new_django_client(omeName, omeName)
 
 .. seealso::
-  :source:`test_simple.py <components/tools/OmeroWeb/test/integration/test_simple.py>`
-     Example test class using the OMERO.web test library methods
+    :source:`test_simple.py <components/tools/OmeroWeb/test/integration/test_simple.py>`
+        Example test class using the OMERO.web test library methods

--- a/omero/developers/testing.txt
+++ b/omero/developers/testing.txt
@@ -237,7 +237,7 @@ an empty marker must be used:
     ./build.py -f components/tools/OmeroPy/build.xml integration -DMARK=
 
 .. seealso::
-	:ref:`marking-python-tests`
+    :ref:`marking-python-tests`
 
 .. _running-python-tests-directly:
 
@@ -577,4 +577,5 @@ New Django test clients can be instantiated by individual tests using the
 
 .. seealso::
     :source:`test_simple.py <components/tools/OmeroWeb/test/integration/test_simple.py>`
+
         Example test class using the OMERO.web test library methods


### PR DESCRIPTION
Following the structural changes in https://github.com/openmicroscopy/openmicroscopy/pull/3318 and https://github.com/openmicroscopy/openmicroscopy/pull/3405, this PR review the OMERO developer page about running and writing tests by:

- moving all aspects about running tests to the first section incl. Java/Python specific sections
- describe the library structure for Omero.Py and OMERO.py
- providing some basic description of the ``ITest` and ``IWebTest`` most useful features/methods

/cc @will-moore @ximenesuk 

--no-rebase