### PR TITLE
Fix link to Homebrew installation script (rebased onto dev_5_0)

### DIFF
--- a/omero/sysadmins/unix/server-install-homebrew.txt
+++ b/omero/sysadmins/unix/server-install-homebrew.txt
@@ -14,7 +14,7 @@ OMERO.server Mac OS X installation walk-through with Homebrew
 
 The instructions provided here depend on Homebrew 0.9 or later, including
 support for the ``brew tap`` command. These instructions are implemented in a
-series of :source:`automated scripts <https://github.com/ome/omero-install/tree/master/homebrew>`
+series of `automated scripts <https://github.com/ome/omero-install/tree/master/homebrew>`_
 which install OMERO via Homebrew from a fresh configuration.
 
 Prerequisites

--- a/omero/sysadmins/unix/server-install-homebrew.txt
+++ b/omero/sysadmins/unix/server-install-homebrew.txt
@@ -14,7 +14,7 @@ OMERO.server Mac OS X installation walk-through with Homebrew
 
 The instructions provided here depend on Homebrew 0.9 or later, including
 support for the ``brew tap`` command. These instructions are implemented in a
-series of :source:`automated scripts <https://github.com/ome/omero-install>`
+series of :source:`automated scripts <https://github.com/ome/omero-install/tree/master/homebrew>`
 which install OMERO via Homebrew from a fresh configuration.
 
 Prerequisites

--- a/omero/sysadmins/unix/server-install-homebrew.txt
+++ b/omero/sysadmins/unix/server-install-homebrew.txt
@@ -13,9 +13,9 @@ OMERO.server Mac OS X installation walk-through with Homebrew
     from the downloads page.**
 
 The instructions provided here depend on Homebrew 0.9 or later, including
-support for the ``brew tap`` command. These instructions are implemented in an
-:source:`automated script <docs/hudson/OMERO-homebrew-install.sh>` which
-installs OMERO via Homebrew from a fresh configuration.
+support for the ``brew tap`` command. These instructions are implemented in a
+series of :source:`automated scripts <https://github.com/ome/omero-install>`
+which install OMERO via Homebrew from a fresh configuration.
 
 Prerequisites
 -------------
@@ -360,13 +360,13 @@ Now connect to your OMERO.server using OMERO.insight with the following credenti
 OMERO.web
 ^^^^^^^^^
 
-In order to deploy OMERO.web in a production environment such as Apache or 
+In order to deploy OMERO.web in a production environment such as Apache or
 Nginx please follow the instructions under :doc:`install-web`.
 
 
 .. note::
-    The internal Django webserver can be used for evaluation and development. 
-    In this case please follow the instructions under 
+    The internal Django webserver can be used for evaluation and development.
+    In this case please follow the instructions under
     :doc:`/developers/Web/Deployment`.
 
 .. _install_homebrew_common_issues:


### PR DESCRIPTION

This is the same as gh-1091 but rebased onto dev_5_0.

----

With the migration of the script to the omero-install repository, the
link on the documentation page needs to be updated

                