### PR TITLE
Making doc links 5.0 specific

### DIFF
--- a/common/conf.py
+++ b/common/conf.py
@@ -159,11 +159,11 @@ extlinks = {
     'schema_plone' : (oo_root + '/Schemas/%s', ''),
     'omero_plone' : (oo_site_root + '/products/omero/%s', ''),
     'secvuln' : (oo_root + '/info/vulnerabilities/%s', ''),
-    'omero_doc' : (oo_site_root + '/support/omero5/%s', ''),
+    'omero_doc' : (oo_site_root + '/support/omero5.0/%s', ''),
     'model_doc' : (oo_site_root + '/support/ome-model/%s', ''),
     'devs_doc' : (oo_site_root + '/support/contributing/%s', ''),
     'bf_plone' : (oo_site_root + '/products/bio-formats/%s', ''),
-    'bf_doc' : (oo_site_root + '/support/bio-formats5/%s', ''),
+    'bf_doc' : (oo_site_root + '/support/bio-formats5.0/%s', ''),
     'partner_plone' : (oo_site_root + '/products/partner/%s', ''),
     # Downloads
     'downloads' : (downloads_root + '/latest/omero5.0/%s', ''),


### PR DESCRIPTION
In preparation for the latest links being updated to point at 5.1, this ensures links in the latest 5.0.x doc release will point to the right branch. Same strategy already in place for the downloads links.
