### PR TITLE
Autogen clients deprecation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -222,8 +222,7 @@ Auto-generated content
 Some parts of the OMERO documentation are auto-generated from the OMERO
 deliverables (e.g. templates, command-line output...). This auto-generation is
 usually done via Continuous Integration builds. To generate these components
-manually, download the OMERO.server and OMERO.clients and run the
-auto-generation script as::
+manually, download the OMERO.server and run the auto-generation script as::
 
       WORSKSPACE=/path/to/OMERO/deliverables ./omero/autogen_docs
 

--- a/omero/autogen_docs
+++ b/omero/autogen_docs
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # This script is used by a Continuous Integration job to auto-generate
 # some components of the OMERO documentation from its deliverables (server,
-# clients). To run it locally, download the server and the linux clients
-# containing the importer-cli and name them OMERO.server and OMERO.clients.
+# clients). To run it locally, download the server and rename the folder as
+# OMERO.server.
 
 set -u
 set -e
@@ -20,9 +20,10 @@ mkdir -p omero/downloads/ldap
 (cd $WORKSPACE/OMERO.server && bin/omero ldap setdn -h) > omero/downloads/ldap/setdn.out
 
 echo "Generating advanced CLI help"
-$WORKSPACE/OMERO.server/bin/omero import --advanced-help 2> advanced-help.txt || echo "Dumped"
-sed 1,3d advanced-help.txt > omero/downloads/inplace/advanced-help.txt
-$WORKSPACE/OMERO.clients/importer-cli -h 2> omero/downloads/cli/help.out || echo "Dumped"
+(cd $WORKSPACE/OMERO.server && bin/omero import --advanced-help) 2> advanced-help.txt || echo "Dumped"
+sed 1,5d advanced-help.txt > omero/downloads/inplace/advanced-help.txt
+(cd $WORKSPACE/OMERO.server && bin/omero import --javahelp) 2> java-help.txt || echo "Dumped"
+sed 1,5d java-help.txt > omero/downloads/cli/help.out
 
 echo "Generating Web configuration templates"
 $WORKSPACE/OMERO.server/bin/omero web config nginx | sed "s|$WORKSPACE|/home/omero|" > omero/sysadmins/unix/nginx-omero.conf
@@ -30,4 +31,5 @@ $WORKSPACE/OMERO.server/bin/omero web config apache | sed "s|$WORKSPACE|/home/om
 $WORKSPACE/OMERO.server/bin/omero web config apache-fcgi | sed "s|$WORKSPACE|/home/omero|" > omero/sysadmins/unix/apache-fcgi-omero.conf
 
 echo "Cleanup"
+rm java-help.txt
 rm advanced-help.txt


### PR DESCRIPTION
In preparation of the deprecation of the `OMERO.clients` bundle on 5.1.0, this PR removes their need for the auto-generated documentation. Instead, it uses the `--java-help` option of the CLI import plugin which dumps the content of `importer-cli`.

To test this PR, check the outcome of the the auto-generated importer help is the same with and without this PR (e.g. by comparing the `develop/latest/autogen` and `develop/merge/autogen` branches of https://github.com/snoopycrimecop/ome-documentation).

--no-rebase