### PR TITLE
autogenerated: update reference for every OMERO model object

### DIFF
--- a/omero/developers/Model/EveryObject.txt
+++ b/omero/developers/Model/EveryObject.txt
@@ -15,303 +15,307 @@ among the objects.
 Reference
 ---------
 
-.. _omero.model.AcquisitionMode:
+.. _Hibernate version of class omero.model.AcquisitionMode:
 
 AcquisitionMode
 """""""""""""""
 
-Used by: :ref:`LogicalChannel.mode <omero.model.LogicalChannel>`
+Used by: :ref:`LogicalChannel.mode <Hibernate version of class omero.model.LogicalChannel>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
 
-.. _omero.model.Annotation:
+.. _Hibernate version of class omero.model.Annotation:
 
 Annotation
 """"""""""
 
-Subclasses: :ref:`BasicAnnotation <omero.model.BasicAnnotation>`, :ref:`ListAnnotation <omero.model.ListAnnotation>`, :ref:`MapAnnotation <omero.model.MapAnnotation>`, :ref:`TextAnnotation <omero.model.TextAnnotation>`, :ref:`TypeAnnotation <omero.model.TypeAnnotation>`
+Subclasses: :ref:`BasicAnnotation <Hibernate version of class omero.model.BasicAnnotation>`, :ref:`ListAnnotation <Hibernate version of class omero.model.ListAnnotation>`, :ref:`MapAnnotation <Hibernate version of class omero.model.MapAnnotation>`, :ref:`TextAnnotation <Hibernate version of class omero.model.TextAnnotation>`, :ref:`TypeAnnotation <Hibernate version of class omero.model.TypeAnnotation>`
 
-Used by: :ref:`AnnotationAnnotationLink.child <omero.model.AnnotationAnnotationLink>`, :ref:`AnnotationAnnotationLink.parent <omero.model.AnnotationAnnotationLink>`, :ref:`ChannelAnnotationLink.child <omero.model.ChannelAnnotationLink>`, :ref:`DatasetAnnotationLink.child <omero.model.DatasetAnnotationLink>`, :ref:`DetectorAnnotationLink.child <omero.model.DetectorAnnotationLink>`, :ref:`DichroicAnnotationLink.child <omero.model.DichroicAnnotationLink>`, :ref:`ExperimenterAnnotationLink.child <omero.model.ExperimenterAnnotationLink>`, :ref:`ExperimenterGroupAnnotationLink.child <omero.model.ExperimenterGroupAnnotationLink>`, :ref:`FilesetAnnotationLink.child <omero.model.FilesetAnnotationLink>`, :ref:`FilterAnnotationLink.child <omero.model.FilterAnnotationLink>`, :ref:`ImageAnnotationLink.child <omero.model.ImageAnnotationLink>`, :ref:`InstrumentAnnotationLink.child <omero.model.InstrumentAnnotationLink>`, :ref:`LightPathAnnotationLink.child <omero.model.LightPathAnnotationLink>`, :ref:`LightSourceAnnotationLink.child <omero.model.LightSourceAnnotationLink>`, :ref:`NamespaceAnnotationLink.child <omero.model.NamespaceAnnotationLink>`, :ref:`NodeAnnotationLink.child <omero.model.NodeAnnotationLink>`, :ref:`ObjectiveAnnotationLink.child <omero.model.ObjectiveAnnotationLink>`, :ref:`OriginalFileAnnotationLink.child <omero.model.OriginalFileAnnotationLink>`, :ref:`PlaneInfoAnnotationLink.child <omero.model.PlaneInfoAnnotationLink>`, :ref:`PlateAcquisitionAnnotationLink.child <omero.model.PlateAcquisitionAnnotationLink>`, :ref:`PlateAnnotationLink.child <omero.model.PlateAnnotationLink>`, :ref:`ProjectAnnotationLink.child <omero.model.ProjectAnnotationLink>`, :ref:`ReagentAnnotationLink.child <omero.model.ReagentAnnotationLink>`, :ref:`RoiAnnotationLink.child <omero.model.RoiAnnotationLink>`, :ref:`ScreenAnnotationLink.child <omero.model.ScreenAnnotationLink>`, :ref:`SessionAnnotationLink.child <omero.model.SessionAnnotationLink>`, :ref:`ShapeAnnotationLink.child <omero.model.ShapeAnnotationLink>`, :ref:`WellAnnotationLink.child <omero.model.WellAnnotationLink>`
+Used by: :ref:`AnnotationAnnotationLink.child <Hibernate version of class omero.model.AnnotationAnnotationLink>`, :ref:`AnnotationAnnotationLink.parent <Hibernate version of class omero.model.AnnotationAnnotationLink>`, :ref:`ChannelAnnotationLink.child <Hibernate version of class omero.model.ChannelAnnotationLink>`, :ref:`DatasetAnnotationLink.child <Hibernate version of class omero.model.DatasetAnnotationLink>`, :ref:`DetectorAnnotationLink.child <Hibernate version of class omero.model.DetectorAnnotationLink>`, :ref:`DichroicAnnotationLink.child <Hibernate version of class omero.model.DichroicAnnotationLink>`, :ref:`ExperimenterAnnotationLink.child <Hibernate version of class omero.model.ExperimenterAnnotationLink>`, :ref:`ExperimenterGroupAnnotationLink.child <Hibernate version of class omero.model.ExperimenterGroupAnnotationLink>`, :ref:`FilesetAnnotationLink.child <Hibernate version of class omero.model.FilesetAnnotationLink>`, :ref:`FilterAnnotationLink.child <Hibernate version of class omero.model.FilterAnnotationLink>`, :ref:`ImageAnnotationLink.child <Hibernate version of class omero.model.ImageAnnotationLink>`, :ref:`InstrumentAnnotationLink.child <Hibernate version of class omero.model.InstrumentAnnotationLink>`, :ref:`LightPathAnnotationLink.child <Hibernate version of class omero.model.LightPathAnnotationLink>`, :ref:`LightSourceAnnotationLink.child <Hibernate version of class omero.model.LightSourceAnnotationLink>`, :ref:`NamespaceAnnotationLink.child <Hibernate version of class omero.model.NamespaceAnnotationLink>`, :ref:`NodeAnnotationLink.child <Hibernate version of class omero.model.NodeAnnotationLink>`, :ref:`ObjectiveAnnotationLink.child <Hibernate version of class omero.model.ObjectiveAnnotationLink>`, :ref:`OriginalFileAnnotationLink.child <Hibernate version of class omero.model.OriginalFileAnnotationLink>`, :ref:`PlaneInfoAnnotationLink.child <Hibernate version of class omero.model.PlaneInfoAnnotationLink>`, :ref:`PlateAcquisitionAnnotationLink.child <Hibernate version of class omero.model.PlateAcquisitionAnnotationLink>`, :ref:`PlateAnnotationLink.child <Hibernate version of class omero.model.PlateAnnotationLink>`, :ref:`ProjectAnnotationLink.child <Hibernate version of class omero.model.ProjectAnnotationLink>`, :ref:`ReagentAnnotationLink.child <Hibernate version of class omero.model.ReagentAnnotationLink>`, :ref:`RoiAnnotationLink.child <Hibernate version of class omero.model.RoiAnnotationLink>`, :ref:`ScreenAnnotationLink.child <Hibernate version of class omero.model.ScreenAnnotationLink>`, :ref:`SessionAnnotationLink.child <Hibernate version of class omero.model.SessionAnnotationLink>`, :ref:`ShapeAnnotationLink.child <Hibernate version of class omero.model.ShapeAnnotationLink>`, :ref:`WellAnnotationLink.child <Hibernate version of class omero.model.WellAnnotationLink>`
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <omero.model.AnnotationAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple)
   | description: ``text`` (optional)
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | name: ``string`` (optional)
   | ns: ``string`` (optional)
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.AnnotationAnnotationLink:
+.. _Hibernate version of class omero.model.AnnotationAnnotationLink:
 
 AnnotationAnnotationLink
 """"""""""""""""""""""""
 
-Used by: :ref:`Annotation.annotationLinks <omero.model.Annotation>`, :ref:`BasicAnnotation.annotationLinks <omero.model.BasicAnnotation>`, :ref:`BooleanAnnotation.annotationLinks <omero.model.BooleanAnnotation>`, :ref:`CommentAnnotation.annotationLinks <omero.model.CommentAnnotation>`, :ref:`DoubleAnnotation.annotationLinks <omero.model.DoubleAnnotation>`, :ref:`FileAnnotation.annotationLinks <omero.model.FileAnnotation>`, :ref:`ListAnnotation.annotationLinks <omero.model.ListAnnotation>`, :ref:`LongAnnotation.annotationLinks <omero.model.LongAnnotation>`, :ref:`MapAnnotation.annotationLinks <omero.model.MapAnnotation>`, :ref:`NumericAnnotation.annotationLinks <omero.model.NumericAnnotation>`, :ref:`TagAnnotation.annotationLinks <omero.model.TagAnnotation>`, :ref:`TermAnnotation.annotationLinks <omero.model.TermAnnotation>`, :ref:`TextAnnotation.annotationLinks <omero.model.TextAnnotation>`, :ref:`TimestampAnnotation.annotationLinks <omero.model.TimestampAnnotation>`, :ref:`TypeAnnotation.annotationLinks <omero.model.TypeAnnotation>`, :ref:`XmlAnnotation.annotationLinks <omero.model.XmlAnnotation>`
+Used by: :ref:`Annotation.annotationLinks <Hibernate version of class omero.model.Annotation>`, :ref:`BasicAnnotation.annotationLinks <Hibernate version of class omero.model.BasicAnnotation>`, :ref:`BooleanAnnotation.annotationLinks <Hibernate version of class omero.model.BooleanAnnotation>`, :ref:`CommentAnnotation.annotationLinks <Hibernate version of class omero.model.CommentAnnotation>`, :ref:`DoubleAnnotation.annotationLinks <Hibernate version of class omero.model.DoubleAnnotation>`, :ref:`FileAnnotation.annotationLinks <Hibernate version of class omero.model.FileAnnotation>`, :ref:`ListAnnotation.annotationLinks <Hibernate version of class omero.model.ListAnnotation>`, :ref:`LongAnnotation.annotationLinks <Hibernate version of class omero.model.LongAnnotation>`, :ref:`MapAnnotation.annotationLinks <Hibernate version of class omero.model.MapAnnotation>`, :ref:`NumericAnnotation.annotationLinks <Hibernate version of class omero.model.NumericAnnotation>`, :ref:`TagAnnotation.annotationLinks <Hibernate version of class omero.model.TagAnnotation>`, :ref:`TermAnnotation.annotationLinks <Hibernate version of class omero.model.TermAnnotation>`, :ref:`TextAnnotation.annotationLinks <Hibernate version of class omero.model.TextAnnotation>`, :ref:`TimestampAnnotation.annotationLinks <Hibernate version of class omero.model.TimestampAnnotation>`, :ref:`TypeAnnotation.annotationLinks <Hibernate version of class omero.model.TypeAnnotation>`, :ref:`XmlAnnotation.annotationLinks <Hibernate version of class omero.model.XmlAnnotation>`
 
 Properties:
-  | child: :ref:`Annotation <omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`Annotation <omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.Arc:
+.. _Hibernate version of class omero.model.Arc:
 
 Arc
 """
 
 Properties:
-  | annotationLinks: :ref:`LightSourceAnnotationLink <omero.model.LightSourceAnnotationLink>` (multiple) from :ref:`LightSource <omero.model.LightSource>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`LightSource <omero.model.LightSource>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`LightSource <omero.model.LightSource>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`LightSource <omero.model.LightSource>`
-  | details.permissions.perm1: ``long`` from :ref:`LightSource <omero.model.LightSource>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`LightSource <omero.model.LightSource>`
-  | instrument: :ref:`Instrument <omero.model.Instrument>` from :ref:`LightSource <omero.model.LightSource>`
-  | lotNumber: ``string`` (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | manufacturer: ``string`` (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | model: ``string`` (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | power.unit: enumeration (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | power.value: ``double`` (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | serialNumber: ``string`` (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | type: :ref:`ArcType <omero.model.ArcType>`
-  | version: ``integer`` (optional) from :ref:`LightSource <omero.model.LightSource>`
+  | annotationLinks: :ref:`LightSourceAnnotationLink <Hibernate version of class omero.model.LightSourceAnnotationLink>` (multiple) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | details.permissions.perm1: ``long`` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | instrument: :ref:`Instrument <Hibernate version of class omero.model.Instrument>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | lotNumber: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | manufacturer: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | model: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | power.unit: enumeration (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | power.value: ``double`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | serialNumber: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | type: :ref:`ArcType <Hibernate version of class omero.model.ArcType>`
+  | version: ``integer`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
 
-.. _omero.model.ArcType:
+.. _Hibernate version of class omero.model.ArcType:
 
 ArcType
 """""""
 
-Used by: :ref:`Arc.type <omero.model.Arc>`
+Used by: :ref:`Arc.type <Hibernate version of class omero.model.Arc>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
 
-.. _omero.model.BasicAnnotation:
+.. _Hibernate version of class omero.model.BasicAnnotation:
 
 BasicAnnotation
 """""""""""""""
 
-Subclasses: :ref:`BooleanAnnotation <omero.model.BooleanAnnotation>`, :ref:`NumericAnnotation <omero.model.NumericAnnotation>`, :ref:`TermAnnotation <omero.model.TermAnnotation>`, :ref:`TimestampAnnotation <omero.model.TimestampAnnotation>`
+Subclasses: :ref:`BooleanAnnotation <Hibernate version of class omero.model.BooleanAnnotation>`, :ref:`NumericAnnotation <Hibernate version of class omero.model.NumericAnnotation>`, :ref:`TermAnnotation <Hibernate version of class omero.model.TermAnnotation>`, :ref:`TimestampAnnotation <Hibernate version of class omero.model.TimestampAnnotation>`
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <omero.model.Annotation>`
-  | description: ``text`` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.permissions.perm1: ``long`` from :ref:`Annotation <omero.model.Annotation>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Annotation <omero.model.Annotation>`
-  | ns: ``string`` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | version: ``integer`` (optional) from :ref:`Annotation <omero.model.Annotation>`
+  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | description: ``text`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.permissions.perm1: ``long`` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | name: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | ns: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | version: ``integer`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
 
-.. _omero.model.Binning:
+.. _Hibernate version of class omero.model.Binning:
 
 Binning
 """""""
 
-Used by: :ref:`DetectorSettings.binning <omero.model.DetectorSettings>`
+Used by: :ref:`DetectorSettings.binning <Hibernate version of class omero.model.DetectorSettings>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
 
-.. _omero.model.BooleanAnnotation:
+.. _Hibernate version of class omero.model.BooleanAnnotation:
 
 BooleanAnnotation
 """""""""""""""""
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <omero.model.Annotation>`
+  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
   | boolValue: ``boolean`` (optional)
-  | description: ``text`` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.permissions.perm1: ``long`` from :ref:`Annotation <omero.model.Annotation>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Annotation <omero.model.Annotation>`
-  | ns: ``string`` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | version: ``integer`` (optional) from :ref:`Annotation <omero.model.Annotation>`
+  | description: ``text`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.permissions.perm1: ``long`` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | name: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | ns: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | version: ``integer`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
 
-.. _omero.model.Channel:
+.. _Hibernate version of class omero.model.Channel:
 
 Channel
 """""""
 
-Used by: :ref:`ChannelAnnotationLink.parent <omero.model.ChannelAnnotationLink>`, :ref:`LogicalChannel.channels <omero.model.LogicalChannel>`, :ref:`Pixels.channels <omero.model.Pixels>`
+Used by: :ref:`ChannelAnnotationLink.parent <Hibernate version of class omero.model.ChannelAnnotationLink>`, :ref:`LogicalChannel.channels <Hibernate version of class omero.model.LogicalChannel>`, :ref:`Pixels.channels <Hibernate version of class omero.model.Pixels>`
 
 Properties:
   | alpha: ``integer`` (optional)
-  | annotationLinks: :ref:`ChannelAnnotationLink <omero.model.ChannelAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`ChannelAnnotationLink <Hibernate version of class omero.model.ChannelAnnotationLink>` (multiple)
   | blue: ``integer`` (optional)
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
   | green: ``integer`` (optional)
-  | logicalChannel: :ref:`LogicalChannel <omero.model.LogicalChannel>`
-  | pixels: :ref:`Pixels <omero.model.Pixels>`
+  | logicalChannel: :ref:`LogicalChannel <Hibernate version of class omero.model.LogicalChannel>`
+  | pixels: :ref:`Pixels <Hibernate version of class omero.model.Pixels>`
   | red: ``integer`` (optional)
-  | statsInfo: :ref:`StatsInfo <omero.model.StatsInfo>` (optional)
+  | statsInfo: :ref:`StatsInfo <Hibernate version of class omero.model.StatsInfo>` (optional)
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.ChannelAnnotationLink:
+.. _Hibernate version of class omero.model.ChannelAnnotationLink:
 
 ChannelAnnotationLink
 """""""""""""""""""""
 
-Used by: :ref:`Channel.annotationLinks <omero.model.Channel>`
+Used by: :ref:`Channel.annotationLinks <Hibernate version of class omero.model.Channel>`
 
 Properties:
-  | child: :ref:`Annotation <omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`Channel <omero.model.Channel>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`Channel <Hibernate version of class omero.model.Channel>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.ChannelBinding:
+.. _Hibernate version of class omero.model.ChannelBinding:
 
 ChannelBinding
 """"""""""""""
 
-Used by: :ref:`RenderingDef.waveRendering <omero.model.RenderingDef>`
+Used by: :ref:`RenderingDef.waveRendering <Hibernate version of class omero.model.RenderingDef>`
 
 Properties:
   | active: ``boolean``
   | alpha: ``integer``
   | blue: ``integer``
   | coefficient: ``double``
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | family: :ref:`Family <omero.model.Family>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | family: :ref:`Family <Hibernate version of class omero.model.Family>`
   | green: ``integer``
   | inputEnd: ``double``
   | inputStart: ``double``
   | noiseReduction: ``boolean``
   | red: ``integer``
-  | renderingDef: :ref:`RenderingDef <omero.model.RenderingDef>`
+  | renderingDef: :ref:`RenderingDef <Hibernate version of class omero.model.RenderingDef>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.ChecksumAlgorithm:
+.. _Hibernate version of class omero.model.ChecksumAlgorithm:
 
 ChecksumAlgorithm
 """""""""""""""""
 
-Used by: :ref:`OriginalFile.hasher <omero.model.OriginalFile>`
+Used by: :ref:`OriginalFile.hasher <Hibernate version of class omero.model.OriginalFile>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
 
-.. _omero.model.CodomainMapContext:
+.. _Hibernate version of class omero.model.CodomainMapContext:
 
 CodomainMapContext
 """"""""""""""""""
 
-Subclasses: :ref:`ContrastStretchingContext <omero.model.ContrastStretchingContext>`, :ref:`PlaneSlicingContext <omero.model.PlaneSlicingContext>`, :ref:`ReverseIntensityContext <omero.model.ReverseIntensityContext>`
+Subclasses: :ref:`ContrastStretchingContext <Hibernate version of class omero.model.ContrastStretchingContext>`, :ref:`PlaneSlicingContext <Hibernate version of class omero.model.PlaneSlicingContext>`, :ref:`ReverseIntensityContext <Hibernate version of class omero.model.ReverseIntensityContext>`
 
-Used by: :ref:`RenderingDef.spatialDomainEnhancement <omero.model.RenderingDef>`
+Used by: :ref:`RenderingDef.spatialDomainEnhancement <Hibernate version of class omero.model.RenderingDef>`
 
 Properties:
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | renderingDef: :ref:`RenderingDef <omero.model.RenderingDef>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | renderingDef: :ref:`RenderingDef <Hibernate version of class omero.model.RenderingDef>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.CommentAnnotation:
+.. _Hibernate version of class omero.model.CommentAnnotation:
 
 CommentAnnotation
 """""""""""""""""
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <omero.model.Annotation>`
-  | description: ``text`` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.permissions.perm1: ``long`` from :ref:`Annotation <omero.model.Annotation>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Annotation <omero.model.Annotation>`
-  | ns: ``string`` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | textValue: ``text`` (optional) from :ref:`TextAnnotation <omero.model.TextAnnotation>`
-  | version: ``integer`` (optional) from :ref:`Annotation <omero.model.Annotation>`
+  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | description: ``text`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.permissions.perm1: ``long`` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | name: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | ns: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | textValue: ``text`` (optional) from :ref:`TextAnnotation <Hibernate version of class omero.model.TextAnnotation>`
+  | version: ``integer`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
 
-.. _omero.model.ContrastMethod:
+.. _Hibernate version of class omero.model.ContrastMethod:
 
 ContrastMethod
 """"""""""""""
 
-Used by: :ref:`LogicalChannel.contrastMethod <omero.model.LogicalChannel>`
+Used by: :ref:`LogicalChannel.contrastMethod <Hibernate version of class omero.model.LogicalChannel>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
 
-.. _omero.model.ContrastStretchingContext:
+.. _Hibernate version of class omero.model.ContrastStretchingContext:
 
 ContrastStretchingContext
 """""""""""""""""""""""""
 
 Properties:
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`CodomainMapContext <omero.model.CodomainMapContext>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`CodomainMapContext <omero.model.CodomainMapContext>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`CodomainMapContext <omero.model.CodomainMapContext>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`CodomainMapContext <omero.model.CodomainMapContext>`
-  | details.permissions.perm1: ``long`` from :ref:`CodomainMapContext <omero.model.CodomainMapContext>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`CodomainMapContext <omero.model.CodomainMapContext>`
-  | renderingDef: :ref:`RenderingDef <omero.model.RenderingDef>` from :ref:`CodomainMapContext <omero.model.CodomainMapContext>`
-  | version: ``integer`` (optional) from :ref:`CodomainMapContext <omero.model.CodomainMapContext>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
+  | details.permissions.perm1: ``long`` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
+  | renderingDef: :ref:`RenderingDef <Hibernate version of class omero.model.RenderingDef>` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
+  | version: ``integer`` (optional) from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
   | xend: ``integer``
   | xstart: ``integer``
   | yend: ``integer``
   | ystart: ``integer``
 
-.. _omero.model.Correction:
+.. _Hibernate version of class omero.model.Correction:
 
 Correction
 """"""""""
 
-Used by: :ref:`Objective.correction <omero.model.Objective>`
+Used by: :ref:`Objective.correction <Hibernate version of class omero.model.Objective>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
 
-.. _omero.model.DBPatch:
+.. _Hibernate version of class omero.model.DBPatch:
 
 DBPatch
 """""""
@@ -319,133 +323,133 @@ DBPatch
 Properties:
   | currentPatch: ``integer``
   | currentVersion: ``string``
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | finished: ``timestamp`` (optional)
   | message: ``string`` (optional)
   | previousPatch: ``integer``
   | previousVersion: ``string``
 
-.. _omero.model.Dataset:
+.. _Hibernate version of class omero.model.Dataset:
 
 Dataset
 """""""
 
-Used by: :ref:`DatasetAnnotationLink.parent <omero.model.DatasetAnnotationLink>`, :ref:`DatasetImageLink.parent <omero.model.DatasetImageLink>`, :ref:`ProjectDatasetLink.child <omero.model.ProjectDatasetLink>`
+Used by: :ref:`DatasetAnnotationLink.parent <Hibernate version of class omero.model.DatasetAnnotationLink>`, :ref:`DatasetImageLink.parent <Hibernate version of class omero.model.DatasetImageLink>`, :ref:`ProjectDatasetLink.child <Hibernate version of class omero.model.ProjectDatasetLink>`
 
 Properties:
-  | annotationLinks: :ref:`DatasetAnnotationLink <omero.model.DatasetAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`DatasetAnnotationLink <Hibernate version of class omero.model.DatasetAnnotationLink>` (multiple)
   | description: ``text`` (optional)
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | imageLinks: :ref:`DatasetImageLink <omero.model.DatasetImageLink>` (multiple)
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | imageLinks: :ref:`DatasetImageLink <Hibernate version of class omero.model.DatasetImageLink>` (multiple)
   | name: ``string``
-  | projectLinks: :ref:`ProjectDatasetLink <omero.model.ProjectDatasetLink>` (multiple)
+  | projectLinks: :ref:`ProjectDatasetLink <Hibernate version of class omero.model.ProjectDatasetLink>` (multiple)
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.DatasetAnnotationLink:
+.. _Hibernate version of class omero.model.DatasetAnnotationLink:
 
 DatasetAnnotationLink
 """""""""""""""""""""
 
-Used by: :ref:`Dataset.annotationLinks <omero.model.Dataset>`
+Used by: :ref:`Dataset.annotationLinks <Hibernate version of class omero.model.Dataset>`
 
 Properties:
-  | child: :ref:`Annotation <omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`Dataset <omero.model.Dataset>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`Dataset <Hibernate version of class omero.model.Dataset>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.DatasetImageLink:
+.. _Hibernate version of class omero.model.DatasetImageLink:
 
 DatasetImageLink
 """"""""""""""""
 
-Used by: :ref:`Dataset.imageLinks <omero.model.Dataset>`, :ref:`Image.datasetLinks <omero.model.Image>`
+Used by: :ref:`Dataset.imageLinks <Hibernate version of class omero.model.Dataset>`, :ref:`Image.datasetLinks <Hibernate version of class omero.model.Image>`
 
 Properties:
-  | child: :ref:`Image <omero.model.Image>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Image <Hibernate version of class omero.model.Image>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`Dataset <omero.model.Dataset>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`Dataset <Hibernate version of class omero.model.Dataset>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.Detector:
+.. _Hibernate version of class omero.model.Detector:
 
 Detector
 """"""""
 
-Used by: :ref:`DetectorAnnotationLink.parent <omero.model.DetectorAnnotationLink>`, :ref:`DetectorSettings.detector <omero.model.DetectorSettings>`, :ref:`Instrument.detector <omero.model.Instrument>`
+Used by: :ref:`DetectorAnnotationLink.parent <Hibernate version of class omero.model.DetectorAnnotationLink>`, :ref:`DetectorSettings.detector <Hibernate version of class omero.model.DetectorSettings>`, :ref:`Instrument.detector <Hibernate version of class omero.model.Instrument>`
 
 Properties:
   | amplificationGain: ``double`` (optional)
-  | annotationLinks: :ref:`DetectorAnnotationLink <omero.model.DetectorAnnotationLink>` (multiple)
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | annotationLinks: :ref:`DetectorAnnotationLink <Hibernate version of class omero.model.DetectorAnnotationLink>` (multiple)
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
   | gain: ``double`` (optional)
-  | instrument: :ref:`Instrument <omero.model.Instrument>`
+  | instrument: :ref:`Instrument <Hibernate version of class omero.model.Instrument>`
   | lotNumber: ``string`` (optional)
   | manufacturer: ``string`` (optional)
   | model: ``string`` (optional)
   | offsetValue: ``double`` (optional)
   | serialNumber: ``string`` (optional)
-  | type: :ref:`DetectorType <omero.model.DetectorType>`
+  | type: :ref:`DetectorType <Hibernate version of class omero.model.DetectorType>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
   | voltage.unit: enumeration (optional)
   | voltage.value: ``double`` (optional)
   | zoom: ``double`` (optional)
 
-.. _omero.model.DetectorAnnotationLink:
+.. _Hibernate version of class omero.model.DetectorAnnotationLink:
 
 DetectorAnnotationLink
 """"""""""""""""""""""
 
-Used by: :ref:`Detector.annotationLinks <omero.model.Detector>`
+Used by: :ref:`Detector.annotationLinks <Hibernate version of class omero.model.Detector>`
 
 Properties:
-  | child: :ref:`Annotation <omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`Detector <omero.model.Detector>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`Detector <Hibernate version of class omero.model.Detector>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.DetectorSettings:
+.. _Hibernate version of class omero.model.DetectorSettings:
 
 DetectorSettings
 """"""""""""""""
 
-Used by: :ref:`LogicalChannel.detectorSettings <omero.model.LogicalChannel>`
+Used by: :ref:`LogicalChannel.detectorSettings <Hibernate version of class omero.model.LogicalChannel>`
 
 Properties:
-  | binning: :ref:`Binning <omero.model.Binning>` (optional)
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | binning: :ref:`Binning <Hibernate version of class omero.model.Binning>` (optional)
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | detector: :ref:`Detector <omero.model.Detector>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | detector: :ref:`Detector <Hibernate version of class omero.model.Detector>`
   | gain: ``double`` (optional)
   | integration: ``integer`` (optional)
   | offsetValue: ``double`` (optional)
@@ -456,225 +460,226 @@ Properties:
   | voltage.value: ``double`` (optional)
   | zoom: ``double`` (optional)
 
-.. _omero.model.DetectorType:
+.. _Hibernate version of class omero.model.DetectorType:
 
 DetectorType
 """"""""""""
 
-Used by: :ref:`Detector.type <omero.model.Detector>`
+Used by: :ref:`Detector.type <Hibernate version of class omero.model.Detector>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
 
-.. _omero.model.Dichroic:
+.. _Hibernate version of class omero.model.Dichroic:
 
 Dichroic
 """"""""
 
-Used by: :ref:`DichroicAnnotationLink.parent <omero.model.DichroicAnnotationLink>`, :ref:`FilterSet.dichroic <omero.model.FilterSet>`, :ref:`Instrument.dichroic <omero.model.Instrument>`, :ref:`LightPath.dichroic <omero.model.LightPath>`
+Used by: :ref:`DichroicAnnotationLink.parent <Hibernate version of class omero.model.DichroicAnnotationLink>`, :ref:`FilterSet.dichroic <Hibernate version of class omero.model.FilterSet>`, :ref:`Instrument.dichroic <Hibernate version of class omero.model.Instrument>`, :ref:`LightPath.dichroic <Hibernate version of class omero.model.LightPath>`
 
 Properties:
-  | annotationLinks: :ref:`DichroicAnnotationLink <omero.model.DichroicAnnotationLink>` (multiple)
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | annotationLinks: :ref:`DichroicAnnotationLink <Hibernate version of class omero.model.DichroicAnnotationLink>` (multiple)
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | instrument: :ref:`Instrument <omero.model.Instrument>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | instrument: :ref:`Instrument <Hibernate version of class omero.model.Instrument>`
   | lotNumber: ``string`` (optional)
   | manufacturer: ``string`` (optional)
   | model: ``string`` (optional)
   | serialNumber: ``string`` (optional)
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.DichroicAnnotationLink:
+.. _Hibernate version of class omero.model.DichroicAnnotationLink:
 
 DichroicAnnotationLink
 """"""""""""""""""""""
 
-Used by: :ref:`Dichroic.annotationLinks <omero.model.Dichroic>`
+Used by: :ref:`Dichroic.annotationLinks <Hibernate version of class omero.model.Dichroic>`
 
 Properties:
-  | child: :ref:`Annotation <omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`Dichroic <omero.model.Dichroic>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`Dichroic <Hibernate version of class omero.model.Dichroic>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.DimensionOrder:
+.. _Hibernate version of class omero.model.DimensionOrder:
 
 DimensionOrder
 """"""""""""""
 
-Used by: :ref:`Pixels.dimensionOrder <omero.model.Pixels>`
+Used by: :ref:`Pixels.dimensionOrder <Hibernate version of class omero.model.Pixels>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
 
-.. _omero.model.DoubleAnnotation:
+.. _Hibernate version of class omero.model.DoubleAnnotation:
 
 DoubleAnnotation
 """"""""""""""""
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <omero.model.Annotation>`
-  | description: ``text`` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.permissions.perm1: ``long`` from :ref:`Annotation <omero.model.Annotation>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Annotation <omero.model.Annotation>`
+  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | description: ``text`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.permissions.perm1: ``long`` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
   | doubleValue: ``double`` (optional)
-  | ns: ``string`` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | version: ``integer`` (optional) from :ref:`Annotation <omero.model.Annotation>`
+  | name: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | ns: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | version: ``integer`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
 
-.. _omero.model.Ellipse:
+.. _Hibernate version of class omero.model.Ellipse:
 
 Ellipse
 """""""
 
 Properties:
-  | annotationLinks: :ref:`ShapeAnnotationLink <omero.model.ShapeAnnotationLink>` (multiple) from :ref:`Shape <omero.model.Shape>`
+  | annotationLinks: :ref:`ShapeAnnotationLink <Hibernate version of class omero.model.ShapeAnnotationLink>` (multiple) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
   | cx: ``double`` (optional)
   | cy: ``double`` (optional)
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Shape <omero.model.Shape>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Shape <omero.model.Shape>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Shape <omero.model.Shape>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Shape <omero.model.Shape>`
-  | details.permissions.perm1: ``long`` from :ref:`Shape <omero.model.Shape>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Shape <omero.model.Shape>`
-  | fillColor: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fillRule: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontFamily: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontSize.unit: enumeration (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontSize.value: ``double`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontStretch: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontStyle: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontVariant: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontWeight: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | g: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | locked: ``boolean`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | roi: :ref:`Roi <omero.model.Roi>` from :ref:`Shape <omero.model.Shape>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.permissions.perm1: ``long`` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fillColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fillRule: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontFamily: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontSize.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontSize.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontStretch: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontStyle: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontVariant: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontWeight: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | g: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | locked: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | roi: :ref:`Roi <Hibernate version of class omero.model.Roi>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
   | rx: ``double`` (optional)
   | ry: ``double`` (optional)
-  | strokeColor: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeDashArray: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeLineCap: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeWidth.unit: enumeration (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <omero.model.Shape>`
+  | strokeColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeDashArray: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeLineCap: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeWidth.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
   | textValue: ``text`` (optional)
-  | theC: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | theT: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | theZ: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | transform: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | vectorEffect: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | version: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | visibility: ``boolean`` (optional) from :ref:`Shape <omero.model.Shape>`
+  | theC: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | theT: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | theZ: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | transform: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | vectorEffect: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | version: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | visibility: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
 
-.. _omero.model.Event:
+.. _Hibernate version of class omero.model.Event:
 
 Event
 """""
 
-Used by: :ref:`Annotation.details.creationEvent <omero.model.Annotation>`, :ref:`Annotation.details.updateEvent <omero.model.Annotation>`, :ref:`AnnotationAnnotationLink.details.creationEvent <omero.model.AnnotationAnnotationLink>`, :ref:`AnnotationAnnotationLink.details.updateEvent <omero.model.AnnotationAnnotationLink>`, :ref:`Arc.details.creationEvent <omero.model.Arc>`, :ref:`Arc.details.updateEvent <omero.model.Arc>`, :ref:`BasicAnnotation.details.creationEvent <omero.model.BasicAnnotation>`, :ref:`BasicAnnotation.details.updateEvent <omero.model.BasicAnnotation>`, :ref:`BooleanAnnotation.details.creationEvent <omero.model.BooleanAnnotation>`, :ref:`BooleanAnnotation.details.updateEvent <omero.model.BooleanAnnotation>`, :ref:`Channel.details.creationEvent <omero.model.Channel>`, :ref:`Channel.details.updateEvent <omero.model.Channel>`, :ref:`ChannelAnnotationLink.details.creationEvent <omero.model.ChannelAnnotationLink>`, :ref:`ChannelAnnotationLink.details.updateEvent <omero.model.ChannelAnnotationLink>`, :ref:`ChannelBinding.details.creationEvent <omero.model.ChannelBinding>`, :ref:`ChannelBinding.details.updateEvent <omero.model.ChannelBinding>`, :ref:`CodomainMapContext.details.creationEvent <omero.model.CodomainMapContext>`, :ref:`CodomainMapContext.details.updateEvent <omero.model.CodomainMapContext>`, :ref:`CommentAnnotation.details.creationEvent <omero.model.CommentAnnotation>`, :ref:`CommentAnnotation.details.updateEvent <omero.model.CommentAnnotation>`, :ref:`ContrastStretchingContext.details.creationEvent <omero.model.ContrastStretchingContext>`, :ref:`ContrastStretchingContext.details.updateEvent <omero.model.ContrastStretchingContext>`, :ref:`Dataset.details.creationEvent <omero.model.Dataset>`, :ref:`Dataset.details.updateEvent <omero.model.Dataset>`, :ref:`DatasetAnnotationLink.details.creationEvent <omero.model.DatasetAnnotationLink>`, :ref:`DatasetAnnotationLink.details.updateEvent <omero.model.DatasetAnnotationLink>`, :ref:`DatasetImageLink.details.creationEvent <omero.model.DatasetImageLink>`, :ref:`DatasetImageLink.details.updateEvent <omero.model.DatasetImageLink>`, :ref:`Detector.details.creationEvent <omero.model.Detector>`, :ref:`Detector.details.updateEvent <omero.model.Detector>`, :ref:`DetectorAnnotationLink.details.creationEvent <omero.model.DetectorAnnotationLink>`, :ref:`DetectorAnnotationLink.details.updateEvent <omero.model.DetectorAnnotationLink>`, :ref:`DetectorSettings.details.creationEvent <omero.model.DetectorSettings>`, :ref:`DetectorSettings.details.updateEvent <omero.model.DetectorSettings>`, :ref:`Dichroic.details.creationEvent <omero.model.Dichroic>`, :ref:`Dichroic.details.updateEvent <omero.model.Dichroic>`, :ref:`DichroicAnnotationLink.details.creationEvent <omero.model.DichroicAnnotationLink>`, :ref:`DichroicAnnotationLink.details.updateEvent <omero.model.DichroicAnnotationLink>`, :ref:`DoubleAnnotation.details.creationEvent <omero.model.DoubleAnnotation>`, :ref:`DoubleAnnotation.details.updateEvent <omero.model.DoubleAnnotation>`, :ref:`Ellipse.details.creationEvent <omero.model.Ellipse>`, :ref:`Ellipse.details.updateEvent <omero.model.Ellipse>`, :ref:`Event.containingEvent <omero.model.Event>`, :ref:`EventLog.event <omero.model.EventLog>`, :ref:`Experiment.details.creationEvent <omero.model.Experiment>`, :ref:`Experiment.details.updateEvent <omero.model.Experiment>`, :ref:`ExperimenterAnnotationLink.details.creationEvent <omero.model.ExperimenterAnnotationLink>`, :ref:`ExperimenterAnnotationLink.details.updateEvent <omero.model.ExperimenterAnnotationLink>`, :ref:`ExperimenterGroupAnnotationLink.details.creationEvent <omero.model.ExperimenterGroupAnnotationLink>`, :ref:`ExperimenterGroupAnnotationLink.details.updateEvent <omero.model.ExperimenterGroupAnnotationLink>`, :ref:`ExternalInfo.details.creationEvent <omero.model.ExternalInfo>`, :ref:`Filament.details.creationEvent <omero.model.Filament>`, :ref:`Filament.details.updateEvent <omero.model.Filament>`, :ref:`FileAnnotation.details.creationEvent <omero.model.FileAnnotation>`, :ref:`FileAnnotation.details.updateEvent <omero.model.FileAnnotation>`, :ref:`Fileset.details.creationEvent <omero.model.Fileset>`, :ref:`Fileset.details.updateEvent <omero.model.Fileset>`, :ref:`FilesetAnnotationLink.details.creationEvent <omero.model.FilesetAnnotationLink>`, :ref:`FilesetAnnotationLink.details.updateEvent <omero.model.FilesetAnnotationLink>`, :ref:`FilesetEntry.details.creationEvent <omero.model.FilesetEntry>`, :ref:`FilesetEntry.details.updateEvent <omero.model.FilesetEntry>`, :ref:`FilesetJobLink.details.creationEvent <omero.model.FilesetJobLink>`, :ref:`FilesetJobLink.details.updateEvent <omero.model.FilesetJobLink>`, :ref:`Filter.details.creationEvent <omero.model.Filter>`, :ref:`Filter.details.updateEvent <omero.model.Filter>`, :ref:`FilterAnnotationLink.details.creationEvent <omero.model.FilterAnnotationLink>`, :ref:`FilterAnnotationLink.details.updateEvent <omero.model.FilterAnnotationLink>`, :ref:`FilterSet.details.creationEvent <omero.model.FilterSet>`, :ref:`FilterSet.details.updateEvent <omero.model.FilterSet>`, :ref:`FilterSetEmissionFilterLink.details.creationEvent <omero.model.FilterSetEmissionFilterLink>`, :ref:`FilterSetEmissionFilterLink.details.updateEvent <omero.model.FilterSetEmissionFilterLink>`, :ref:`FilterSetExcitationFilterLink.details.creationEvent <omero.model.FilterSetExcitationFilterLink>`, :ref:`FilterSetExcitationFilterLink.details.updateEvent <omero.model.FilterSetExcitationFilterLink>`, :ref:`GenericExcitationSource.details.creationEvent <omero.model.GenericExcitationSource>`, :ref:`GenericExcitationSource.details.updateEvent <omero.model.GenericExcitationSource>`, :ref:`Image.details.creationEvent <omero.model.Image>`, :ref:`Image.details.updateEvent <omero.model.Image>`, :ref:`ImageAnnotationLink.details.creationEvent <omero.model.ImageAnnotationLink>`, :ref:`ImageAnnotationLink.details.updateEvent <omero.model.ImageAnnotationLink>`, :ref:`ImagingEnvironment.details.creationEvent <omero.model.ImagingEnvironment>`, :ref:`ImagingEnvironment.details.updateEvent <omero.model.ImagingEnvironment>`, :ref:`ImportJob.details.creationEvent <omero.model.ImportJob>`, :ref:`ImportJob.details.updateEvent <omero.model.ImportJob>`, :ref:`IndexingJob.details.creationEvent <omero.model.IndexingJob>`, :ref:`IndexingJob.details.updateEvent <omero.model.IndexingJob>`, :ref:`Instrument.details.creationEvent <omero.model.Instrument>`, :ref:`Instrument.details.updateEvent <omero.model.Instrument>`, :ref:`InstrumentAnnotationLink.details.creationEvent <omero.model.InstrumentAnnotationLink>`, :ref:`InstrumentAnnotationLink.details.updateEvent <omero.model.InstrumentAnnotationLink>`, :ref:`IntegrityCheckJob.details.creationEvent <omero.model.IntegrityCheckJob>`, :ref:`IntegrityCheckJob.details.updateEvent <omero.model.IntegrityCheckJob>`, :ref:`Job.details.creationEvent <omero.model.Job>`, :ref:`Job.details.updateEvent <omero.model.Job>`, :ref:`JobOriginalFileLink.details.creationEvent <omero.model.JobOriginalFileLink>`, :ref:`JobOriginalFileLink.details.updateEvent <omero.model.JobOriginalFileLink>`, :ref:`Label.details.creationEvent <omero.model.Label>`, :ref:`Label.details.updateEvent <omero.model.Label>`, :ref:`Laser.details.creationEvent <omero.model.Laser>`, :ref:`Laser.details.updateEvent <omero.model.Laser>`, :ref:`LightEmittingDiode.details.creationEvent <omero.model.LightEmittingDiode>`, :ref:`LightEmittingDiode.details.updateEvent <omero.model.LightEmittingDiode>`, :ref:`LightPath.details.creationEvent <omero.model.LightPath>`, :ref:`LightPath.details.updateEvent <omero.model.LightPath>`, :ref:`LightPathAnnotationLink.details.creationEvent <omero.model.LightPathAnnotationLink>`, :ref:`LightPathAnnotationLink.details.updateEvent <omero.model.LightPathAnnotationLink>`, :ref:`LightPathEmissionFilterLink.details.creationEvent <omero.model.LightPathEmissionFilterLink>`, :ref:`LightPathEmissionFilterLink.details.updateEvent <omero.model.LightPathEmissionFilterLink>`, :ref:`LightPathExcitationFilterLink.details.creationEvent <omero.model.LightPathExcitationFilterLink>`, :ref:`LightPathExcitationFilterLink.details.updateEvent <omero.model.LightPathExcitationFilterLink>`, :ref:`LightSettings.details.creationEvent <omero.model.LightSettings>`, :ref:`LightSettings.details.updateEvent <omero.model.LightSettings>`, :ref:`LightSource.details.creationEvent <omero.model.LightSource>`, :ref:`LightSource.details.updateEvent <omero.model.LightSource>`, :ref:`LightSourceAnnotationLink.details.creationEvent <omero.model.LightSourceAnnotationLink>`, :ref:`LightSourceAnnotationLink.details.updateEvent <omero.model.LightSourceAnnotationLink>`, :ref:`Line.details.creationEvent <omero.model.Line>`, :ref:`Line.details.updateEvent <omero.model.Line>`, :ref:`Link.details.creationEvent <omero.model.Link>`, :ref:`Link.details.updateEvent <omero.model.Link>`, :ref:`ListAnnotation.details.creationEvent <omero.model.ListAnnotation>`, :ref:`ListAnnotation.details.updateEvent <omero.model.ListAnnotation>`, :ref:`LogicalChannel.details.creationEvent <omero.model.LogicalChannel>`, :ref:`LogicalChannel.details.updateEvent <omero.model.LogicalChannel>`, :ref:`LongAnnotation.details.creationEvent <omero.model.LongAnnotation>`, :ref:`LongAnnotation.details.updateEvent <omero.model.LongAnnotation>`, :ref:`MapAnnotation.details.creationEvent <omero.model.MapAnnotation>`, :ref:`MapAnnotation.details.updateEvent <omero.model.MapAnnotation>`, :ref:`Mask.details.creationEvent <omero.model.Mask>`, :ref:`Mask.details.updateEvent <omero.model.Mask>`, :ref:`MetadataImportJob.details.creationEvent <omero.model.MetadataImportJob>`, :ref:`MetadataImportJob.details.updateEvent <omero.model.MetadataImportJob>`, :ref:`MicrobeamManipulation.details.creationEvent <omero.model.MicrobeamManipulation>`, :ref:`MicrobeamManipulation.details.updateEvent <omero.model.MicrobeamManipulation>`, :ref:`Microscope.details.creationEvent <omero.model.Microscope>`, :ref:`Microscope.details.updateEvent <omero.model.Microscope>`, :ref:`Namespace.details.creationEvent <omero.model.Namespace>`, :ref:`Namespace.details.updateEvent <omero.model.Namespace>`, :ref:`NamespaceAnnotationLink.details.creationEvent <omero.model.NamespaceAnnotationLink>`, :ref:`NamespaceAnnotationLink.details.updateEvent <omero.model.NamespaceAnnotationLink>`, :ref:`NodeAnnotationLink.details.creationEvent <omero.model.NodeAnnotationLink>`, :ref:`NodeAnnotationLink.details.updateEvent <omero.model.NodeAnnotationLink>`, :ref:`NumericAnnotation.details.creationEvent <omero.model.NumericAnnotation>`, :ref:`NumericAnnotation.details.updateEvent <omero.model.NumericAnnotation>`, :ref:`OTF.details.creationEvent <omero.model.OTF>`, :ref:`OTF.details.updateEvent <omero.model.OTF>`, :ref:`Objective.details.creationEvent <omero.model.Objective>`, :ref:`Objective.details.updateEvent <omero.model.Objective>`, :ref:`ObjectiveAnnotationLink.details.creationEvent <omero.model.ObjectiveAnnotationLink>`, :ref:`ObjectiveAnnotationLink.details.updateEvent <omero.model.ObjectiveAnnotationLink>`, :ref:`ObjectiveSettings.details.creationEvent <omero.model.ObjectiveSettings>`, :ref:`ObjectiveSettings.details.updateEvent <omero.model.ObjectiveSettings>`, :ref:`OriginalFile.details.creationEvent <omero.model.OriginalFile>`, :ref:`OriginalFile.details.updateEvent <omero.model.OriginalFile>`, :ref:`OriginalFileAnnotationLink.details.creationEvent <omero.model.OriginalFileAnnotationLink>`, :ref:`OriginalFileAnnotationLink.details.updateEvent <omero.model.OriginalFileAnnotationLink>`, :ref:`ParseJob.details.creationEvent <omero.model.ParseJob>`, :ref:`ParseJob.details.updateEvent <omero.model.ParseJob>`, :ref:`Path.details.creationEvent <omero.model.Path>`, :ref:`Path.details.updateEvent <omero.model.Path>`, :ref:`PixelDataJob.details.creationEvent <omero.model.PixelDataJob>`, :ref:`PixelDataJob.details.updateEvent <omero.model.PixelDataJob>`, :ref:`Pixels.details.creationEvent <omero.model.Pixels>`, :ref:`Pixels.details.updateEvent <omero.model.Pixels>`, :ref:`PixelsOriginalFileMap.details.creationEvent <omero.model.PixelsOriginalFileMap>`, :ref:`PixelsOriginalFileMap.details.updateEvent <omero.model.PixelsOriginalFileMap>`, :ref:`PlaneInfo.details.creationEvent <omero.model.PlaneInfo>`, :ref:`PlaneInfo.details.updateEvent <omero.model.PlaneInfo>`, :ref:`PlaneInfoAnnotationLink.details.creationEvent <omero.model.PlaneInfoAnnotationLink>`, :ref:`PlaneInfoAnnotationLink.details.updateEvent <omero.model.PlaneInfoAnnotationLink>`, :ref:`PlaneSlicingContext.details.creationEvent <omero.model.PlaneSlicingContext>`, :ref:`PlaneSlicingContext.details.updateEvent <omero.model.PlaneSlicingContext>`, :ref:`Plate.details.creationEvent <omero.model.Plate>`, :ref:`Plate.details.updateEvent <omero.model.Plate>`, :ref:`PlateAcquisition.details.creationEvent <omero.model.PlateAcquisition>`, :ref:`PlateAcquisition.details.updateEvent <omero.model.PlateAcquisition>`, :ref:`PlateAcquisitionAnnotationLink.details.creationEvent <omero.model.PlateAcquisitionAnnotationLink>`, :ref:`PlateAcquisitionAnnotationLink.details.updateEvent <omero.model.PlateAcquisitionAnnotationLink>`, :ref:`PlateAnnotationLink.details.creationEvent <omero.model.PlateAnnotationLink>`, :ref:`PlateAnnotationLink.details.updateEvent <omero.model.PlateAnnotationLink>`, :ref:`Point.details.creationEvent <omero.model.Point>`, :ref:`Point.details.updateEvent <omero.model.Point>`, :ref:`Polygon.details.creationEvent <omero.model.Polygon>`, :ref:`Polygon.details.updateEvent <omero.model.Polygon>`, :ref:`Polyline.details.creationEvent <omero.model.Polyline>`, :ref:`Polyline.details.updateEvent <omero.model.Polyline>`, :ref:`Project.details.creationEvent <omero.model.Project>`, :ref:`Project.details.updateEvent <omero.model.Project>`, :ref:`ProjectAnnotationLink.details.creationEvent <omero.model.ProjectAnnotationLink>`, :ref:`ProjectAnnotationLink.details.updateEvent <omero.model.ProjectAnnotationLink>`, :ref:`ProjectDatasetLink.details.creationEvent <omero.model.ProjectDatasetLink>`, :ref:`ProjectDatasetLink.details.updateEvent <omero.model.ProjectDatasetLink>`, :ref:`QuantumDef.details.creationEvent <omero.model.QuantumDef>`, :ref:`QuantumDef.details.updateEvent <omero.model.QuantumDef>`, :ref:`Reagent.details.creationEvent <omero.model.Reagent>`, :ref:`Reagent.details.updateEvent <omero.model.Reagent>`, :ref:`ReagentAnnotationLink.details.creationEvent <omero.model.ReagentAnnotationLink>`, :ref:`ReagentAnnotationLink.details.updateEvent <omero.model.ReagentAnnotationLink>`, :ref:`Rect.details.creationEvent <omero.model.Rect>`, :ref:`Rect.details.updateEvent <omero.model.Rect>`, :ref:`RenderingDef.details.creationEvent <omero.model.RenderingDef>`, :ref:`RenderingDef.details.updateEvent <omero.model.RenderingDef>`, :ref:`ReverseIntensityContext.details.creationEvent <omero.model.ReverseIntensityContext>`, :ref:`ReverseIntensityContext.details.updateEvent <omero.model.ReverseIntensityContext>`, :ref:`Roi.details.creationEvent <omero.model.Roi>`, :ref:`Roi.details.updateEvent <omero.model.Roi>`, :ref:`RoiAnnotationLink.details.creationEvent <omero.model.RoiAnnotationLink>`, :ref:`RoiAnnotationLink.details.updateEvent <omero.model.RoiAnnotationLink>`, :ref:`Screen.details.creationEvent <omero.model.Screen>`, :ref:`Screen.details.updateEvent <omero.model.Screen>`, :ref:`ScreenAnnotationLink.details.creationEvent <omero.model.ScreenAnnotationLink>`, :ref:`ScreenAnnotationLink.details.updateEvent <omero.model.ScreenAnnotationLink>`, :ref:`ScreenPlateLink.details.creationEvent <omero.model.ScreenPlateLink>`, :ref:`ScreenPlateLink.details.updateEvent <omero.model.ScreenPlateLink>`, :ref:`ScriptJob.details.creationEvent <omero.model.ScriptJob>`, :ref:`ScriptJob.details.updateEvent <omero.model.ScriptJob>`, :ref:`Session.events <omero.model.Session>`, :ref:`SessionAnnotationLink.details.creationEvent <omero.model.SessionAnnotationLink>`, :ref:`SessionAnnotationLink.details.updateEvent <omero.model.SessionAnnotationLink>`, :ref:`Shape.details.creationEvent <omero.model.Shape>`, :ref:`Shape.details.updateEvent <omero.model.Shape>`, :ref:`ShapeAnnotationLink.details.creationEvent <omero.model.ShapeAnnotationLink>`, :ref:`ShapeAnnotationLink.details.updateEvent <omero.model.ShapeAnnotationLink>`, :ref:`Share.events <omero.model.Share>`, :ref:`StageLabel.details.creationEvent <omero.model.StageLabel>`, :ref:`StageLabel.details.updateEvent <omero.model.StageLabel>`, :ref:`StatsInfo.details.creationEvent <omero.model.StatsInfo>`, :ref:`StatsInfo.details.updateEvent <omero.model.StatsInfo>`, :ref:`TagAnnotation.details.creationEvent <omero.model.TagAnnotation>`, :ref:`TagAnnotation.details.updateEvent <omero.model.TagAnnotation>`, :ref:`TermAnnotation.details.creationEvent <omero.model.TermAnnotation>`, :ref:`TermAnnotation.details.updateEvent <omero.model.TermAnnotation>`, :ref:`TextAnnotation.details.creationEvent <omero.model.TextAnnotation>`, :ref:`TextAnnotation.details.updateEvent <omero.model.TextAnnotation>`, :ref:`Thumbnail.details.creationEvent <omero.model.Thumbnail>`, :ref:`Thumbnail.details.updateEvent <omero.model.Thumbnail>`, :ref:`ThumbnailGenerationJob.details.creationEvent <omero.model.ThumbnailGenerationJob>`, :ref:`ThumbnailGenerationJob.details.updateEvent <omero.model.ThumbnailGenerationJob>`, :ref:`TimestampAnnotation.details.creationEvent <omero.model.TimestampAnnotation>`, :ref:`TimestampAnnotation.details.updateEvent <omero.model.TimestampAnnotation>`, :ref:`TransmittanceRange.details.creationEvent <omero.model.TransmittanceRange>`, :ref:`TransmittanceRange.details.updateEvent <omero.model.TransmittanceRange>`, :ref:`TypeAnnotation.details.creationEvent <omero.model.TypeAnnotation>`, :ref:`TypeAnnotation.details.updateEvent <omero.model.TypeAnnotation>`, :ref:`UploadJob.details.creationEvent <omero.model.UploadJob>`, :ref:`UploadJob.details.updateEvent <omero.model.UploadJob>`, :ref:`Well.details.creationEvent <omero.model.Well>`, :ref:`Well.details.updateEvent <omero.model.Well>`, :ref:`WellAnnotationLink.details.creationEvent <omero.model.WellAnnotationLink>`, :ref:`WellAnnotationLink.details.updateEvent <omero.model.WellAnnotationLink>`, :ref:`WellReagentLink.details.creationEvent <omero.model.WellReagentLink>`, :ref:`WellReagentLink.details.updateEvent <omero.model.WellReagentLink>`, :ref:`WellSample.details.creationEvent <omero.model.WellSample>`, :ref:`WellSample.details.updateEvent <omero.model.WellSample>`, :ref:`XmlAnnotation.details.creationEvent <omero.model.XmlAnnotation>`, :ref:`XmlAnnotation.details.updateEvent <omero.model.XmlAnnotation>`
+Used by: :ref:`Annotation.details.creationEvent <Hibernate version of class omero.model.Annotation>`, :ref:`Annotation.details.updateEvent <Hibernate version of class omero.model.Annotation>`, :ref:`AnnotationAnnotationLink.details.creationEvent <Hibernate version of class omero.model.AnnotationAnnotationLink>`, :ref:`AnnotationAnnotationLink.details.updateEvent <Hibernate version of class omero.model.AnnotationAnnotationLink>`, :ref:`Arc.details.creationEvent <Hibernate version of class omero.model.Arc>`, :ref:`Arc.details.updateEvent <Hibernate version of class omero.model.Arc>`, :ref:`BasicAnnotation.details.creationEvent <Hibernate version of class omero.model.BasicAnnotation>`, :ref:`BasicAnnotation.details.updateEvent <Hibernate version of class omero.model.BasicAnnotation>`, :ref:`BooleanAnnotation.details.creationEvent <Hibernate version of class omero.model.BooleanAnnotation>`, :ref:`BooleanAnnotation.details.updateEvent <Hibernate version of class omero.model.BooleanAnnotation>`, :ref:`Channel.details.creationEvent <Hibernate version of class omero.model.Channel>`, :ref:`Channel.details.updateEvent <Hibernate version of class omero.model.Channel>`, :ref:`ChannelAnnotationLink.details.creationEvent <Hibernate version of class omero.model.ChannelAnnotationLink>`, :ref:`ChannelAnnotationLink.details.updateEvent <Hibernate version of class omero.model.ChannelAnnotationLink>`, :ref:`ChannelBinding.details.creationEvent <Hibernate version of class omero.model.ChannelBinding>`, :ref:`ChannelBinding.details.updateEvent <Hibernate version of class omero.model.ChannelBinding>`, :ref:`CodomainMapContext.details.creationEvent <Hibernate version of class omero.model.CodomainMapContext>`, :ref:`CodomainMapContext.details.updateEvent <Hibernate version of class omero.model.CodomainMapContext>`, :ref:`CommentAnnotation.details.creationEvent <Hibernate version of class omero.model.CommentAnnotation>`, :ref:`CommentAnnotation.details.updateEvent <Hibernate version of class omero.model.CommentAnnotation>`, :ref:`ContrastStretchingContext.details.creationEvent <Hibernate version of class omero.model.ContrastStretchingContext>`, :ref:`ContrastStretchingContext.details.updateEvent <Hibernate version of class omero.model.ContrastStretchingContext>`, :ref:`Dataset.details.creationEvent <Hibernate version of class omero.model.Dataset>`, :ref:`Dataset.details.updateEvent <Hibernate version of class omero.model.Dataset>`, :ref:`DatasetAnnotationLink.details.creationEvent <Hibernate version of class omero.model.DatasetAnnotationLink>`, :ref:`DatasetAnnotationLink.details.updateEvent <Hibernate version of class omero.model.DatasetAnnotationLink>`, :ref:`DatasetImageLink.details.creationEvent <Hibernate version of class omero.model.DatasetImageLink>`, :ref:`DatasetImageLink.details.updateEvent <Hibernate version of class omero.model.DatasetImageLink>`, :ref:`Detector.details.creationEvent <Hibernate version of class omero.model.Detector>`, :ref:`Detector.details.updateEvent <Hibernate version of class omero.model.Detector>`, :ref:`DetectorAnnotationLink.details.creationEvent <Hibernate version of class omero.model.DetectorAnnotationLink>`, :ref:`DetectorAnnotationLink.details.updateEvent <Hibernate version of class omero.model.DetectorAnnotationLink>`, :ref:`DetectorSettings.details.creationEvent <Hibernate version of class omero.model.DetectorSettings>`, :ref:`DetectorSettings.details.updateEvent <Hibernate version of class omero.model.DetectorSettings>`, :ref:`Dichroic.details.creationEvent <Hibernate version of class omero.model.Dichroic>`, :ref:`Dichroic.details.updateEvent <Hibernate version of class omero.model.Dichroic>`, :ref:`DichroicAnnotationLink.details.creationEvent <Hibernate version of class omero.model.DichroicAnnotationLink>`, :ref:`DichroicAnnotationLink.details.updateEvent <Hibernate version of class omero.model.DichroicAnnotationLink>`, :ref:`DoubleAnnotation.details.creationEvent <Hibernate version of class omero.model.DoubleAnnotation>`, :ref:`DoubleAnnotation.details.updateEvent <Hibernate version of class omero.model.DoubleAnnotation>`, :ref:`Ellipse.details.creationEvent <Hibernate version of class omero.model.Ellipse>`, :ref:`Ellipse.details.updateEvent <Hibernate version of class omero.model.Ellipse>`, :ref:`Event.containingEvent <Hibernate version of class omero.model.Event>`, :ref:`EventLog.event <Hibernate version of class omero.model.EventLog>`, :ref:`Experiment.details.creationEvent <Hibernate version of class omero.model.Experiment>`, :ref:`Experiment.details.updateEvent <Hibernate version of class omero.model.Experiment>`, :ref:`ExperimenterAnnotationLink.details.creationEvent <Hibernate version of class omero.model.ExperimenterAnnotationLink>`, :ref:`ExperimenterAnnotationLink.details.updateEvent <Hibernate version of class omero.model.ExperimenterAnnotationLink>`, :ref:`ExperimenterGroupAnnotationLink.details.creationEvent <Hibernate version of class omero.model.ExperimenterGroupAnnotationLink>`, :ref:`ExperimenterGroupAnnotationLink.details.updateEvent <Hibernate version of class omero.model.ExperimenterGroupAnnotationLink>`, :ref:`ExternalInfo.details.creationEvent <Hibernate version of class omero.model.ExternalInfo>`, :ref:`Filament.details.creationEvent <Hibernate version of class omero.model.Filament>`, :ref:`Filament.details.updateEvent <Hibernate version of class omero.model.Filament>`, :ref:`FileAnnotation.details.creationEvent <Hibernate version of class omero.model.FileAnnotation>`, :ref:`FileAnnotation.details.updateEvent <Hibernate version of class omero.model.FileAnnotation>`, :ref:`Fileset.details.creationEvent <Hibernate version of class omero.model.Fileset>`, :ref:`Fileset.details.updateEvent <Hibernate version of class omero.model.Fileset>`, :ref:`FilesetAnnotationLink.details.creationEvent <Hibernate version of class omero.model.FilesetAnnotationLink>`, :ref:`FilesetAnnotationLink.details.updateEvent <Hibernate version of class omero.model.FilesetAnnotationLink>`, :ref:`FilesetEntry.details.creationEvent <Hibernate version of class omero.model.FilesetEntry>`, :ref:`FilesetEntry.details.updateEvent <Hibernate version of class omero.model.FilesetEntry>`, :ref:`FilesetJobLink.details.creationEvent <Hibernate version of class omero.model.FilesetJobLink>`, :ref:`FilesetJobLink.details.updateEvent <Hibernate version of class omero.model.FilesetJobLink>`, :ref:`Filter.details.creationEvent <Hibernate version of class omero.model.Filter>`, :ref:`Filter.details.updateEvent <Hibernate version of class omero.model.Filter>`, :ref:`FilterAnnotationLink.details.creationEvent <Hibernate version of class omero.model.FilterAnnotationLink>`, :ref:`FilterAnnotationLink.details.updateEvent <Hibernate version of class omero.model.FilterAnnotationLink>`, :ref:`FilterSet.details.creationEvent <Hibernate version of class omero.model.FilterSet>`, :ref:`FilterSet.details.updateEvent <Hibernate version of class omero.model.FilterSet>`, :ref:`FilterSetEmissionFilterLink.details.creationEvent <Hibernate version of class omero.model.FilterSetEmissionFilterLink>`, :ref:`FilterSetEmissionFilterLink.details.updateEvent <Hibernate version of class omero.model.FilterSetEmissionFilterLink>`, :ref:`FilterSetExcitationFilterLink.details.creationEvent <Hibernate version of class omero.model.FilterSetExcitationFilterLink>`, :ref:`FilterSetExcitationFilterLink.details.updateEvent <Hibernate version of class omero.model.FilterSetExcitationFilterLink>`, :ref:`GenericExcitationSource.details.creationEvent <Hibernate version of class omero.model.GenericExcitationSource>`, :ref:`GenericExcitationSource.details.updateEvent <Hibernate version of class omero.model.GenericExcitationSource>`, :ref:`Image.details.creationEvent <Hibernate version of class omero.model.Image>`, :ref:`Image.details.updateEvent <Hibernate version of class omero.model.Image>`, :ref:`ImageAnnotationLink.details.creationEvent <Hibernate version of class omero.model.ImageAnnotationLink>`, :ref:`ImageAnnotationLink.details.updateEvent <Hibernate version of class omero.model.ImageAnnotationLink>`, :ref:`ImagingEnvironment.details.creationEvent <Hibernate version of class omero.model.ImagingEnvironment>`, :ref:`ImagingEnvironment.details.updateEvent <Hibernate version of class omero.model.ImagingEnvironment>`, :ref:`ImportJob.details.creationEvent <Hibernate version of class omero.model.ImportJob>`, :ref:`ImportJob.details.updateEvent <Hibernate version of class omero.model.ImportJob>`, :ref:`IndexingJob.details.creationEvent <Hibernate version of class omero.model.IndexingJob>`, :ref:`IndexingJob.details.updateEvent <Hibernate version of class omero.model.IndexingJob>`, :ref:`Instrument.details.creationEvent <Hibernate version of class omero.model.Instrument>`, :ref:`Instrument.details.updateEvent <Hibernate version of class omero.model.Instrument>`, :ref:`InstrumentAnnotationLink.details.creationEvent <Hibernate version of class omero.model.InstrumentAnnotationLink>`, :ref:`InstrumentAnnotationLink.details.updateEvent <Hibernate version of class omero.model.InstrumentAnnotationLink>`, :ref:`IntegrityCheckJob.details.creationEvent <Hibernate version of class omero.model.IntegrityCheckJob>`, :ref:`IntegrityCheckJob.details.updateEvent <Hibernate version of class omero.model.IntegrityCheckJob>`, :ref:`Job.details.creationEvent <Hibernate version of class omero.model.Job>`, :ref:`Job.details.updateEvent <Hibernate version of class omero.model.Job>`, :ref:`JobOriginalFileLink.details.creationEvent <Hibernate version of class omero.model.JobOriginalFileLink>`, :ref:`JobOriginalFileLink.details.updateEvent <Hibernate version of class omero.model.JobOriginalFileLink>`, :ref:`Label.details.creationEvent <Hibernate version of class omero.model.Label>`, :ref:`Label.details.updateEvent <Hibernate version of class omero.model.Label>`, :ref:`Laser.details.creationEvent <Hibernate version of class omero.model.Laser>`, :ref:`Laser.details.updateEvent <Hibernate version of class omero.model.Laser>`, :ref:`LightEmittingDiode.details.creationEvent <Hibernate version of class omero.model.LightEmittingDiode>`, :ref:`LightEmittingDiode.details.updateEvent <Hibernate version of class omero.model.LightEmittingDiode>`, :ref:`LightPath.details.creationEvent <Hibernate version of class omero.model.LightPath>`, :ref:`LightPath.details.updateEvent <Hibernate version of class omero.model.LightPath>`, :ref:`LightPathAnnotationLink.details.creationEvent <Hibernate version of class omero.model.LightPathAnnotationLink>`, :ref:`LightPathAnnotationLink.details.updateEvent <Hibernate version of class omero.model.LightPathAnnotationLink>`, :ref:`LightPathEmissionFilterLink.details.creationEvent <Hibernate version of class omero.model.LightPathEmissionFilterLink>`, :ref:`LightPathEmissionFilterLink.details.updateEvent <Hibernate version of class omero.model.LightPathEmissionFilterLink>`, :ref:`LightPathExcitationFilterLink.details.creationEvent <Hibernate version of class omero.model.LightPathExcitationFilterLink>`, :ref:`LightPathExcitationFilterLink.details.updateEvent <Hibernate version of class omero.model.LightPathExcitationFilterLink>`, :ref:`LightSettings.details.creationEvent <Hibernate version of class omero.model.LightSettings>`, :ref:`LightSettings.details.updateEvent <Hibernate version of class omero.model.LightSettings>`, :ref:`LightSource.details.creationEvent <Hibernate version of class omero.model.LightSource>`, :ref:`LightSource.details.updateEvent <Hibernate version of class omero.model.LightSource>`, :ref:`LightSourceAnnotationLink.details.creationEvent <Hibernate version of class omero.model.LightSourceAnnotationLink>`, :ref:`LightSourceAnnotationLink.details.updateEvent <Hibernate version of class omero.model.LightSourceAnnotationLink>`, :ref:`Line.details.creationEvent <Hibernate version of class omero.model.Line>`, :ref:`Line.details.updateEvent <Hibernate version of class omero.model.Line>`, :ref:`Link.details.creationEvent <Hibernate version of class omero.model.Link>`, :ref:`Link.details.updateEvent <Hibernate version of class omero.model.Link>`, :ref:`ListAnnotation.details.creationEvent <Hibernate version of class omero.model.ListAnnotation>`, :ref:`ListAnnotation.details.updateEvent <Hibernate version of class omero.model.ListAnnotation>`, :ref:`LogicalChannel.details.creationEvent <Hibernate version of class omero.model.LogicalChannel>`, :ref:`LogicalChannel.details.updateEvent <Hibernate version of class omero.model.LogicalChannel>`, :ref:`LongAnnotation.details.creationEvent <Hibernate version of class omero.model.LongAnnotation>`, :ref:`LongAnnotation.details.updateEvent <Hibernate version of class omero.model.LongAnnotation>`, :ref:`MapAnnotation.details.creationEvent <Hibernate version of class omero.model.MapAnnotation>`, :ref:`MapAnnotation.details.updateEvent <Hibernate version of class omero.model.MapAnnotation>`, :ref:`Mask.details.creationEvent <Hibernate version of class omero.model.Mask>`, :ref:`Mask.details.updateEvent <Hibernate version of class omero.model.Mask>`, :ref:`MetadataImportJob.details.creationEvent <Hibernate version of class omero.model.MetadataImportJob>`, :ref:`MetadataImportJob.details.updateEvent <Hibernate version of class omero.model.MetadataImportJob>`, :ref:`MicrobeamManipulation.details.creationEvent <Hibernate version of class omero.model.MicrobeamManipulation>`, :ref:`MicrobeamManipulation.details.updateEvent <Hibernate version of class omero.model.MicrobeamManipulation>`, :ref:`Microscope.details.creationEvent <Hibernate version of class omero.model.Microscope>`, :ref:`Microscope.details.updateEvent <Hibernate version of class omero.model.Microscope>`, :ref:`NamespaceAnnotationLink.details.creationEvent <Hibernate version of class omero.model.NamespaceAnnotationLink>`, :ref:`NamespaceAnnotationLink.details.updateEvent <Hibernate version of class omero.model.NamespaceAnnotationLink>`, :ref:`NodeAnnotationLink.details.creationEvent <Hibernate version of class omero.model.NodeAnnotationLink>`, :ref:`NodeAnnotationLink.details.updateEvent <Hibernate version of class omero.model.NodeAnnotationLink>`, :ref:`NumericAnnotation.details.creationEvent <Hibernate version of class omero.model.NumericAnnotation>`, :ref:`NumericAnnotation.details.updateEvent <Hibernate version of class omero.model.NumericAnnotation>`, :ref:`OTF.details.creationEvent <Hibernate version of class omero.model.OTF>`, :ref:`OTF.details.updateEvent <Hibernate version of class omero.model.OTF>`, :ref:`Objective.details.creationEvent <Hibernate version of class omero.model.Objective>`, :ref:`Objective.details.updateEvent <Hibernate version of class omero.model.Objective>`, :ref:`ObjectiveAnnotationLink.details.creationEvent <Hibernate version of class omero.model.ObjectiveAnnotationLink>`, :ref:`ObjectiveAnnotationLink.details.updateEvent <Hibernate version of class omero.model.ObjectiveAnnotationLink>`, :ref:`ObjectiveSettings.details.creationEvent <Hibernate version of class omero.model.ObjectiveSettings>`, :ref:`ObjectiveSettings.details.updateEvent <Hibernate version of class omero.model.ObjectiveSettings>`, :ref:`OriginalFile.details.creationEvent <Hibernate version of class omero.model.OriginalFile>`, :ref:`OriginalFile.details.updateEvent <Hibernate version of class omero.model.OriginalFile>`, :ref:`OriginalFileAnnotationLink.details.creationEvent <Hibernate version of class omero.model.OriginalFileAnnotationLink>`, :ref:`OriginalFileAnnotationLink.details.updateEvent <Hibernate version of class omero.model.OriginalFileAnnotationLink>`, :ref:`ParseJob.details.creationEvent <Hibernate version of class omero.model.ParseJob>`, :ref:`ParseJob.details.updateEvent <Hibernate version of class omero.model.ParseJob>`, :ref:`Path.details.creationEvent <Hibernate version of class omero.model.Path>`, :ref:`Path.details.updateEvent <Hibernate version of class omero.model.Path>`, :ref:`PixelDataJob.details.creationEvent <Hibernate version of class omero.model.PixelDataJob>`, :ref:`PixelDataJob.details.updateEvent <Hibernate version of class omero.model.PixelDataJob>`, :ref:`Pixels.details.creationEvent <Hibernate version of class omero.model.Pixels>`, :ref:`Pixels.details.updateEvent <Hibernate version of class omero.model.Pixels>`, :ref:`PixelsOriginalFileMap.details.creationEvent <Hibernate version of class omero.model.PixelsOriginalFileMap>`, :ref:`PixelsOriginalFileMap.details.updateEvent <Hibernate version of class omero.model.PixelsOriginalFileMap>`, :ref:`PlaneInfo.details.creationEvent <Hibernate version of class omero.model.PlaneInfo>`, :ref:`PlaneInfo.details.updateEvent <Hibernate version of class omero.model.PlaneInfo>`, :ref:`PlaneInfoAnnotationLink.details.creationEvent <Hibernate version of class omero.model.PlaneInfoAnnotationLink>`, :ref:`PlaneInfoAnnotationLink.details.updateEvent <Hibernate version of class omero.model.PlaneInfoAnnotationLink>`, :ref:`PlaneSlicingContext.details.creationEvent <Hibernate version of class omero.model.PlaneSlicingContext>`, :ref:`PlaneSlicingContext.details.updateEvent <Hibernate version of class omero.model.PlaneSlicingContext>`, :ref:`Plate.details.creationEvent <Hibernate version of class omero.model.Plate>`, :ref:`Plate.details.updateEvent <Hibernate version of class omero.model.Plate>`, :ref:`PlateAcquisition.details.creationEvent <Hibernate version of class omero.model.PlateAcquisition>`, :ref:`PlateAcquisition.details.updateEvent <Hibernate version of class omero.model.PlateAcquisition>`, :ref:`PlateAcquisitionAnnotationLink.details.creationEvent <Hibernate version of class omero.model.PlateAcquisitionAnnotationLink>`, :ref:`PlateAcquisitionAnnotationLink.details.updateEvent <Hibernate version of class omero.model.PlateAcquisitionAnnotationLink>`, :ref:`PlateAnnotationLink.details.creationEvent <Hibernate version of class omero.model.PlateAnnotationLink>`, :ref:`PlateAnnotationLink.details.updateEvent <Hibernate version of class omero.model.PlateAnnotationLink>`, :ref:`Point.details.creationEvent <Hibernate version of class omero.model.Point>`, :ref:`Point.details.updateEvent <Hibernate version of class omero.model.Point>`, :ref:`Polygon.details.creationEvent <Hibernate version of class omero.model.Polygon>`, :ref:`Polygon.details.updateEvent <Hibernate version of class omero.model.Polygon>`, :ref:`Polyline.details.creationEvent <Hibernate version of class omero.model.Polyline>`, :ref:`Polyline.details.updateEvent <Hibernate version of class omero.model.Polyline>`, :ref:`Project.details.creationEvent <Hibernate version of class omero.model.Project>`, :ref:`Project.details.updateEvent <Hibernate version of class omero.model.Project>`, :ref:`ProjectAnnotationLink.details.creationEvent <Hibernate version of class omero.model.ProjectAnnotationLink>`, :ref:`ProjectAnnotationLink.details.updateEvent <Hibernate version of class omero.model.ProjectAnnotationLink>`, :ref:`ProjectDatasetLink.details.creationEvent <Hibernate version of class omero.model.ProjectDatasetLink>`, :ref:`ProjectDatasetLink.details.updateEvent <Hibernate version of class omero.model.ProjectDatasetLink>`, :ref:`QuantumDef.details.creationEvent <Hibernate version of class omero.model.QuantumDef>`, :ref:`QuantumDef.details.updateEvent <Hibernate version of class omero.model.QuantumDef>`, :ref:`Reagent.details.creationEvent <Hibernate version of class omero.model.Reagent>`, :ref:`Reagent.details.updateEvent <Hibernate version of class omero.model.Reagent>`, :ref:`ReagentAnnotationLink.details.creationEvent <Hibernate version of class omero.model.ReagentAnnotationLink>`, :ref:`ReagentAnnotationLink.details.updateEvent <Hibernate version of class omero.model.ReagentAnnotationLink>`, :ref:`Rect.details.creationEvent <Hibernate version of class omero.model.Rect>`, :ref:`Rect.details.updateEvent <Hibernate version of class omero.model.Rect>`, :ref:`RenderingDef.details.creationEvent <Hibernate version of class omero.model.RenderingDef>`, :ref:`RenderingDef.details.updateEvent <Hibernate version of class omero.model.RenderingDef>`, :ref:`ReverseIntensityContext.details.creationEvent <Hibernate version of class omero.model.ReverseIntensityContext>`, :ref:`ReverseIntensityContext.details.updateEvent <Hibernate version of class omero.model.ReverseIntensityContext>`, :ref:`Roi.details.creationEvent <Hibernate version of class omero.model.Roi>`, :ref:`Roi.details.updateEvent <Hibernate version of class omero.model.Roi>`, :ref:`RoiAnnotationLink.details.creationEvent <Hibernate version of class omero.model.RoiAnnotationLink>`, :ref:`RoiAnnotationLink.details.updateEvent <Hibernate version of class omero.model.RoiAnnotationLink>`, :ref:`Screen.details.creationEvent <Hibernate version of class omero.model.Screen>`, :ref:`Screen.details.updateEvent <Hibernate version of class omero.model.Screen>`, :ref:`ScreenAnnotationLink.details.creationEvent <Hibernate version of class omero.model.ScreenAnnotationLink>`, :ref:`ScreenAnnotationLink.details.updateEvent <Hibernate version of class omero.model.ScreenAnnotationLink>`, :ref:`ScreenPlateLink.details.creationEvent <Hibernate version of class omero.model.ScreenPlateLink>`, :ref:`ScreenPlateLink.details.updateEvent <Hibernate version of class omero.model.ScreenPlateLink>`, :ref:`ScriptJob.details.creationEvent <Hibernate version of class omero.model.ScriptJob>`, :ref:`ScriptJob.details.updateEvent <Hibernate version of class omero.model.ScriptJob>`, :ref:`Session.events <Hibernate version of class omero.model.Session>`, :ref:`SessionAnnotationLink.details.creationEvent <Hibernate version of class omero.model.SessionAnnotationLink>`, :ref:`SessionAnnotationLink.details.updateEvent <Hibernate version of class omero.model.SessionAnnotationLink>`, :ref:`Shape.details.creationEvent <Hibernate version of class omero.model.Shape>`, :ref:`Shape.details.updateEvent <Hibernate version of class omero.model.Shape>`, :ref:`ShapeAnnotationLink.details.creationEvent <Hibernate version of class omero.model.ShapeAnnotationLink>`, :ref:`ShapeAnnotationLink.details.updateEvent <Hibernate version of class omero.model.ShapeAnnotationLink>`, :ref:`Share.events <Hibernate version of class omero.model.Share>`, :ref:`StageLabel.details.creationEvent <Hibernate version of class omero.model.StageLabel>`, :ref:`StageLabel.details.updateEvent <Hibernate version of class omero.model.StageLabel>`, :ref:`StatsInfo.details.creationEvent <Hibernate version of class omero.model.StatsInfo>`, :ref:`StatsInfo.details.updateEvent <Hibernate version of class omero.model.StatsInfo>`, :ref:`TagAnnotation.details.creationEvent <Hibernate version of class omero.model.TagAnnotation>`, :ref:`TagAnnotation.details.updateEvent <Hibernate version of class omero.model.TagAnnotation>`, :ref:`TermAnnotation.details.creationEvent <Hibernate version of class omero.model.TermAnnotation>`, :ref:`TermAnnotation.details.updateEvent <Hibernate version of class omero.model.TermAnnotation>`, :ref:`TextAnnotation.details.creationEvent <Hibernate version of class omero.model.TextAnnotation>`, :ref:`TextAnnotation.details.updateEvent <Hibernate version of class omero.model.TextAnnotation>`, :ref:`Thumbnail.details.creationEvent <Hibernate version of class omero.model.Thumbnail>`, :ref:`Thumbnail.details.updateEvent <Hibernate version of class omero.model.Thumbnail>`, :ref:`ThumbnailGenerationJob.details.creationEvent <Hibernate version of class omero.model.ThumbnailGenerationJob>`, :ref:`ThumbnailGenerationJob.details.updateEvent <Hibernate version of class omero.model.ThumbnailGenerationJob>`, :ref:`TimestampAnnotation.details.creationEvent <Hibernate version of class omero.model.TimestampAnnotation>`, :ref:`TimestampAnnotation.details.updateEvent <Hibernate version of class omero.model.TimestampAnnotation>`, :ref:`TransmittanceRange.details.creationEvent <Hibernate version of class omero.model.TransmittanceRange>`, :ref:`TransmittanceRange.details.updateEvent <Hibernate version of class omero.model.TransmittanceRange>`, :ref:`TypeAnnotation.details.creationEvent <Hibernate version of class omero.model.TypeAnnotation>`, :ref:`TypeAnnotation.details.updateEvent <Hibernate version of class omero.model.TypeAnnotation>`, :ref:`UploadJob.details.creationEvent <Hibernate version of class omero.model.UploadJob>`, :ref:`UploadJob.details.updateEvent <Hibernate version of class omero.model.UploadJob>`, :ref:`Well.details.creationEvent <Hibernate version of class omero.model.Well>`, :ref:`Well.details.updateEvent <Hibernate version of class omero.model.Well>`, :ref:`WellAnnotationLink.details.creationEvent <Hibernate version of class omero.model.WellAnnotationLink>`, :ref:`WellAnnotationLink.details.updateEvent <Hibernate version of class omero.model.WellAnnotationLink>`, :ref:`WellReagentLink.details.creationEvent <Hibernate version of class omero.model.WellReagentLink>`, :ref:`WellReagentLink.details.updateEvent <Hibernate version of class omero.model.WellReagentLink>`, :ref:`WellSample.details.creationEvent <Hibernate version of class omero.model.WellSample>`, :ref:`WellSample.details.updateEvent <Hibernate version of class omero.model.WellSample>`, :ref:`XmlAnnotation.details.creationEvent <Hibernate version of class omero.model.XmlAnnotation>`, :ref:`XmlAnnotation.details.updateEvent <Hibernate version of class omero.model.XmlAnnotation>`
 
 Properties:
-  | containingEvent: :ref:`Event <omero.model.Event>` (optional)
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | containingEvent: :ref:`Event <Hibernate version of class omero.model.Event>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | experimenter: :ref:`Experimenter <omero.model.Experimenter>`
-  | experimenterGroup: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | logs: :ref:`EventLog <omero.model.EventLog>` (multiple)
-  | session: :ref:`Session <omero.model.Session>`
+  | experimenter: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | experimenterGroup: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | logs: :ref:`EventLog <Hibernate version of class omero.model.EventLog>` (multiple)
+  | session: :ref:`Session <Hibernate version of class omero.model.Session>`
   | status: ``string`` (optional)
   | time: ``timestamp``
-  | type: :ref:`EventType <omero.model.EventType>`
+  | type: :ref:`EventType <Hibernate version of class omero.model.EventType>`
 
-.. _omero.model.EventLog:
+.. _Hibernate version of class omero.model.EventLog:
 
 EventLog
 """"""""
 
-Used by: :ref:`Event.logs <omero.model.Event>`
+Used by: :ref:`Event.logs <Hibernate version of class omero.model.Event>`
 
 Properties:
   | action: ``string``
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | entityId: ``long``
   | entityType: ``string``
-  | event: :ref:`Event <omero.model.Event>`
+  | event: :ref:`Event <Hibernate version of class omero.model.Event>`
 
-.. _omero.model.EventType:
+.. _Hibernate version of class omero.model.EventType:
 
 EventType
 """""""""
 
-Used by: :ref:`Event.type <omero.model.Event>`
+Used by: :ref:`Event.type <Hibernate version of class omero.model.Event>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
 
-.. _omero.model.Experiment:
+.. _Hibernate version of class omero.model.Experiment:
 
 Experiment
 """"""""""
 
-Used by: :ref:`Image.experiment <omero.model.Image>`, :ref:`MicrobeamManipulation.experiment <omero.model.MicrobeamManipulation>`
+Used by: :ref:`Image.experiment <Hibernate version of class omero.model.Image>`, :ref:`MicrobeamManipulation.experiment <Hibernate version of class omero.model.MicrobeamManipulation>`
 
 Properties:
   | description: ``text`` (optional)
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | microbeamManipulation: :ref:`MicrobeamManipulation <omero.model.MicrobeamManipulation>` (multiple)
-  | type: :ref:`ExperimentType <omero.model.ExperimentType>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | microbeamManipulation: :ref:`MicrobeamManipulation <Hibernate version of class omero.model.MicrobeamManipulation>` (multiple)
+  | type: :ref:`ExperimentType <Hibernate version of class omero.model.ExperimentType>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.ExperimentType:
+.. _Hibernate version of class omero.model.ExperimentType:
 
 ExperimentType
 """"""""""""""
 
-Used by: :ref:`Experiment.type <omero.model.Experiment>`
+Used by: :ref:`Experiment.type <Hibernate version of class omero.model.Experiment>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
 
-.. _omero.model.Experimenter:
+.. _Hibernate version of class omero.model.Experimenter:
 
 Experimenter
 """"""""""""
 
-Used by: :ref:`Annotation.details.owner <omero.model.Annotation>`, :ref:`AnnotationAnnotationLink.details.owner <omero.model.AnnotationAnnotationLink>`, :ref:`Arc.details.owner <omero.model.Arc>`, :ref:`BasicAnnotation.details.owner <omero.model.BasicAnnotation>`, :ref:`BooleanAnnotation.details.owner <omero.model.BooleanAnnotation>`, :ref:`Channel.details.owner <omero.model.Channel>`, :ref:`ChannelAnnotationLink.details.owner <omero.model.ChannelAnnotationLink>`, :ref:`ChannelBinding.details.owner <omero.model.ChannelBinding>`, :ref:`CodomainMapContext.details.owner <omero.model.CodomainMapContext>`, :ref:`CommentAnnotation.details.owner <omero.model.CommentAnnotation>`, :ref:`ContrastStretchingContext.details.owner <omero.model.ContrastStretchingContext>`, :ref:`Dataset.details.owner <omero.model.Dataset>`, :ref:`DatasetAnnotationLink.details.owner <omero.model.DatasetAnnotationLink>`, :ref:`DatasetImageLink.details.owner <omero.model.DatasetImageLink>`, :ref:`Detector.details.owner <omero.model.Detector>`, :ref:`DetectorAnnotationLink.details.owner <omero.model.DetectorAnnotationLink>`, :ref:`DetectorSettings.details.owner <omero.model.DetectorSettings>`, :ref:`Dichroic.details.owner <omero.model.Dichroic>`, :ref:`DichroicAnnotationLink.details.owner <omero.model.DichroicAnnotationLink>`, :ref:`DoubleAnnotation.details.owner <omero.model.DoubleAnnotation>`, :ref:`Ellipse.details.owner <omero.model.Ellipse>`, :ref:`Event.experimenter <omero.model.Event>`, :ref:`Experiment.details.owner <omero.model.Experiment>`, :ref:`ExperimenterAnnotationLink.details.owner <omero.model.ExperimenterAnnotationLink>`, :ref:`ExperimenterAnnotationLink.parent <omero.model.ExperimenterAnnotationLink>`, :ref:`ExperimenterGroupAnnotationLink.details.owner <omero.model.ExperimenterGroupAnnotationLink>`, :ref:`ExternalInfo.details.owner <omero.model.ExternalInfo>`, :ref:`Filament.details.owner <omero.model.Filament>`, :ref:`FileAnnotation.details.owner <omero.model.FileAnnotation>`, :ref:`Fileset.details.owner <omero.model.Fileset>`, :ref:`FilesetAnnotationLink.details.owner <omero.model.FilesetAnnotationLink>`, :ref:`FilesetEntry.details.owner <omero.model.FilesetEntry>`, :ref:`FilesetJobLink.details.owner <omero.model.FilesetJobLink>`, :ref:`Filter.details.owner <omero.model.Filter>`, :ref:`FilterAnnotationLink.details.owner <omero.model.FilterAnnotationLink>`, :ref:`FilterSet.details.owner <omero.model.FilterSet>`, :ref:`FilterSetEmissionFilterLink.details.owner <omero.model.FilterSetEmissionFilterLink>`, :ref:`FilterSetExcitationFilterLink.details.owner <omero.model.FilterSetExcitationFilterLink>`, :ref:`GenericExcitationSource.details.owner <omero.model.GenericExcitationSource>`, :ref:`GroupExperimenterMap.child <omero.model.GroupExperimenterMap>`, :ref:`Image.details.owner <omero.model.Image>`, :ref:`ImageAnnotationLink.details.owner <omero.model.ImageAnnotationLink>`, :ref:`ImagingEnvironment.details.owner <omero.model.ImagingEnvironment>`, :ref:`ImportJob.details.owner <omero.model.ImportJob>`, :ref:`IndexingJob.details.owner <omero.model.IndexingJob>`, :ref:`Instrument.details.owner <omero.model.Instrument>`, :ref:`InstrumentAnnotationLink.details.owner <omero.model.InstrumentAnnotationLink>`, :ref:`IntegrityCheckJob.details.owner <omero.model.IntegrityCheckJob>`, :ref:`Job.details.owner <omero.model.Job>`, :ref:`JobOriginalFileLink.details.owner <omero.model.JobOriginalFileLink>`, :ref:`Label.details.owner <omero.model.Label>`, :ref:`Laser.details.owner <omero.model.Laser>`, :ref:`LightEmittingDiode.details.owner <omero.model.LightEmittingDiode>`, :ref:`LightPath.details.owner <omero.model.LightPath>`, :ref:`LightPathAnnotationLink.details.owner <omero.model.LightPathAnnotationLink>`, :ref:`LightPathEmissionFilterLink.details.owner <omero.model.LightPathEmissionFilterLink>`, :ref:`LightPathExcitationFilterLink.details.owner <omero.model.LightPathExcitationFilterLink>`, :ref:`LightSettings.details.owner <omero.model.LightSettings>`, :ref:`LightSource.details.owner <omero.model.LightSource>`, :ref:`LightSourceAnnotationLink.details.owner <omero.model.LightSourceAnnotationLink>`, :ref:`Line.details.owner <omero.model.Line>`, :ref:`Link.details.owner <omero.model.Link>`, :ref:`ListAnnotation.details.owner <omero.model.ListAnnotation>`, :ref:`LogicalChannel.details.owner <omero.model.LogicalChannel>`, :ref:`LongAnnotation.details.owner <omero.model.LongAnnotation>`, :ref:`MapAnnotation.details.owner <omero.model.MapAnnotation>`, :ref:`Mask.details.owner <omero.model.Mask>`, :ref:`MetadataImportJob.details.owner <omero.model.MetadataImportJob>`, :ref:`MicrobeamManipulation.details.owner <omero.model.MicrobeamManipulation>`, :ref:`Microscope.details.owner <omero.model.Microscope>`, :ref:`Namespace.details.owner <omero.model.Namespace>`, :ref:`NamespaceAnnotationLink.details.owner <omero.model.NamespaceAnnotationLink>`, :ref:`NodeAnnotationLink.details.owner <omero.model.NodeAnnotationLink>`, :ref:`NumericAnnotation.details.owner <omero.model.NumericAnnotation>`, :ref:`OTF.details.owner <omero.model.OTF>`, :ref:`Objective.details.owner <omero.model.Objective>`, :ref:`ObjectiveAnnotationLink.details.owner <omero.model.ObjectiveAnnotationLink>`, :ref:`ObjectiveSettings.details.owner <omero.model.ObjectiveSettings>`, :ref:`OriginalFile.details.owner <omero.model.OriginalFile>`, :ref:`OriginalFileAnnotationLink.details.owner <omero.model.OriginalFileAnnotationLink>`, :ref:`ParseJob.details.owner <omero.model.ParseJob>`, :ref:`Path.details.owner <omero.model.Path>`, :ref:`PixelDataJob.details.owner <omero.model.PixelDataJob>`, :ref:`Pixels.details.owner <omero.model.Pixels>`, :ref:`PixelsOriginalFileMap.details.owner <omero.model.PixelsOriginalFileMap>`, :ref:`PlaneInfo.details.owner <omero.model.PlaneInfo>`, :ref:`PlaneInfoAnnotationLink.details.owner <omero.model.PlaneInfoAnnotationLink>`, :ref:`PlaneSlicingContext.details.owner <omero.model.PlaneSlicingContext>`, :ref:`Plate.details.owner <omero.model.Plate>`, :ref:`PlateAcquisition.details.owner <omero.model.PlateAcquisition>`, :ref:`PlateAcquisitionAnnotationLink.details.owner <omero.model.PlateAcquisitionAnnotationLink>`, :ref:`PlateAnnotationLink.details.owner <omero.model.PlateAnnotationLink>`, :ref:`Point.details.owner <omero.model.Point>`, :ref:`Polygon.details.owner <omero.model.Polygon>`, :ref:`Polyline.details.owner <omero.model.Polyline>`, :ref:`Project.details.owner <omero.model.Project>`, :ref:`ProjectAnnotationLink.details.owner <omero.model.ProjectAnnotationLink>`, :ref:`ProjectDatasetLink.details.owner <omero.model.ProjectDatasetLink>`, :ref:`QuantumDef.details.owner <omero.model.QuantumDef>`, :ref:`Reagent.details.owner <omero.model.Reagent>`, :ref:`ReagentAnnotationLink.details.owner <omero.model.ReagentAnnotationLink>`, :ref:`Rect.details.owner <omero.model.Rect>`, :ref:`RenderingDef.details.owner <omero.model.RenderingDef>`, :ref:`ReverseIntensityContext.details.owner <omero.model.ReverseIntensityContext>`, :ref:`Roi.details.owner <omero.model.Roi>`, :ref:`RoiAnnotationLink.details.owner <omero.model.RoiAnnotationLink>`, :ref:`Screen.details.owner <omero.model.Screen>`, :ref:`ScreenAnnotationLink.details.owner <omero.model.ScreenAnnotationLink>`, :ref:`ScreenPlateLink.details.owner <omero.model.ScreenPlateLink>`, :ref:`ScriptJob.details.owner <omero.model.ScriptJob>`, :ref:`Session.owner <omero.model.Session>`, :ref:`SessionAnnotationLink.details.owner <omero.model.SessionAnnotationLink>`, :ref:`Shape.details.owner <omero.model.Shape>`, :ref:`ShapeAnnotationLink.details.owner <omero.model.ShapeAnnotationLink>`, :ref:`Share.owner <omero.model.Share>`, :ref:`ShareMember.child <omero.model.ShareMember>`, :ref:`StageLabel.details.owner <omero.model.StageLabel>`, :ref:`StatsInfo.details.owner <omero.model.StatsInfo>`, :ref:`TagAnnotation.details.owner <omero.model.TagAnnotation>`, :ref:`TermAnnotation.details.owner <omero.model.TermAnnotation>`, :ref:`TextAnnotation.details.owner <omero.model.TextAnnotation>`, :ref:`Thumbnail.details.owner <omero.model.Thumbnail>`, :ref:`ThumbnailGenerationJob.details.owner <omero.model.ThumbnailGenerationJob>`, :ref:`TimestampAnnotation.details.owner <omero.model.TimestampAnnotation>`, :ref:`TransmittanceRange.details.owner <omero.model.TransmittanceRange>`, :ref:`TypeAnnotation.details.owner <omero.model.TypeAnnotation>`, :ref:`UploadJob.details.owner <omero.model.UploadJob>`, :ref:`Well.details.owner <omero.model.Well>`, :ref:`WellAnnotationLink.details.owner <omero.model.WellAnnotationLink>`, :ref:`WellReagentLink.details.owner <omero.model.WellReagentLink>`, :ref:`WellSample.details.owner <omero.model.WellSample>`, :ref:`XmlAnnotation.details.owner <omero.model.XmlAnnotation>`
+Used by: :ref:`Annotation.details.owner <Hibernate version of class omero.model.Annotation>`, :ref:`AnnotationAnnotationLink.details.owner <Hibernate version of class omero.model.AnnotationAnnotationLink>`, :ref:`Arc.details.owner <Hibernate version of class omero.model.Arc>`, :ref:`BasicAnnotation.details.owner <Hibernate version of class omero.model.BasicAnnotation>`, :ref:`BooleanAnnotation.details.owner <Hibernate version of class omero.model.BooleanAnnotation>`, :ref:`Channel.details.owner <Hibernate version of class omero.model.Channel>`, :ref:`ChannelAnnotationLink.details.owner <Hibernate version of class omero.model.ChannelAnnotationLink>`, :ref:`ChannelBinding.details.owner <Hibernate version of class omero.model.ChannelBinding>`, :ref:`CodomainMapContext.details.owner <Hibernate version of class omero.model.CodomainMapContext>`, :ref:`CommentAnnotation.details.owner <Hibernate version of class omero.model.CommentAnnotation>`, :ref:`ContrastStretchingContext.details.owner <Hibernate version of class omero.model.ContrastStretchingContext>`, :ref:`Dataset.details.owner <Hibernate version of class omero.model.Dataset>`, :ref:`DatasetAnnotationLink.details.owner <Hibernate version of class omero.model.DatasetAnnotationLink>`, :ref:`DatasetImageLink.details.owner <Hibernate version of class omero.model.DatasetImageLink>`, :ref:`Detector.details.owner <Hibernate version of class omero.model.Detector>`, :ref:`DetectorAnnotationLink.details.owner <Hibernate version of class omero.model.DetectorAnnotationLink>`, :ref:`DetectorSettings.details.owner <Hibernate version of class omero.model.DetectorSettings>`, :ref:`Dichroic.details.owner <Hibernate version of class omero.model.Dichroic>`, :ref:`DichroicAnnotationLink.details.owner <Hibernate version of class omero.model.DichroicAnnotationLink>`, :ref:`DoubleAnnotation.details.owner <Hibernate version of class omero.model.DoubleAnnotation>`, :ref:`Ellipse.details.owner <Hibernate version of class omero.model.Ellipse>`, :ref:`Event.experimenter <Hibernate version of class omero.model.Event>`, :ref:`Experiment.details.owner <Hibernate version of class omero.model.Experiment>`, :ref:`ExperimenterAnnotationLink.details.owner <Hibernate version of class omero.model.ExperimenterAnnotationLink>`, :ref:`ExperimenterAnnotationLink.parent <Hibernate version of class omero.model.ExperimenterAnnotationLink>`, :ref:`ExperimenterGroupAnnotationLink.details.owner <Hibernate version of class omero.model.ExperimenterGroupAnnotationLink>`, :ref:`ExternalInfo.details.owner <Hibernate version of class omero.model.ExternalInfo>`, :ref:`Filament.details.owner <Hibernate version of class omero.model.Filament>`, :ref:`FileAnnotation.details.owner <Hibernate version of class omero.model.FileAnnotation>`, :ref:`Fileset.details.owner <Hibernate version of class omero.model.Fileset>`, :ref:`FilesetAnnotationLink.details.owner <Hibernate version of class omero.model.FilesetAnnotationLink>`, :ref:`FilesetEntry.details.owner <Hibernate version of class omero.model.FilesetEntry>`, :ref:`FilesetJobLink.details.owner <Hibernate version of class omero.model.FilesetJobLink>`, :ref:`Filter.details.owner <Hibernate version of class omero.model.Filter>`, :ref:`FilterAnnotationLink.details.owner <Hibernate version of class omero.model.FilterAnnotationLink>`, :ref:`FilterSet.details.owner <Hibernate version of class omero.model.FilterSet>`, :ref:`FilterSetEmissionFilterLink.details.owner <Hibernate version of class omero.model.FilterSetEmissionFilterLink>`, :ref:`FilterSetExcitationFilterLink.details.owner <Hibernate version of class omero.model.FilterSetExcitationFilterLink>`, :ref:`GenericExcitationSource.details.owner <Hibernate version of class omero.model.GenericExcitationSource>`, :ref:`GroupExperimenterMap.child <Hibernate version of class omero.model.GroupExperimenterMap>`, :ref:`Image.details.owner <Hibernate version of class omero.model.Image>`, :ref:`ImageAnnotationLink.details.owner <Hibernate version of class omero.model.ImageAnnotationLink>`, :ref:`ImagingEnvironment.details.owner <Hibernate version of class omero.model.ImagingEnvironment>`, :ref:`ImportJob.details.owner <Hibernate version of class omero.model.ImportJob>`, :ref:`IndexingJob.details.owner <Hibernate version of class omero.model.IndexingJob>`, :ref:`Instrument.details.owner <Hibernate version of class omero.model.Instrument>`, :ref:`InstrumentAnnotationLink.details.owner <Hibernate version of class omero.model.InstrumentAnnotationLink>`, :ref:`IntegrityCheckJob.details.owner <Hibernate version of class omero.model.IntegrityCheckJob>`, :ref:`Job.details.owner <Hibernate version of class omero.model.Job>`, :ref:`JobOriginalFileLink.details.owner <Hibernate version of class omero.model.JobOriginalFileLink>`, :ref:`Label.details.owner <Hibernate version of class omero.model.Label>`, :ref:`Laser.details.owner <Hibernate version of class omero.model.Laser>`, :ref:`LightEmittingDiode.details.owner <Hibernate version of class omero.model.LightEmittingDiode>`, :ref:`LightPath.details.owner <Hibernate version of class omero.model.LightPath>`, :ref:`LightPathAnnotationLink.details.owner <Hibernate version of class omero.model.LightPathAnnotationLink>`, :ref:`LightPathEmissionFilterLink.details.owner <Hibernate version of class omero.model.LightPathEmissionFilterLink>`, :ref:`LightPathExcitationFilterLink.details.owner <Hibernate version of class omero.model.LightPathExcitationFilterLink>`, :ref:`LightSettings.details.owner <Hibernate version of class omero.model.LightSettings>`, :ref:`LightSource.details.owner <Hibernate version of class omero.model.LightSource>`, :ref:`LightSourceAnnotationLink.details.owner <Hibernate version of class omero.model.LightSourceAnnotationLink>`, :ref:`Line.details.owner <Hibernate version of class omero.model.Line>`, :ref:`Link.details.owner <Hibernate version of class omero.model.Link>`, :ref:`ListAnnotation.details.owner <Hibernate version of class omero.model.ListAnnotation>`, :ref:`LogicalChannel.details.owner <Hibernate version of class omero.model.LogicalChannel>`, :ref:`LongAnnotation.details.owner <Hibernate version of class omero.model.LongAnnotation>`, :ref:`MapAnnotation.details.owner <Hibernate version of class omero.model.MapAnnotation>`, :ref:`Mask.details.owner <Hibernate version of class omero.model.Mask>`, :ref:`MetadataImportJob.details.owner <Hibernate version of class omero.model.MetadataImportJob>`, :ref:`MicrobeamManipulation.details.owner <Hibernate version of class omero.model.MicrobeamManipulation>`, :ref:`Microscope.details.owner <Hibernate version of class omero.model.Microscope>`, :ref:`NamespaceAnnotationLink.details.owner <Hibernate version of class omero.model.NamespaceAnnotationLink>`, :ref:`NodeAnnotationLink.details.owner <Hibernate version of class omero.model.NodeAnnotationLink>`, :ref:`NumericAnnotation.details.owner <Hibernate version of class omero.model.NumericAnnotation>`, :ref:`OTF.details.owner <Hibernate version of class omero.model.OTF>`, :ref:`Objective.details.owner <Hibernate version of class omero.model.Objective>`, :ref:`ObjectiveAnnotationLink.details.owner <Hibernate version of class omero.model.ObjectiveAnnotationLink>`, :ref:`ObjectiveSettings.details.owner <Hibernate version of class omero.model.ObjectiveSettings>`, :ref:`OriginalFile.details.owner <Hibernate version of class omero.model.OriginalFile>`, :ref:`OriginalFileAnnotationLink.details.owner <Hibernate version of class omero.model.OriginalFileAnnotationLink>`, :ref:`ParseJob.details.owner <Hibernate version of class omero.model.ParseJob>`, :ref:`Path.details.owner <Hibernate version of class omero.model.Path>`, :ref:`PixelDataJob.details.owner <Hibernate version of class omero.model.PixelDataJob>`, :ref:`Pixels.details.owner <Hibernate version of class omero.model.Pixels>`, :ref:`PixelsOriginalFileMap.details.owner <Hibernate version of class omero.model.PixelsOriginalFileMap>`, :ref:`PlaneInfo.details.owner <Hibernate version of class omero.model.PlaneInfo>`, :ref:`PlaneInfoAnnotationLink.details.owner <Hibernate version of class omero.model.PlaneInfoAnnotationLink>`, :ref:`PlaneSlicingContext.details.owner <Hibernate version of class omero.model.PlaneSlicingContext>`, :ref:`Plate.details.owner <Hibernate version of class omero.model.Plate>`, :ref:`PlateAcquisition.details.owner <Hibernate version of class omero.model.PlateAcquisition>`, :ref:`PlateAcquisitionAnnotationLink.details.owner <Hibernate version of class omero.model.PlateAcquisitionAnnotationLink>`, :ref:`PlateAnnotationLink.details.owner <Hibernate version of class omero.model.PlateAnnotationLink>`, :ref:`Point.details.owner <Hibernate version of class omero.model.Point>`, :ref:`Polygon.details.owner <Hibernate version of class omero.model.Polygon>`, :ref:`Polyline.details.owner <Hibernate version of class omero.model.Polyline>`, :ref:`Project.details.owner <Hibernate version of class omero.model.Project>`, :ref:`ProjectAnnotationLink.details.owner <Hibernate version of class omero.model.ProjectAnnotationLink>`, :ref:`ProjectDatasetLink.details.owner <Hibernate version of class omero.model.ProjectDatasetLink>`, :ref:`QuantumDef.details.owner <Hibernate version of class omero.model.QuantumDef>`, :ref:`Reagent.details.owner <Hibernate version of class omero.model.Reagent>`, :ref:`ReagentAnnotationLink.details.owner <Hibernate version of class omero.model.ReagentAnnotationLink>`, :ref:`Rect.details.owner <Hibernate version of class omero.model.Rect>`, :ref:`RenderingDef.details.owner <Hibernate version of class omero.model.RenderingDef>`, :ref:`ReverseIntensityContext.details.owner <Hibernate version of class omero.model.ReverseIntensityContext>`, :ref:`Roi.details.owner <Hibernate version of class omero.model.Roi>`, :ref:`RoiAnnotationLink.details.owner <Hibernate version of class omero.model.RoiAnnotationLink>`, :ref:`Screen.details.owner <Hibernate version of class omero.model.Screen>`, :ref:`ScreenAnnotationLink.details.owner <Hibernate version of class omero.model.ScreenAnnotationLink>`, :ref:`ScreenPlateLink.details.owner <Hibernate version of class omero.model.ScreenPlateLink>`, :ref:`ScriptJob.details.owner <Hibernate version of class omero.model.ScriptJob>`, :ref:`Session.owner <Hibernate version of class omero.model.Session>`, :ref:`SessionAnnotationLink.details.owner <Hibernate version of class omero.model.SessionAnnotationLink>`, :ref:`Shape.details.owner <Hibernate version of class omero.model.Shape>`, :ref:`ShapeAnnotationLink.details.owner <Hibernate version of class omero.model.ShapeAnnotationLink>`, :ref:`Share.owner <Hibernate version of class omero.model.Share>`, :ref:`ShareMember.child <Hibernate version of class omero.model.ShareMember>`, :ref:`StageLabel.details.owner <Hibernate version of class omero.model.StageLabel>`, :ref:`StatsInfo.details.owner <Hibernate version of class omero.model.StatsInfo>`, :ref:`TagAnnotation.details.owner <Hibernate version of class omero.model.TagAnnotation>`, :ref:`TermAnnotation.details.owner <Hibernate version of class omero.model.TermAnnotation>`, :ref:`TextAnnotation.details.owner <Hibernate version of class omero.model.TextAnnotation>`, :ref:`Thumbnail.details.owner <Hibernate version of class omero.model.Thumbnail>`, :ref:`ThumbnailGenerationJob.details.owner <Hibernate version of class omero.model.ThumbnailGenerationJob>`, :ref:`TimestampAnnotation.details.owner <Hibernate version of class omero.model.TimestampAnnotation>`, :ref:`TransmittanceRange.details.owner <Hibernate version of class omero.model.TransmittanceRange>`, :ref:`TypeAnnotation.details.owner <Hibernate version of class omero.model.TypeAnnotation>`, :ref:`UploadJob.details.owner <Hibernate version of class omero.model.UploadJob>`, :ref:`Well.details.owner <Hibernate version of class omero.model.Well>`, :ref:`WellAnnotationLink.details.owner <Hibernate version of class omero.model.WellAnnotationLink>`, :ref:`WellReagentLink.details.owner <Hibernate version of class omero.model.WellReagentLink>`, :ref:`WellSample.details.owner <Hibernate version of class omero.model.WellSample>`, :ref:`XmlAnnotation.details.owner <Hibernate version of class omero.model.XmlAnnotation>`
 
 Properties:
-  | annotationLinks: :ref:`ExperimenterAnnotationLink <omero.model.ExperimenterAnnotationLink>` (multiple)
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | annotationLinks: :ref:`ExperimenterAnnotationLink <Hibernate version of class omero.model.ExperimenterAnnotationLink>` (multiple)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | email: ``string`` (optional)
   | firstName: ``string``
-  | groupExperimenterMap: :ref:`GroupExperimenterMap <omero.model.GroupExperimenterMap>` (multiple)
+  | groupExperimenterMap: :ref:`GroupExperimenterMap <Hibernate version of class omero.model.GroupExperimenterMap>` (multiple)
   | institution: ``string`` (optional)
   | lastName: ``string``
   | ldap: ``boolean``
@@ -682,901 +687,903 @@ Properties:
   | omeName: ``string``
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.ExperimenterAnnotationLink:
+.. _Hibernate version of class omero.model.ExperimenterAnnotationLink:
 
 ExperimenterAnnotationLink
 """"""""""""""""""""""""""
 
-Used by: :ref:`Experimenter.annotationLinks <omero.model.Experimenter>`
+Used by: :ref:`Experimenter.annotationLinks <Hibernate version of class omero.model.Experimenter>`
 
 Properties:
-  | child: :ref:`Annotation <omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`Experimenter <omero.model.Experimenter>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.ExperimenterGroup:
+.. _Hibernate version of class omero.model.ExperimenterGroup:
 
 ExperimenterGroup
 """""""""""""""""
 
-Used by: :ref:`Annotation.details.group <omero.model.Annotation>`, :ref:`AnnotationAnnotationLink.details.group <omero.model.AnnotationAnnotationLink>`, :ref:`Arc.details.group <omero.model.Arc>`, :ref:`BasicAnnotation.details.group <omero.model.BasicAnnotation>`, :ref:`BooleanAnnotation.details.group <omero.model.BooleanAnnotation>`, :ref:`Channel.details.group <omero.model.Channel>`, :ref:`ChannelAnnotationLink.details.group <omero.model.ChannelAnnotationLink>`, :ref:`ChannelBinding.details.group <omero.model.ChannelBinding>`, :ref:`CodomainMapContext.details.group <omero.model.CodomainMapContext>`, :ref:`CommentAnnotation.details.group <omero.model.CommentAnnotation>`, :ref:`ContrastStretchingContext.details.group <omero.model.ContrastStretchingContext>`, :ref:`Dataset.details.group <omero.model.Dataset>`, :ref:`DatasetAnnotationLink.details.group <omero.model.DatasetAnnotationLink>`, :ref:`DatasetImageLink.details.group <omero.model.DatasetImageLink>`, :ref:`Detector.details.group <omero.model.Detector>`, :ref:`DetectorAnnotationLink.details.group <omero.model.DetectorAnnotationLink>`, :ref:`DetectorSettings.details.group <omero.model.DetectorSettings>`, :ref:`Dichroic.details.group <omero.model.Dichroic>`, :ref:`DichroicAnnotationLink.details.group <omero.model.DichroicAnnotationLink>`, :ref:`DoubleAnnotation.details.group <omero.model.DoubleAnnotation>`, :ref:`Ellipse.details.group <omero.model.Ellipse>`, :ref:`Event.experimenterGroup <omero.model.Event>`, :ref:`Experiment.details.group <omero.model.Experiment>`, :ref:`ExperimenterAnnotationLink.details.group <omero.model.ExperimenterAnnotationLink>`, :ref:`ExperimenterGroupAnnotationLink.details.group <omero.model.ExperimenterGroupAnnotationLink>`, :ref:`ExperimenterGroupAnnotationLink.parent <omero.model.ExperimenterGroupAnnotationLink>`, :ref:`ExternalInfo.details.group <omero.model.ExternalInfo>`, :ref:`Filament.details.group <omero.model.Filament>`, :ref:`FileAnnotation.details.group <omero.model.FileAnnotation>`, :ref:`Fileset.details.group <omero.model.Fileset>`, :ref:`FilesetAnnotationLink.details.group <omero.model.FilesetAnnotationLink>`, :ref:`FilesetEntry.details.group <omero.model.FilesetEntry>`, :ref:`FilesetJobLink.details.group <omero.model.FilesetJobLink>`, :ref:`Filter.details.group <omero.model.Filter>`, :ref:`FilterAnnotationLink.details.group <omero.model.FilterAnnotationLink>`, :ref:`FilterSet.details.group <omero.model.FilterSet>`, :ref:`FilterSetEmissionFilterLink.details.group <omero.model.FilterSetEmissionFilterLink>`, :ref:`FilterSetExcitationFilterLink.details.group <omero.model.FilterSetExcitationFilterLink>`, :ref:`GenericExcitationSource.details.group <omero.model.GenericExcitationSource>`, :ref:`GroupExperimenterMap.parent <omero.model.GroupExperimenterMap>`, :ref:`Image.details.group <omero.model.Image>`, :ref:`ImageAnnotationLink.details.group <omero.model.ImageAnnotationLink>`, :ref:`ImagingEnvironment.details.group <omero.model.ImagingEnvironment>`, :ref:`ImportJob.details.group <omero.model.ImportJob>`, :ref:`IndexingJob.details.group <omero.model.IndexingJob>`, :ref:`Instrument.details.group <omero.model.Instrument>`, :ref:`InstrumentAnnotationLink.details.group <omero.model.InstrumentAnnotationLink>`, :ref:`IntegrityCheckJob.details.group <omero.model.IntegrityCheckJob>`, :ref:`Job.details.group <omero.model.Job>`, :ref:`JobOriginalFileLink.details.group <omero.model.JobOriginalFileLink>`, :ref:`Label.details.group <omero.model.Label>`, :ref:`Laser.details.group <omero.model.Laser>`, :ref:`LightEmittingDiode.details.group <omero.model.LightEmittingDiode>`, :ref:`LightPath.details.group <omero.model.LightPath>`, :ref:`LightPathAnnotationLink.details.group <omero.model.LightPathAnnotationLink>`, :ref:`LightPathEmissionFilterLink.details.group <omero.model.LightPathEmissionFilterLink>`, :ref:`LightPathExcitationFilterLink.details.group <omero.model.LightPathExcitationFilterLink>`, :ref:`LightSettings.details.group <omero.model.LightSettings>`, :ref:`LightSource.details.group <omero.model.LightSource>`, :ref:`LightSourceAnnotationLink.details.group <omero.model.LightSourceAnnotationLink>`, :ref:`Line.details.group <omero.model.Line>`, :ref:`Link.details.group <omero.model.Link>`, :ref:`ListAnnotation.details.group <omero.model.ListAnnotation>`, :ref:`LogicalChannel.details.group <omero.model.LogicalChannel>`, :ref:`LongAnnotation.details.group <omero.model.LongAnnotation>`, :ref:`MapAnnotation.details.group <omero.model.MapAnnotation>`, :ref:`Mask.details.group <omero.model.Mask>`, :ref:`MetadataImportJob.details.group <omero.model.MetadataImportJob>`, :ref:`MicrobeamManipulation.details.group <omero.model.MicrobeamManipulation>`, :ref:`Microscope.details.group <omero.model.Microscope>`, :ref:`Namespace.details.group <omero.model.Namespace>`, :ref:`NamespaceAnnotationLink.details.group <omero.model.NamespaceAnnotationLink>`, :ref:`NodeAnnotationLink.details.group <omero.model.NodeAnnotationLink>`, :ref:`NumericAnnotation.details.group <omero.model.NumericAnnotation>`, :ref:`OTF.details.group <omero.model.OTF>`, :ref:`Objective.details.group <omero.model.Objective>`, :ref:`ObjectiveAnnotationLink.details.group <omero.model.ObjectiveAnnotationLink>`, :ref:`ObjectiveSettings.details.group <omero.model.ObjectiveSettings>`, :ref:`OriginalFile.details.group <omero.model.OriginalFile>`, :ref:`OriginalFileAnnotationLink.details.group <omero.model.OriginalFileAnnotationLink>`, :ref:`ParseJob.details.group <omero.model.ParseJob>`, :ref:`Path.details.group <omero.model.Path>`, :ref:`PixelDataJob.details.group <omero.model.PixelDataJob>`, :ref:`Pixels.details.group <omero.model.Pixels>`, :ref:`PixelsOriginalFileMap.details.group <omero.model.PixelsOriginalFileMap>`, :ref:`PlaneInfo.details.group <omero.model.PlaneInfo>`, :ref:`PlaneInfoAnnotationLink.details.group <omero.model.PlaneInfoAnnotationLink>`, :ref:`PlaneSlicingContext.details.group <omero.model.PlaneSlicingContext>`, :ref:`Plate.details.group <omero.model.Plate>`, :ref:`PlateAcquisition.details.group <omero.model.PlateAcquisition>`, :ref:`PlateAcquisitionAnnotationLink.details.group <omero.model.PlateAcquisitionAnnotationLink>`, :ref:`PlateAnnotationLink.details.group <omero.model.PlateAnnotationLink>`, :ref:`Point.details.group <omero.model.Point>`, :ref:`Polygon.details.group <omero.model.Polygon>`, :ref:`Polyline.details.group <omero.model.Polyline>`, :ref:`Project.details.group <omero.model.Project>`, :ref:`ProjectAnnotationLink.details.group <omero.model.ProjectAnnotationLink>`, :ref:`ProjectDatasetLink.details.group <omero.model.ProjectDatasetLink>`, :ref:`QuantumDef.details.group <omero.model.QuantumDef>`, :ref:`Reagent.details.group <omero.model.Reagent>`, :ref:`ReagentAnnotationLink.details.group <omero.model.ReagentAnnotationLink>`, :ref:`Rect.details.group <omero.model.Rect>`, :ref:`RenderingDef.details.group <omero.model.RenderingDef>`, :ref:`ReverseIntensityContext.details.group <omero.model.ReverseIntensityContext>`, :ref:`Roi.details.group <omero.model.Roi>`, :ref:`RoiAnnotationLink.details.group <omero.model.RoiAnnotationLink>`, :ref:`Screen.details.group <omero.model.Screen>`, :ref:`ScreenAnnotationLink.details.group <omero.model.ScreenAnnotationLink>`, :ref:`ScreenPlateLink.details.group <omero.model.ScreenPlateLink>`, :ref:`ScriptJob.details.group <omero.model.ScriptJob>`, :ref:`SessionAnnotationLink.details.group <omero.model.SessionAnnotationLink>`, :ref:`Shape.details.group <omero.model.Shape>`, :ref:`ShapeAnnotationLink.details.group <omero.model.ShapeAnnotationLink>`, :ref:`Share.group <omero.model.Share>`, :ref:`StageLabel.details.group <omero.model.StageLabel>`, :ref:`StatsInfo.details.group <omero.model.StatsInfo>`, :ref:`TagAnnotation.details.group <omero.model.TagAnnotation>`, :ref:`TermAnnotation.details.group <omero.model.TermAnnotation>`, :ref:`TextAnnotation.details.group <omero.model.TextAnnotation>`, :ref:`Thumbnail.details.group <omero.model.Thumbnail>`, :ref:`ThumbnailGenerationJob.details.group <omero.model.ThumbnailGenerationJob>`, :ref:`TimestampAnnotation.details.group <omero.model.TimestampAnnotation>`, :ref:`TransmittanceRange.details.group <omero.model.TransmittanceRange>`, :ref:`TypeAnnotation.details.group <omero.model.TypeAnnotation>`, :ref:`UploadJob.details.group <omero.model.UploadJob>`, :ref:`Well.details.group <omero.model.Well>`, :ref:`WellAnnotationLink.details.group <omero.model.WellAnnotationLink>`, :ref:`WellReagentLink.details.group <omero.model.WellReagentLink>`, :ref:`WellSample.details.group <omero.model.WellSample>`, :ref:`XmlAnnotation.details.group <omero.model.XmlAnnotation>`
+Used by: :ref:`Annotation.details.group <Hibernate version of class omero.model.Annotation>`, :ref:`AnnotationAnnotationLink.details.group <Hibernate version of class omero.model.AnnotationAnnotationLink>`, :ref:`Arc.details.group <Hibernate version of class omero.model.Arc>`, :ref:`BasicAnnotation.details.group <Hibernate version of class omero.model.BasicAnnotation>`, :ref:`BooleanAnnotation.details.group <Hibernate version of class omero.model.BooleanAnnotation>`, :ref:`Channel.details.group <Hibernate version of class omero.model.Channel>`, :ref:`ChannelAnnotationLink.details.group <Hibernate version of class omero.model.ChannelAnnotationLink>`, :ref:`ChannelBinding.details.group <Hibernate version of class omero.model.ChannelBinding>`, :ref:`CodomainMapContext.details.group <Hibernate version of class omero.model.CodomainMapContext>`, :ref:`CommentAnnotation.details.group <Hibernate version of class omero.model.CommentAnnotation>`, :ref:`ContrastStretchingContext.details.group <Hibernate version of class omero.model.ContrastStretchingContext>`, :ref:`Dataset.details.group <Hibernate version of class omero.model.Dataset>`, :ref:`DatasetAnnotationLink.details.group <Hibernate version of class omero.model.DatasetAnnotationLink>`, :ref:`DatasetImageLink.details.group <Hibernate version of class omero.model.DatasetImageLink>`, :ref:`Detector.details.group <Hibernate version of class omero.model.Detector>`, :ref:`DetectorAnnotationLink.details.group <Hibernate version of class omero.model.DetectorAnnotationLink>`, :ref:`DetectorSettings.details.group <Hibernate version of class omero.model.DetectorSettings>`, :ref:`Dichroic.details.group <Hibernate version of class omero.model.Dichroic>`, :ref:`DichroicAnnotationLink.details.group <Hibernate version of class omero.model.DichroicAnnotationLink>`, :ref:`DoubleAnnotation.details.group <Hibernate version of class omero.model.DoubleAnnotation>`, :ref:`Ellipse.details.group <Hibernate version of class omero.model.Ellipse>`, :ref:`Event.experimenterGroup <Hibernate version of class omero.model.Event>`, :ref:`Experiment.details.group <Hibernate version of class omero.model.Experiment>`, :ref:`ExperimenterAnnotationLink.details.group <Hibernate version of class omero.model.ExperimenterAnnotationLink>`, :ref:`ExperimenterGroupAnnotationLink.details.group <Hibernate version of class omero.model.ExperimenterGroupAnnotationLink>`, :ref:`ExperimenterGroupAnnotationLink.parent <Hibernate version of class omero.model.ExperimenterGroupAnnotationLink>`, :ref:`ExternalInfo.details.group <Hibernate version of class omero.model.ExternalInfo>`, :ref:`Filament.details.group <Hibernate version of class omero.model.Filament>`, :ref:`FileAnnotation.details.group <Hibernate version of class omero.model.FileAnnotation>`, :ref:`Fileset.details.group <Hibernate version of class omero.model.Fileset>`, :ref:`FilesetAnnotationLink.details.group <Hibernate version of class omero.model.FilesetAnnotationLink>`, :ref:`FilesetEntry.details.group <Hibernate version of class omero.model.FilesetEntry>`, :ref:`FilesetJobLink.details.group <Hibernate version of class omero.model.FilesetJobLink>`, :ref:`Filter.details.group <Hibernate version of class omero.model.Filter>`, :ref:`FilterAnnotationLink.details.group <Hibernate version of class omero.model.FilterAnnotationLink>`, :ref:`FilterSet.details.group <Hibernate version of class omero.model.FilterSet>`, :ref:`FilterSetEmissionFilterLink.details.group <Hibernate version of class omero.model.FilterSetEmissionFilterLink>`, :ref:`FilterSetExcitationFilterLink.details.group <Hibernate version of class omero.model.FilterSetExcitationFilterLink>`, :ref:`GenericExcitationSource.details.group <Hibernate version of class omero.model.GenericExcitationSource>`, :ref:`GroupExperimenterMap.parent <Hibernate version of class omero.model.GroupExperimenterMap>`, :ref:`Image.details.group <Hibernate version of class omero.model.Image>`, :ref:`ImageAnnotationLink.details.group <Hibernate version of class omero.model.ImageAnnotationLink>`, :ref:`ImagingEnvironment.details.group <Hibernate version of class omero.model.ImagingEnvironment>`, :ref:`ImportJob.details.group <Hibernate version of class omero.model.ImportJob>`, :ref:`IndexingJob.details.group <Hibernate version of class omero.model.IndexingJob>`, :ref:`Instrument.details.group <Hibernate version of class omero.model.Instrument>`, :ref:`InstrumentAnnotationLink.details.group <Hibernate version of class omero.model.InstrumentAnnotationLink>`, :ref:`IntegrityCheckJob.details.group <Hibernate version of class omero.model.IntegrityCheckJob>`, :ref:`Job.details.group <Hibernate version of class omero.model.Job>`, :ref:`JobOriginalFileLink.details.group <Hibernate version of class omero.model.JobOriginalFileLink>`, :ref:`Label.details.group <Hibernate version of class omero.model.Label>`, :ref:`Laser.details.group <Hibernate version of class omero.model.Laser>`, :ref:`LightEmittingDiode.details.group <Hibernate version of class omero.model.LightEmittingDiode>`, :ref:`LightPath.details.group <Hibernate version of class omero.model.LightPath>`, :ref:`LightPathAnnotationLink.details.group <Hibernate version of class omero.model.LightPathAnnotationLink>`, :ref:`LightPathEmissionFilterLink.details.group <Hibernate version of class omero.model.LightPathEmissionFilterLink>`, :ref:`LightPathExcitationFilterLink.details.group <Hibernate version of class omero.model.LightPathExcitationFilterLink>`, :ref:`LightSettings.details.group <Hibernate version of class omero.model.LightSettings>`, :ref:`LightSource.details.group <Hibernate version of class omero.model.LightSource>`, :ref:`LightSourceAnnotationLink.details.group <Hibernate version of class omero.model.LightSourceAnnotationLink>`, :ref:`Line.details.group <Hibernate version of class omero.model.Line>`, :ref:`Link.details.group <Hibernate version of class omero.model.Link>`, :ref:`ListAnnotation.details.group <Hibernate version of class omero.model.ListAnnotation>`, :ref:`LogicalChannel.details.group <Hibernate version of class omero.model.LogicalChannel>`, :ref:`LongAnnotation.details.group <Hibernate version of class omero.model.LongAnnotation>`, :ref:`MapAnnotation.details.group <Hibernate version of class omero.model.MapAnnotation>`, :ref:`Mask.details.group <Hibernate version of class omero.model.Mask>`, :ref:`MetadataImportJob.details.group <Hibernate version of class omero.model.MetadataImportJob>`, :ref:`MicrobeamManipulation.details.group <Hibernate version of class omero.model.MicrobeamManipulation>`, :ref:`Microscope.details.group <Hibernate version of class omero.model.Microscope>`, :ref:`NamespaceAnnotationLink.details.group <Hibernate version of class omero.model.NamespaceAnnotationLink>`, :ref:`NodeAnnotationLink.details.group <Hibernate version of class omero.model.NodeAnnotationLink>`, :ref:`NumericAnnotation.details.group <Hibernate version of class omero.model.NumericAnnotation>`, :ref:`OTF.details.group <Hibernate version of class omero.model.OTF>`, :ref:`Objective.details.group <Hibernate version of class omero.model.Objective>`, :ref:`ObjectiveAnnotationLink.details.group <Hibernate version of class omero.model.ObjectiveAnnotationLink>`, :ref:`ObjectiveSettings.details.group <Hibernate version of class omero.model.ObjectiveSettings>`, :ref:`OriginalFile.details.group <Hibernate version of class omero.model.OriginalFile>`, :ref:`OriginalFileAnnotationLink.details.group <Hibernate version of class omero.model.OriginalFileAnnotationLink>`, :ref:`ParseJob.details.group <Hibernate version of class omero.model.ParseJob>`, :ref:`Path.details.group <Hibernate version of class omero.model.Path>`, :ref:`PixelDataJob.details.group <Hibernate version of class omero.model.PixelDataJob>`, :ref:`Pixels.details.group <Hibernate version of class omero.model.Pixels>`, :ref:`PixelsOriginalFileMap.details.group <Hibernate version of class omero.model.PixelsOriginalFileMap>`, :ref:`PlaneInfo.details.group <Hibernate version of class omero.model.PlaneInfo>`, :ref:`PlaneInfoAnnotationLink.details.group <Hibernate version of class omero.model.PlaneInfoAnnotationLink>`, :ref:`PlaneSlicingContext.details.group <Hibernate version of class omero.model.PlaneSlicingContext>`, :ref:`Plate.details.group <Hibernate version of class omero.model.Plate>`, :ref:`PlateAcquisition.details.group <Hibernate version of class omero.model.PlateAcquisition>`, :ref:`PlateAcquisitionAnnotationLink.details.group <Hibernate version of class omero.model.PlateAcquisitionAnnotationLink>`, :ref:`PlateAnnotationLink.details.group <Hibernate version of class omero.model.PlateAnnotationLink>`, :ref:`Point.details.group <Hibernate version of class omero.model.Point>`, :ref:`Polygon.details.group <Hibernate version of class omero.model.Polygon>`, :ref:`Polyline.details.group <Hibernate version of class omero.model.Polyline>`, :ref:`Project.details.group <Hibernate version of class omero.model.Project>`, :ref:`ProjectAnnotationLink.details.group <Hibernate version of class omero.model.ProjectAnnotationLink>`, :ref:`ProjectDatasetLink.details.group <Hibernate version of class omero.model.ProjectDatasetLink>`, :ref:`QuantumDef.details.group <Hibernate version of class omero.model.QuantumDef>`, :ref:`Reagent.details.group <Hibernate version of class omero.model.Reagent>`, :ref:`ReagentAnnotationLink.details.group <Hibernate version of class omero.model.ReagentAnnotationLink>`, :ref:`Rect.details.group <Hibernate version of class omero.model.Rect>`, :ref:`RenderingDef.details.group <Hibernate version of class omero.model.RenderingDef>`, :ref:`ReverseIntensityContext.details.group <Hibernate version of class omero.model.ReverseIntensityContext>`, :ref:`Roi.details.group <Hibernate version of class omero.model.Roi>`, :ref:`RoiAnnotationLink.details.group <Hibernate version of class omero.model.RoiAnnotationLink>`, :ref:`Screen.details.group <Hibernate version of class omero.model.Screen>`, :ref:`ScreenAnnotationLink.details.group <Hibernate version of class omero.model.ScreenAnnotationLink>`, :ref:`ScreenPlateLink.details.group <Hibernate version of class omero.model.ScreenPlateLink>`, :ref:`ScriptJob.details.group <Hibernate version of class omero.model.ScriptJob>`, :ref:`SessionAnnotationLink.details.group <Hibernate version of class omero.model.SessionAnnotationLink>`, :ref:`Shape.details.group <Hibernate version of class omero.model.Shape>`, :ref:`ShapeAnnotationLink.details.group <Hibernate version of class omero.model.ShapeAnnotationLink>`, :ref:`Share.group <Hibernate version of class omero.model.Share>`, :ref:`StageLabel.details.group <Hibernate version of class omero.model.StageLabel>`, :ref:`StatsInfo.details.group <Hibernate version of class omero.model.StatsInfo>`, :ref:`TagAnnotation.details.group <Hibernate version of class omero.model.TagAnnotation>`, :ref:`TermAnnotation.details.group <Hibernate version of class omero.model.TermAnnotation>`, :ref:`TextAnnotation.details.group <Hibernate version of class omero.model.TextAnnotation>`, :ref:`Thumbnail.details.group <Hibernate version of class omero.model.Thumbnail>`, :ref:`ThumbnailGenerationJob.details.group <Hibernate version of class omero.model.ThumbnailGenerationJob>`, :ref:`TimestampAnnotation.details.group <Hibernate version of class omero.model.TimestampAnnotation>`, :ref:`TransmittanceRange.details.group <Hibernate version of class omero.model.TransmittanceRange>`, :ref:`TypeAnnotation.details.group <Hibernate version of class omero.model.TypeAnnotation>`, :ref:`UploadJob.details.group <Hibernate version of class omero.model.UploadJob>`, :ref:`Well.details.group <Hibernate version of class omero.model.Well>`, :ref:`WellAnnotationLink.details.group <Hibernate version of class omero.model.WellAnnotationLink>`, :ref:`WellReagentLink.details.group <Hibernate version of class omero.model.WellReagentLink>`, :ref:`WellSample.details.group <Hibernate version of class omero.model.WellSample>`, :ref:`XmlAnnotation.details.group <Hibernate version of class omero.model.XmlAnnotation>`
 
 Properties:
-  | annotationLinks: :ref:`ExperimenterGroupAnnotationLink <omero.model.ExperimenterGroupAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`ExperimenterGroupAnnotationLink <Hibernate version of class omero.model.ExperimenterGroupAnnotationLink>` (multiple)
   | config: list (multiple)
   | description: ``text`` (optional)
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | groupExperimenterMap: :ref:`GroupExperimenterMap <omero.model.GroupExperimenterMap>` (multiple)
+  | groupExperimenterMap: :ref:`GroupExperimenterMap <Hibernate version of class omero.model.GroupExperimenterMap>` (multiple)
   | ldap: ``boolean``
   | name: ``string``
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.ExperimenterGroupAnnotationLink:
+.. _Hibernate version of class omero.model.ExperimenterGroupAnnotationLink:
 
 ExperimenterGroupAnnotationLink
 """""""""""""""""""""""""""""""
 
-Used by: :ref:`ExperimenterGroup.annotationLinks <omero.model.ExperimenterGroup>`
+Used by: :ref:`ExperimenterGroup.annotationLinks <Hibernate version of class omero.model.ExperimenterGroup>`
 
 Properties:
-  | child: :ref:`Annotation <omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.ExternalInfo:
+.. _Hibernate version of class omero.model.ExternalInfo:
 
 ExternalInfo
 """"""""""""
 
-Used by: :ref:`AcquisitionMode.details.externalInfo <omero.model.AcquisitionMode>`, :ref:`Annotation.details.externalInfo <omero.model.Annotation>`, :ref:`AnnotationAnnotationLink.details.externalInfo <omero.model.AnnotationAnnotationLink>`, :ref:`Arc.details.externalInfo <omero.model.Arc>`, :ref:`ArcType.details.externalInfo <omero.model.ArcType>`, :ref:`BasicAnnotation.details.externalInfo <omero.model.BasicAnnotation>`, :ref:`Binning.details.externalInfo <omero.model.Binning>`, :ref:`BooleanAnnotation.details.externalInfo <omero.model.BooleanAnnotation>`, :ref:`Channel.details.externalInfo <omero.model.Channel>`, :ref:`ChannelAnnotationLink.details.externalInfo <omero.model.ChannelAnnotationLink>`, :ref:`ChannelBinding.details.externalInfo <omero.model.ChannelBinding>`, :ref:`ChecksumAlgorithm.details.externalInfo <omero.model.ChecksumAlgorithm>`, :ref:`CodomainMapContext.details.externalInfo <omero.model.CodomainMapContext>`, :ref:`CommentAnnotation.details.externalInfo <omero.model.CommentAnnotation>`, :ref:`ContrastMethod.details.externalInfo <omero.model.ContrastMethod>`, :ref:`ContrastStretchingContext.details.externalInfo <omero.model.ContrastStretchingContext>`, :ref:`Correction.details.externalInfo <omero.model.Correction>`, :ref:`DBPatch.details.externalInfo <omero.model.DBPatch>`, :ref:`Dataset.details.externalInfo <omero.model.Dataset>`, :ref:`DatasetAnnotationLink.details.externalInfo <omero.model.DatasetAnnotationLink>`, :ref:`DatasetImageLink.details.externalInfo <omero.model.DatasetImageLink>`, :ref:`Detector.details.externalInfo <omero.model.Detector>`, :ref:`DetectorAnnotationLink.details.externalInfo <omero.model.DetectorAnnotationLink>`, :ref:`DetectorSettings.details.externalInfo <omero.model.DetectorSettings>`, :ref:`DetectorType.details.externalInfo <omero.model.DetectorType>`, :ref:`Dichroic.details.externalInfo <omero.model.Dichroic>`, :ref:`DichroicAnnotationLink.details.externalInfo <omero.model.DichroicAnnotationLink>`, :ref:`DimensionOrder.details.externalInfo <omero.model.DimensionOrder>`, :ref:`DoubleAnnotation.details.externalInfo <omero.model.DoubleAnnotation>`, :ref:`Ellipse.details.externalInfo <omero.model.Ellipse>`, :ref:`Event.details.externalInfo <omero.model.Event>`, :ref:`EventLog.details.externalInfo <omero.model.EventLog>`, :ref:`EventType.details.externalInfo <omero.model.EventType>`, :ref:`Experiment.details.externalInfo <omero.model.Experiment>`, :ref:`ExperimentType.details.externalInfo <omero.model.ExperimentType>`, :ref:`Experimenter.details.externalInfo <omero.model.Experimenter>`, :ref:`ExperimenterAnnotationLink.details.externalInfo <omero.model.ExperimenterAnnotationLink>`, :ref:`ExperimenterGroup.details.externalInfo <omero.model.ExperimenterGroup>`, :ref:`ExperimenterGroupAnnotationLink.details.externalInfo <omero.model.ExperimenterGroupAnnotationLink>`, :ref:`ExternalInfo.details.externalInfo <omero.model.ExternalInfo>`, :ref:`Family.details.externalInfo <omero.model.Family>`, :ref:`Filament.details.externalInfo <omero.model.Filament>`, :ref:`FilamentType.details.externalInfo <omero.model.FilamentType>`, :ref:`FileAnnotation.details.externalInfo <omero.model.FileAnnotation>`, :ref:`Fileset.details.externalInfo <omero.model.Fileset>`, :ref:`FilesetAnnotationLink.details.externalInfo <omero.model.FilesetAnnotationLink>`, :ref:`FilesetEntry.details.externalInfo <omero.model.FilesetEntry>`, :ref:`FilesetJobLink.details.externalInfo <omero.model.FilesetJobLink>`, :ref:`Filter.details.externalInfo <omero.model.Filter>`, :ref:`FilterAnnotationLink.details.externalInfo <omero.model.FilterAnnotationLink>`, :ref:`FilterSet.details.externalInfo <omero.model.FilterSet>`, :ref:`FilterSetEmissionFilterLink.details.externalInfo <omero.model.FilterSetEmissionFilterLink>`, :ref:`FilterSetExcitationFilterLink.details.externalInfo <omero.model.FilterSetExcitationFilterLink>`, :ref:`FilterType.details.externalInfo <omero.model.FilterType>`, :ref:`Format.details.externalInfo <omero.model.Format>`, :ref:`GenericExcitationSource.details.externalInfo <omero.model.GenericExcitationSource>`, :ref:`GroupExperimenterMap.details.externalInfo <omero.model.GroupExperimenterMap>`, :ref:`Illumination.details.externalInfo <omero.model.Illumination>`, :ref:`Image.details.externalInfo <omero.model.Image>`, :ref:`ImageAnnotationLink.details.externalInfo <omero.model.ImageAnnotationLink>`, :ref:`ImagingEnvironment.details.externalInfo <omero.model.ImagingEnvironment>`, :ref:`Immersion.details.externalInfo <omero.model.Immersion>`, :ref:`ImportJob.details.externalInfo <omero.model.ImportJob>`, :ref:`IndexingJob.details.externalInfo <omero.model.IndexingJob>`, :ref:`Instrument.details.externalInfo <omero.model.Instrument>`, :ref:`InstrumentAnnotationLink.details.externalInfo <omero.model.InstrumentAnnotationLink>`, :ref:`IntegrityCheckJob.details.externalInfo <omero.model.IntegrityCheckJob>`, :ref:`Job.details.externalInfo <omero.model.Job>`, :ref:`JobOriginalFileLink.details.externalInfo <omero.model.JobOriginalFileLink>`, :ref:`JobStatus.details.externalInfo <omero.model.JobStatus>`, :ref:`Label.details.externalInfo <omero.model.Label>`, :ref:`Laser.details.externalInfo <omero.model.Laser>`, :ref:`LaserMedium.details.externalInfo <omero.model.LaserMedium>`, :ref:`LaserType.details.externalInfo <omero.model.LaserType>`, :ref:`LightEmittingDiode.details.externalInfo <omero.model.LightEmittingDiode>`, :ref:`LightPath.details.externalInfo <omero.model.LightPath>`, :ref:`LightPathAnnotationLink.details.externalInfo <omero.model.LightPathAnnotationLink>`, :ref:`LightPathEmissionFilterLink.details.externalInfo <omero.model.LightPathEmissionFilterLink>`, :ref:`LightPathExcitationFilterLink.details.externalInfo <omero.model.LightPathExcitationFilterLink>`, :ref:`LightSettings.details.externalInfo <omero.model.LightSettings>`, :ref:`LightSource.details.externalInfo <omero.model.LightSource>`, :ref:`LightSourceAnnotationLink.details.externalInfo <omero.model.LightSourceAnnotationLink>`, :ref:`Line.details.externalInfo <omero.model.Line>`, :ref:`Link.details.externalInfo <omero.model.Link>`, :ref:`ListAnnotation.details.externalInfo <omero.model.ListAnnotation>`, :ref:`LogicalChannel.details.externalInfo <omero.model.LogicalChannel>`, :ref:`LongAnnotation.details.externalInfo <omero.model.LongAnnotation>`, :ref:`MapAnnotation.details.externalInfo <omero.model.MapAnnotation>`, :ref:`Mask.details.externalInfo <omero.model.Mask>`, :ref:`Medium.details.externalInfo <omero.model.Medium>`, :ref:`MetadataImportJob.details.externalInfo <omero.model.MetadataImportJob>`, :ref:`MicrobeamManipulation.details.externalInfo <omero.model.MicrobeamManipulation>`, :ref:`MicrobeamManipulationType.details.externalInfo <omero.model.MicrobeamManipulationType>`, :ref:`Microscope.details.externalInfo <omero.model.Microscope>`, :ref:`MicroscopeType.details.externalInfo <omero.model.MicroscopeType>`, :ref:`Namespace.details.externalInfo <omero.model.Namespace>`, :ref:`NamespaceAnnotationLink.details.externalInfo <omero.model.NamespaceAnnotationLink>`, :ref:`Node.details.externalInfo <omero.model.Node>`, :ref:`NodeAnnotationLink.details.externalInfo <omero.model.NodeAnnotationLink>`, :ref:`NumericAnnotation.details.externalInfo <omero.model.NumericAnnotation>`, :ref:`OTF.details.externalInfo <omero.model.OTF>`, :ref:`Objective.details.externalInfo <omero.model.Objective>`, :ref:`ObjectiveAnnotationLink.details.externalInfo <omero.model.ObjectiveAnnotationLink>`, :ref:`ObjectiveSettings.details.externalInfo <omero.model.ObjectiveSettings>`, :ref:`OriginalFile.details.externalInfo <omero.model.OriginalFile>`, :ref:`OriginalFileAnnotationLink.details.externalInfo <omero.model.OriginalFileAnnotationLink>`, :ref:`ParseJob.details.externalInfo <omero.model.ParseJob>`, :ref:`Path.details.externalInfo <omero.model.Path>`, :ref:`PhotometricInterpretation.details.externalInfo <omero.model.PhotometricInterpretation>`, :ref:`PixelDataJob.details.externalInfo <omero.model.PixelDataJob>`, :ref:`Pixels.details.externalInfo <omero.model.Pixels>`, :ref:`PixelsOriginalFileMap.details.externalInfo <omero.model.PixelsOriginalFileMap>`, :ref:`PixelsType.details.externalInfo <omero.model.PixelsType>`, :ref:`PlaneInfo.details.externalInfo <omero.model.PlaneInfo>`, :ref:`PlaneInfoAnnotationLink.details.externalInfo <omero.model.PlaneInfoAnnotationLink>`, :ref:`PlaneSlicingContext.details.externalInfo <omero.model.PlaneSlicingContext>`, :ref:`Plate.details.externalInfo <omero.model.Plate>`, :ref:`PlateAcquisition.details.externalInfo <omero.model.PlateAcquisition>`, :ref:`PlateAcquisitionAnnotationLink.details.externalInfo <omero.model.PlateAcquisitionAnnotationLink>`, :ref:`PlateAnnotationLink.details.externalInfo <omero.model.PlateAnnotationLink>`, :ref:`Point.details.externalInfo <omero.model.Point>`, :ref:`Polygon.details.externalInfo <omero.model.Polygon>`, :ref:`Polyline.details.externalInfo <omero.model.Polyline>`, :ref:`Project.details.externalInfo <omero.model.Project>`, :ref:`ProjectAnnotationLink.details.externalInfo <omero.model.ProjectAnnotationLink>`, :ref:`ProjectDatasetLink.details.externalInfo <omero.model.ProjectDatasetLink>`, :ref:`Pulse.details.externalInfo <omero.model.Pulse>`, :ref:`QuantumDef.details.externalInfo <omero.model.QuantumDef>`, :ref:`Reagent.details.externalInfo <omero.model.Reagent>`, :ref:`ReagentAnnotationLink.details.externalInfo <omero.model.ReagentAnnotationLink>`, :ref:`Rect.details.externalInfo <omero.model.Rect>`, :ref:`RenderingDef.details.externalInfo <omero.model.RenderingDef>`, :ref:`RenderingModel.details.externalInfo <omero.model.RenderingModel>`, :ref:`ReverseIntensityContext.details.externalInfo <omero.model.ReverseIntensityContext>`, :ref:`Roi.details.externalInfo <omero.model.Roi>`, :ref:`RoiAnnotationLink.details.externalInfo <omero.model.RoiAnnotationLink>`, :ref:`Screen.details.externalInfo <omero.model.Screen>`, :ref:`ScreenAnnotationLink.details.externalInfo <omero.model.ScreenAnnotationLink>`, :ref:`ScreenPlateLink.details.externalInfo <omero.model.ScreenPlateLink>`, :ref:`ScriptJob.details.externalInfo <omero.model.ScriptJob>`, :ref:`Session.details.externalInfo <omero.model.Session>`, :ref:`SessionAnnotationLink.details.externalInfo <omero.model.SessionAnnotationLink>`, :ref:`Shape.details.externalInfo <omero.model.Shape>`, :ref:`ShapeAnnotationLink.details.externalInfo <omero.model.ShapeAnnotationLink>`, :ref:`Share.details.externalInfo <omero.model.Share>`, :ref:`ShareMember.details.externalInfo <omero.model.ShareMember>`, :ref:`StageLabel.details.externalInfo <omero.model.StageLabel>`, :ref:`StatsInfo.details.externalInfo <omero.model.StatsInfo>`, :ref:`TagAnnotation.details.externalInfo <omero.model.TagAnnotation>`, :ref:`TermAnnotation.details.externalInfo <omero.model.TermAnnotation>`, :ref:`TextAnnotation.details.externalInfo <omero.model.TextAnnotation>`, :ref:`Thumbnail.details.externalInfo <omero.model.Thumbnail>`, :ref:`ThumbnailGenerationJob.details.externalInfo <omero.model.ThumbnailGenerationJob>`, :ref:`TimestampAnnotation.details.externalInfo <omero.model.TimestampAnnotation>`, :ref:`TransmittanceRange.details.externalInfo <omero.model.TransmittanceRange>`, :ref:`TypeAnnotation.details.externalInfo <omero.model.TypeAnnotation>`, :ref:`UploadJob.details.externalInfo <omero.model.UploadJob>`, :ref:`Well.details.externalInfo <omero.model.Well>`, :ref:`WellAnnotationLink.details.externalInfo <omero.model.WellAnnotationLink>`, :ref:`WellReagentLink.details.externalInfo <omero.model.WellReagentLink>`, :ref:`WellSample.details.externalInfo <omero.model.WellSample>`, :ref:`XmlAnnotation.details.externalInfo <omero.model.XmlAnnotation>`
+Used by: :ref:`AcquisitionMode.details.externalInfo <Hibernate version of class omero.model.AcquisitionMode>`, :ref:`Annotation.details.externalInfo <Hibernate version of class omero.model.Annotation>`, :ref:`AnnotationAnnotationLink.details.externalInfo <Hibernate version of class omero.model.AnnotationAnnotationLink>`, :ref:`Arc.details.externalInfo <Hibernate version of class omero.model.Arc>`, :ref:`ArcType.details.externalInfo <Hibernate version of class omero.model.ArcType>`, :ref:`BasicAnnotation.details.externalInfo <Hibernate version of class omero.model.BasicAnnotation>`, :ref:`Binning.details.externalInfo <Hibernate version of class omero.model.Binning>`, :ref:`BooleanAnnotation.details.externalInfo <Hibernate version of class omero.model.BooleanAnnotation>`, :ref:`Channel.details.externalInfo <Hibernate version of class omero.model.Channel>`, :ref:`ChannelAnnotationLink.details.externalInfo <Hibernate version of class omero.model.ChannelAnnotationLink>`, :ref:`ChannelBinding.details.externalInfo <Hibernate version of class omero.model.ChannelBinding>`, :ref:`ChecksumAlgorithm.details.externalInfo <Hibernate version of class omero.model.ChecksumAlgorithm>`, :ref:`CodomainMapContext.details.externalInfo <Hibernate version of class omero.model.CodomainMapContext>`, :ref:`CommentAnnotation.details.externalInfo <Hibernate version of class omero.model.CommentAnnotation>`, :ref:`ContrastMethod.details.externalInfo <Hibernate version of class omero.model.ContrastMethod>`, :ref:`ContrastStretchingContext.details.externalInfo <Hibernate version of class omero.model.ContrastStretchingContext>`, :ref:`Correction.details.externalInfo <Hibernate version of class omero.model.Correction>`, :ref:`DBPatch.details.externalInfo <Hibernate version of class omero.model.DBPatch>`, :ref:`Dataset.details.externalInfo <Hibernate version of class omero.model.Dataset>`, :ref:`DatasetAnnotationLink.details.externalInfo <Hibernate version of class omero.model.DatasetAnnotationLink>`, :ref:`DatasetImageLink.details.externalInfo <Hibernate version of class omero.model.DatasetImageLink>`, :ref:`Detector.details.externalInfo <Hibernate version of class omero.model.Detector>`, :ref:`DetectorAnnotationLink.details.externalInfo <Hibernate version of class omero.model.DetectorAnnotationLink>`, :ref:`DetectorSettings.details.externalInfo <Hibernate version of class omero.model.DetectorSettings>`, :ref:`DetectorType.details.externalInfo <Hibernate version of class omero.model.DetectorType>`, :ref:`Dichroic.details.externalInfo <Hibernate version of class omero.model.Dichroic>`, :ref:`DichroicAnnotationLink.details.externalInfo <Hibernate version of class omero.model.DichroicAnnotationLink>`, :ref:`DimensionOrder.details.externalInfo <Hibernate version of class omero.model.DimensionOrder>`, :ref:`DoubleAnnotation.details.externalInfo <Hibernate version of class omero.model.DoubleAnnotation>`, :ref:`Ellipse.details.externalInfo <Hibernate version of class omero.model.Ellipse>`, :ref:`Event.details.externalInfo <Hibernate version of class omero.model.Event>`, :ref:`EventLog.details.externalInfo <Hibernate version of class omero.model.EventLog>`, :ref:`EventType.details.externalInfo <Hibernate version of class omero.model.EventType>`, :ref:`Experiment.details.externalInfo <Hibernate version of class omero.model.Experiment>`, :ref:`ExperimentType.details.externalInfo <Hibernate version of class omero.model.ExperimentType>`, :ref:`Experimenter.details.externalInfo <Hibernate version of class omero.model.Experimenter>`, :ref:`ExperimenterAnnotationLink.details.externalInfo <Hibernate version of class omero.model.ExperimenterAnnotationLink>`, :ref:`ExperimenterGroup.details.externalInfo <Hibernate version of class omero.model.ExperimenterGroup>`, :ref:`ExperimenterGroupAnnotationLink.details.externalInfo <Hibernate version of class omero.model.ExperimenterGroupAnnotationLink>`, :ref:`ExternalInfo.details.externalInfo <Hibernate version of class omero.model.ExternalInfo>`, :ref:`Family.details.externalInfo <Hibernate version of class omero.model.Family>`, :ref:`Filament.details.externalInfo <Hibernate version of class omero.model.Filament>`, :ref:`FilamentType.details.externalInfo <Hibernate version of class omero.model.FilamentType>`, :ref:`FileAnnotation.details.externalInfo <Hibernate version of class omero.model.FileAnnotation>`, :ref:`Fileset.details.externalInfo <Hibernate version of class omero.model.Fileset>`, :ref:`FilesetAnnotationLink.details.externalInfo <Hibernate version of class omero.model.FilesetAnnotationLink>`, :ref:`FilesetEntry.details.externalInfo <Hibernate version of class omero.model.FilesetEntry>`, :ref:`FilesetJobLink.details.externalInfo <Hibernate version of class omero.model.FilesetJobLink>`, :ref:`Filter.details.externalInfo <Hibernate version of class omero.model.Filter>`, :ref:`FilterAnnotationLink.details.externalInfo <Hibernate version of class omero.model.FilterAnnotationLink>`, :ref:`FilterSet.details.externalInfo <Hibernate version of class omero.model.FilterSet>`, :ref:`FilterSetEmissionFilterLink.details.externalInfo <Hibernate version of class omero.model.FilterSetEmissionFilterLink>`, :ref:`FilterSetExcitationFilterLink.details.externalInfo <Hibernate version of class omero.model.FilterSetExcitationFilterLink>`, :ref:`FilterType.details.externalInfo <Hibernate version of class omero.model.FilterType>`, :ref:`Format.details.externalInfo <Hibernate version of class omero.model.Format>`, :ref:`GenericExcitationSource.details.externalInfo <Hibernate version of class omero.model.GenericExcitationSource>`, :ref:`GroupExperimenterMap.details.externalInfo <Hibernate version of class omero.model.GroupExperimenterMap>`, :ref:`Illumination.details.externalInfo <Hibernate version of class omero.model.Illumination>`, :ref:`Image.details.externalInfo <Hibernate version of class omero.model.Image>`, :ref:`ImageAnnotationLink.details.externalInfo <Hibernate version of class omero.model.ImageAnnotationLink>`, :ref:`ImagingEnvironment.details.externalInfo <Hibernate version of class omero.model.ImagingEnvironment>`, :ref:`Immersion.details.externalInfo <Hibernate version of class omero.model.Immersion>`, :ref:`ImportJob.details.externalInfo <Hibernate version of class omero.model.ImportJob>`, :ref:`IndexingJob.details.externalInfo <Hibernate version of class omero.model.IndexingJob>`, :ref:`Instrument.details.externalInfo <Hibernate version of class omero.model.Instrument>`, :ref:`InstrumentAnnotationLink.details.externalInfo <Hibernate version of class omero.model.InstrumentAnnotationLink>`, :ref:`IntegrityCheckJob.details.externalInfo <Hibernate version of class omero.model.IntegrityCheckJob>`, :ref:`Job.details.externalInfo <Hibernate version of class omero.model.Job>`, :ref:`JobOriginalFileLink.details.externalInfo <Hibernate version of class omero.model.JobOriginalFileLink>`, :ref:`JobStatus.details.externalInfo <Hibernate version of class omero.model.JobStatus>`, :ref:`Label.details.externalInfo <Hibernate version of class omero.model.Label>`, :ref:`Laser.details.externalInfo <Hibernate version of class omero.model.Laser>`, :ref:`LaserMedium.details.externalInfo <Hibernate version of class omero.model.LaserMedium>`, :ref:`LaserType.details.externalInfo <Hibernate version of class omero.model.LaserType>`, :ref:`LightEmittingDiode.details.externalInfo <Hibernate version of class omero.model.LightEmittingDiode>`, :ref:`LightPath.details.externalInfo <Hibernate version of class omero.model.LightPath>`, :ref:`LightPathAnnotationLink.details.externalInfo <Hibernate version of class omero.model.LightPathAnnotationLink>`, :ref:`LightPathEmissionFilterLink.details.externalInfo <Hibernate version of class omero.model.LightPathEmissionFilterLink>`, :ref:`LightPathExcitationFilterLink.details.externalInfo <Hibernate version of class omero.model.LightPathExcitationFilterLink>`, :ref:`LightSettings.details.externalInfo <Hibernate version of class omero.model.LightSettings>`, :ref:`LightSource.details.externalInfo <Hibernate version of class omero.model.LightSource>`, :ref:`LightSourceAnnotationLink.details.externalInfo <Hibernate version of class omero.model.LightSourceAnnotationLink>`, :ref:`Line.details.externalInfo <Hibernate version of class omero.model.Line>`, :ref:`Link.details.externalInfo <Hibernate version of class omero.model.Link>`, :ref:`ListAnnotation.details.externalInfo <Hibernate version of class omero.model.ListAnnotation>`, :ref:`LogicalChannel.details.externalInfo <Hibernate version of class omero.model.LogicalChannel>`, :ref:`LongAnnotation.details.externalInfo <Hibernate version of class omero.model.LongAnnotation>`, :ref:`MapAnnotation.details.externalInfo <Hibernate version of class omero.model.MapAnnotation>`, :ref:`Mask.details.externalInfo <Hibernate version of class omero.model.Mask>`, :ref:`Medium.details.externalInfo <Hibernate version of class omero.model.Medium>`, :ref:`MetadataImportJob.details.externalInfo <Hibernate version of class omero.model.MetadataImportJob>`, :ref:`MicrobeamManipulation.details.externalInfo <Hibernate version of class omero.model.MicrobeamManipulation>`, :ref:`MicrobeamManipulationType.details.externalInfo <Hibernate version of class omero.model.MicrobeamManipulationType>`, :ref:`Microscope.details.externalInfo <Hibernate version of class omero.model.Microscope>`, :ref:`MicroscopeType.details.externalInfo <Hibernate version of class omero.model.MicroscopeType>`, :ref:`Namespace.details.externalInfo <Hibernate version of class omero.model.Namespace>`, :ref:`NamespaceAnnotationLink.details.externalInfo <Hibernate version of class omero.model.NamespaceAnnotationLink>`, :ref:`Node.details.externalInfo <Hibernate version of class omero.model.Node>`, :ref:`NodeAnnotationLink.details.externalInfo <Hibernate version of class omero.model.NodeAnnotationLink>`, :ref:`NumericAnnotation.details.externalInfo <Hibernate version of class omero.model.NumericAnnotation>`, :ref:`OTF.details.externalInfo <Hibernate version of class omero.model.OTF>`, :ref:`Objective.details.externalInfo <Hibernate version of class omero.model.Objective>`, :ref:`ObjectiveAnnotationLink.details.externalInfo <Hibernate version of class omero.model.ObjectiveAnnotationLink>`, :ref:`ObjectiveSettings.details.externalInfo <Hibernate version of class omero.model.ObjectiveSettings>`, :ref:`OriginalFile.details.externalInfo <Hibernate version of class omero.model.OriginalFile>`, :ref:`OriginalFileAnnotationLink.details.externalInfo <Hibernate version of class omero.model.OriginalFileAnnotationLink>`, :ref:`ParseJob.details.externalInfo <Hibernate version of class omero.model.ParseJob>`, :ref:`Path.details.externalInfo <Hibernate version of class omero.model.Path>`, :ref:`PhotometricInterpretation.details.externalInfo <Hibernate version of class omero.model.PhotometricInterpretation>`, :ref:`PixelDataJob.details.externalInfo <Hibernate version of class omero.model.PixelDataJob>`, :ref:`Pixels.details.externalInfo <Hibernate version of class omero.model.Pixels>`, :ref:`PixelsOriginalFileMap.details.externalInfo <Hibernate version of class omero.model.PixelsOriginalFileMap>`, :ref:`PixelsType.details.externalInfo <Hibernate version of class omero.model.PixelsType>`, :ref:`PlaneInfo.details.externalInfo <Hibernate version of class omero.model.PlaneInfo>`, :ref:`PlaneInfoAnnotationLink.details.externalInfo <Hibernate version of class omero.model.PlaneInfoAnnotationLink>`, :ref:`PlaneSlicingContext.details.externalInfo <Hibernate version of class omero.model.PlaneSlicingContext>`, :ref:`Plate.details.externalInfo <Hibernate version of class omero.model.Plate>`, :ref:`PlateAcquisition.details.externalInfo <Hibernate version of class omero.model.PlateAcquisition>`, :ref:`PlateAcquisitionAnnotationLink.details.externalInfo <Hibernate version of class omero.model.PlateAcquisitionAnnotationLink>`, :ref:`PlateAnnotationLink.details.externalInfo <Hibernate version of class omero.model.PlateAnnotationLink>`, :ref:`Point.details.externalInfo <Hibernate version of class omero.model.Point>`, :ref:`Polygon.details.externalInfo <Hibernate version of class omero.model.Polygon>`, :ref:`Polyline.details.externalInfo <Hibernate version of class omero.model.Polyline>`, :ref:`Project.details.externalInfo <Hibernate version of class omero.model.Project>`, :ref:`ProjectAnnotationLink.details.externalInfo <Hibernate version of class omero.model.ProjectAnnotationLink>`, :ref:`ProjectDatasetLink.details.externalInfo <Hibernate version of class omero.model.ProjectDatasetLink>`, :ref:`Pulse.details.externalInfo <Hibernate version of class omero.model.Pulse>`, :ref:`QuantumDef.details.externalInfo <Hibernate version of class omero.model.QuantumDef>`, :ref:`Reagent.details.externalInfo <Hibernate version of class omero.model.Reagent>`, :ref:`ReagentAnnotationLink.details.externalInfo <Hibernate version of class omero.model.ReagentAnnotationLink>`, :ref:`Rect.details.externalInfo <Hibernate version of class omero.model.Rect>`, :ref:`RenderingDef.details.externalInfo <Hibernate version of class omero.model.RenderingDef>`, :ref:`RenderingModel.details.externalInfo <Hibernate version of class omero.model.RenderingModel>`, :ref:`ReverseIntensityContext.details.externalInfo <Hibernate version of class omero.model.ReverseIntensityContext>`, :ref:`Roi.details.externalInfo <Hibernate version of class omero.model.Roi>`, :ref:`RoiAnnotationLink.details.externalInfo <Hibernate version of class omero.model.RoiAnnotationLink>`, :ref:`Screen.details.externalInfo <Hibernate version of class omero.model.Screen>`, :ref:`ScreenAnnotationLink.details.externalInfo <Hibernate version of class omero.model.ScreenAnnotationLink>`, :ref:`ScreenPlateLink.details.externalInfo <Hibernate version of class omero.model.ScreenPlateLink>`, :ref:`ScriptJob.details.externalInfo <Hibernate version of class omero.model.ScriptJob>`, :ref:`Session.details.externalInfo <Hibernate version of class omero.model.Session>`, :ref:`SessionAnnotationLink.details.externalInfo <Hibernate version of class omero.model.SessionAnnotationLink>`, :ref:`Shape.details.externalInfo <Hibernate version of class omero.model.Shape>`, :ref:`ShapeAnnotationLink.details.externalInfo <Hibernate version of class omero.model.ShapeAnnotationLink>`, :ref:`Share.details.externalInfo <Hibernate version of class omero.model.Share>`, :ref:`ShareMember.details.externalInfo <Hibernate version of class omero.model.ShareMember>`, :ref:`StageLabel.details.externalInfo <Hibernate version of class omero.model.StageLabel>`, :ref:`StatsInfo.details.externalInfo <Hibernate version of class omero.model.StatsInfo>`, :ref:`TagAnnotation.details.externalInfo <Hibernate version of class omero.model.TagAnnotation>`, :ref:`TermAnnotation.details.externalInfo <Hibernate version of class omero.model.TermAnnotation>`, :ref:`TextAnnotation.details.externalInfo <Hibernate version of class omero.model.TextAnnotation>`, :ref:`Thumbnail.details.externalInfo <Hibernate version of class omero.model.Thumbnail>`, :ref:`ThumbnailGenerationJob.details.externalInfo <Hibernate version of class omero.model.ThumbnailGenerationJob>`, :ref:`TimestampAnnotation.details.externalInfo <Hibernate version of class omero.model.TimestampAnnotation>`, :ref:`TransmittanceRange.details.externalInfo <Hibernate version of class omero.model.TransmittanceRange>`, :ref:`TypeAnnotation.details.externalInfo <Hibernate version of class omero.model.TypeAnnotation>`, :ref:`UploadJob.details.externalInfo <Hibernate version of class omero.model.UploadJob>`, :ref:`Well.details.externalInfo <Hibernate version of class omero.model.Well>`, :ref:`WellAnnotationLink.details.externalInfo <Hibernate version of class omero.model.WellAnnotationLink>`, :ref:`WellReagentLink.details.externalInfo <Hibernate version of class omero.model.WellReagentLink>`, :ref:`WellSample.details.externalInfo <Hibernate version of class omero.model.WellSample>`, :ref:`XmlAnnotation.details.externalInfo <Hibernate version of class omero.model.XmlAnnotation>`
 
 Properties:
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
   | entityId: ``long``
   | entityType: ``string``
   | lsid: ``string`` (optional)
   | uuid: ``string`` (optional)
 
-.. _omero.model.Family:
+.. _Hibernate version of class omero.model.Family:
 
 Family
 """"""
 
-Used by: :ref:`ChannelBinding.family <omero.model.ChannelBinding>`
+Used by: :ref:`ChannelBinding.family <Hibernate version of class omero.model.ChannelBinding>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
 
-.. _omero.model.Filament:
+.. _Hibernate version of class omero.model.Filament:
 
 Filament
 """"""""
 
 Properties:
-  | annotationLinks: :ref:`LightSourceAnnotationLink <omero.model.LightSourceAnnotationLink>` (multiple) from :ref:`LightSource <omero.model.LightSource>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`LightSource <omero.model.LightSource>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`LightSource <omero.model.LightSource>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`LightSource <omero.model.LightSource>`
-  | details.permissions.perm1: ``long`` from :ref:`LightSource <omero.model.LightSource>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`LightSource <omero.model.LightSource>`
-  | instrument: :ref:`Instrument <omero.model.Instrument>` from :ref:`LightSource <omero.model.LightSource>`
-  | lotNumber: ``string`` (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | manufacturer: ``string`` (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | model: ``string`` (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | power.unit: enumeration (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | power.value: ``double`` (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | serialNumber: ``string`` (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | type: :ref:`FilamentType <omero.model.FilamentType>`
-  | version: ``integer`` (optional) from :ref:`LightSource <omero.model.LightSource>`
+  | annotationLinks: :ref:`LightSourceAnnotationLink <Hibernate version of class omero.model.LightSourceAnnotationLink>` (multiple) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | details.permissions.perm1: ``long`` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | instrument: :ref:`Instrument <Hibernate version of class omero.model.Instrument>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | lotNumber: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | manufacturer: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | model: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | power.unit: enumeration (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | power.value: ``double`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | serialNumber: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | type: :ref:`FilamentType <Hibernate version of class omero.model.FilamentType>`
+  | version: ``integer`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
 
-.. _omero.model.FilamentType:
+.. _Hibernate version of class omero.model.FilamentType:
 
 FilamentType
 """"""""""""
 
-Used by: :ref:`Filament.type <omero.model.Filament>`
+Used by: :ref:`Filament.type <Hibernate version of class omero.model.Filament>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
 
-.. _omero.model.FileAnnotation:
+.. _Hibernate version of class omero.model.FileAnnotation:
 
 FileAnnotation
 """"""""""""""
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <omero.model.Annotation>`
-  | description: ``text`` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.permissions.perm1: ``long`` from :ref:`Annotation <omero.model.Annotation>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Annotation <omero.model.Annotation>`
-  | file: :ref:`OriginalFile <omero.model.OriginalFile>` (optional)
-  | ns: ``string`` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | version: ``integer`` (optional) from :ref:`Annotation <omero.model.Annotation>`
+  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | description: ``text`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.permissions.perm1: ``long`` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | file: :ref:`OriginalFile <Hibernate version of class omero.model.OriginalFile>` (optional)
+  | name: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | ns: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | version: ``integer`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
 
-.. _omero.model.Fileset:
+.. _Hibernate version of class omero.model.Fileset:
 
 Fileset
 """""""
 
-Used by: :ref:`FilesetAnnotationLink.parent <omero.model.FilesetAnnotationLink>`, :ref:`FilesetEntry.fileset <omero.model.FilesetEntry>`, :ref:`FilesetJobLink.parent <omero.model.FilesetJobLink>`, :ref:`Image.fileset <omero.model.Image>`
+Used by: :ref:`FilesetAnnotationLink.parent <Hibernate version of class omero.model.FilesetAnnotationLink>`, :ref:`FilesetEntry.fileset <Hibernate version of class omero.model.FilesetEntry>`, :ref:`FilesetJobLink.parent <Hibernate version of class omero.model.FilesetJobLink>`, :ref:`Image.fileset <Hibernate version of class omero.model.Image>`
 
 Properties:
-  | annotationLinks: :ref:`FilesetAnnotationLink <omero.model.FilesetAnnotationLink>` (multiple)
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | annotationLinks: :ref:`FilesetAnnotationLink <Hibernate version of class omero.model.FilesetAnnotationLink>` (multiple)
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | images: :ref:`Image <omero.model.Image>` (multiple)
-  | jobLinks: :ref:`FilesetJobLink <omero.model.FilesetJobLink>` (multiple)
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | images: :ref:`Image <Hibernate version of class omero.model.Image>` (multiple)
+  | jobLinks: :ref:`FilesetJobLink <Hibernate version of class omero.model.FilesetJobLink>` (multiple)
   | templatePrefix: ``text``
-  | usedFiles: :ref:`FilesetEntry <omero.model.FilesetEntry>` (multiple)
+  | usedFiles: :ref:`FilesetEntry <Hibernate version of class omero.model.FilesetEntry>` (multiple)
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.FilesetAnnotationLink:
+.. _Hibernate version of class omero.model.FilesetAnnotationLink:
 
 FilesetAnnotationLink
 """""""""""""""""""""
 
-Used by: :ref:`Fileset.annotationLinks <omero.model.Fileset>`
+Used by: :ref:`Fileset.annotationLinks <Hibernate version of class omero.model.Fileset>`
 
 Properties:
-  | child: :ref:`Annotation <omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`Fileset <omero.model.Fileset>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`Fileset <Hibernate version of class omero.model.Fileset>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.FilesetEntry:
+.. _Hibernate version of class omero.model.FilesetEntry:
 
 FilesetEntry
 """"""""""""
 
-Used by: :ref:`Fileset.usedFiles <omero.model.Fileset>`
+Used by: :ref:`Fileset.usedFiles <Hibernate version of class omero.model.Fileset>`
 
 Properties:
   | clientPath: ``text``
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | fileset: :ref:`Fileset <omero.model.Fileset>`
-  | originalFile: :ref:`OriginalFile <omero.model.OriginalFile>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | fileset: :ref:`Fileset <Hibernate version of class omero.model.Fileset>`
+  | originalFile: :ref:`OriginalFile <Hibernate version of class omero.model.OriginalFile>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.FilesetJobLink:
+.. _Hibernate version of class omero.model.FilesetJobLink:
 
 FilesetJobLink
 """"""""""""""
 
-Used by: :ref:`Fileset.jobLinks <omero.model.Fileset>`
+Used by: :ref:`Fileset.jobLinks <Hibernate version of class omero.model.Fileset>`
 
 Properties:
-  | child: :ref:`Job <omero.model.Job>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Job <Hibernate version of class omero.model.Job>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`Fileset <omero.model.Fileset>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`Fileset <Hibernate version of class omero.model.Fileset>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.Filter:
+.. _Hibernate version of class omero.model.Filter:
 
 Filter
 """"""
 
-Used by: :ref:`FilterAnnotationLink.parent <omero.model.FilterAnnotationLink>`, :ref:`FilterSetEmissionFilterLink.child <omero.model.FilterSetEmissionFilterLink>`, :ref:`FilterSetExcitationFilterLink.child <omero.model.FilterSetExcitationFilterLink>`, :ref:`Instrument.filter <omero.model.Instrument>`, :ref:`LightPathEmissionFilterLink.child <omero.model.LightPathEmissionFilterLink>`, :ref:`LightPathExcitationFilterLink.child <omero.model.LightPathExcitationFilterLink>`
+Used by: :ref:`FilterAnnotationLink.parent <Hibernate version of class omero.model.FilterAnnotationLink>`, :ref:`FilterSetEmissionFilterLink.child <Hibernate version of class omero.model.FilterSetEmissionFilterLink>`, :ref:`FilterSetExcitationFilterLink.child <Hibernate version of class omero.model.FilterSetExcitationFilterLink>`, :ref:`Instrument.filter <Hibernate version of class omero.model.Instrument>`, :ref:`LightPathEmissionFilterLink.child <Hibernate version of class omero.model.LightPathEmissionFilterLink>`, :ref:`LightPathExcitationFilterLink.child <Hibernate version of class omero.model.LightPathExcitationFilterLink>`
 
 Properties:
-  | annotationLinks: :ref:`FilterAnnotationLink <omero.model.FilterAnnotationLink>` (multiple)
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | annotationLinks: :ref:`FilterAnnotationLink <Hibernate version of class omero.model.FilterAnnotationLink>` (multiple)
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | emissionFilterLink: :ref:`FilterSetEmissionFilterLink <omero.model.FilterSetEmissionFilterLink>` (multiple)
-  | excitationFilterLink: :ref:`FilterSetExcitationFilterLink <omero.model.FilterSetExcitationFilterLink>` (multiple)
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | emissionFilterLink: :ref:`FilterSetEmissionFilterLink <Hibernate version of class omero.model.FilterSetEmissionFilterLink>` (multiple)
+  | excitationFilterLink: :ref:`FilterSetExcitationFilterLink <Hibernate version of class omero.model.FilterSetExcitationFilterLink>` (multiple)
   | filterWheel: ``string`` (optional)
-  | instrument: :ref:`Instrument <omero.model.Instrument>`
+  | instrument: :ref:`Instrument <Hibernate version of class omero.model.Instrument>`
   | lotNumber: ``string`` (optional)
   | manufacturer: ``string`` (optional)
   | model: ``string`` (optional)
   | serialNumber: ``string`` (optional)
-  | transmittanceRange: :ref:`TransmittanceRange <omero.model.TransmittanceRange>` (optional)
-  | type: :ref:`FilterType <omero.model.FilterType>` (optional)
+  | transmittanceRange: :ref:`TransmittanceRange <Hibernate version of class omero.model.TransmittanceRange>` (optional)
+  | type: :ref:`FilterType <Hibernate version of class omero.model.FilterType>` (optional)
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.FilterAnnotationLink:
+.. _Hibernate version of class omero.model.FilterAnnotationLink:
 
 FilterAnnotationLink
 """"""""""""""""""""
 
-Used by: :ref:`Filter.annotationLinks <omero.model.Filter>`
+Used by: :ref:`Filter.annotationLinks <Hibernate version of class omero.model.Filter>`
 
 Properties:
-  | child: :ref:`Annotation <omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`Filter <omero.model.Filter>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`Filter <Hibernate version of class omero.model.Filter>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.FilterSet:
+.. _Hibernate version of class omero.model.FilterSet:
 
 FilterSet
 """""""""
 
-Used by: :ref:`FilterSetEmissionFilterLink.parent <omero.model.FilterSetEmissionFilterLink>`, :ref:`FilterSetExcitationFilterLink.parent <omero.model.FilterSetExcitationFilterLink>`, :ref:`Instrument.filterSet <omero.model.Instrument>`, :ref:`LogicalChannel.filterSet <omero.model.LogicalChannel>`, :ref:`OTF.filterSet <omero.model.OTF>`
+Used by: :ref:`FilterSetEmissionFilterLink.parent <Hibernate version of class omero.model.FilterSetEmissionFilterLink>`, :ref:`FilterSetExcitationFilterLink.parent <Hibernate version of class omero.model.FilterSetExcitationFilterLink>`, :ref:`Instrument.filterSet <Hibernate version of class omero.model.Instrument>`, :ref:`LogicalChannel.filterSet <Hibernate version of class omero.model.LogicalChannel>`, :ref:`OTF.filterSet <Hibernate version of class omero.model.OTF>`
 
 Properties:
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | dichroic: :ref:`Dichroic <omero.model.Dichroic>` (optional)
-  | emissionFilterLink: :ref:`FilterSetEmissionFilterLink <omero.model.FilterSetEmissionFilterLink>` (multiple)
-  | excitationFilterLink: :ref:`FilterSetExcitationFilterLink <omero.model.FilterSetExcitationFilterLink>` (multiple)
-  | instrument: :ref:`Instrument <omero.model.Instrument>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | dichroic: :ref:`Dichroic <Hibernate version of class omero.model.Dichroic>` (optional)
+  | emissionFilterLink: :ref:`FilterSetEmissionFilterLink <Hibernate version of class omero.model.FilterSetEmissionFilterLink>` (multiple)
+  | excitationFilterLink: :ref:`FilterSetExcitationFilterLink <Hibernate version of class omero.model.FilterSetExcitationFilterLink>` (multiple)
+  | instrument: :ref:`Instrument <Hibernate version of class omero.model.Instrument>`
   | lotNumber: ``string`` (optional)
   | manufacturer: ``string`` (optional)
   | model: ``string`` (optional)
   | serialNumber: ``string`` (optional)
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.FilterSetEmissionFilterLink:
+.. _Hibernate version of class omero.model.FilterSetEmissionFilterLink:
 
 FilterSetEmissionFilterLink
 """""""""""""""""""""""""""
 
-Used by: :ref:`Filter.emissionFilterLink <omero.model.Filter>`, :ref:`FilterSet.emissionFilterLink <omero.model.FilterSet>`
+Used by: :ref:`Filter.emissionFilterLink <Hibernate version of class omero.model.Filter>`, :ref:`FilterSet.emissionFilterLink <Hibernate version of class omero.model.FilterSet>`
 
 Properties:
-  | child: :ref:`Filter <omero.model.Filter>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Filter <Hibernate version of class omero.model.Filter>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`FilterSet <omero.model.FilterSet>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`FilterSet <Hibernate version of class omero.model.FilterSet>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.FilterSetExcitationFilterLink:
+.. _Hibernate version of class omero.model.FilterSetExcitationFilterLink:
 
 FilterSetExcitationFilterLink
 """""""""""""""""""""""""""""
 
-Used by: :ref:`Filter.excitationFilterLink <omero.model.Filter>`, :ref:`FilterSet.excitationFilterLink <omero.model.FilterSet>`
+Used by: :ref:`Filter.excitationFilterLink <Hibernate version of class omero.model.Filter>`, :ref:`FilterSet.excitationFilterLink <Hibernate version of class omero.model.FilterSet>`
 
 Properties:
-  | child: :ref:`Filter <omero.model.Filter>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Filter <Hibernate version of class omero.model.Filter>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`FilterSet <omero.model.FilterSet>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`FilterSet <Hibernate version of class omero.model.FilterSet>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.FilterType:
+.. _Hibernate version of class omero.model.FilterType:
 
 FilterType
 """"""""""
 
-Used by: :ref:`Filter.type <omero.model.Filter>`
+Used by: :ref:`Filter.type <Hibernate version of class omero.model.Filter>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
 
-.. _omero.model.Format:
+.. _Hibernate version of class omero.model.Format:
 
 Format
 """"""
 
-Used by: :ref:`Image.format <omero.model.Image>`
+Used by: :ref:`Image.format <Hibernate version of class omero.model.Image>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
 
-.. _omero.model.GenericExcitationSource:
+.. _Hibernate version of class omero.model.GenericExcitationSource:
 
 GenericExcitationSource
 """""""""""""""""""""""
 
 Properties:
-  | annotationLinks: :ref:`LightSourceAnnotationLink <omero.model.LightSourceAnnotationLink>` (multiple) from :ref:`LightSource <omero.model.LightSource>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`LightSource <omero.model.LightSource>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`LightSource <omero.model.LightSource>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`LightSource <omero.model.LightSource>`
-  | details.permissions.perm1: ``long`` from :ref:`LightSource <omero.model.LightSource>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`LightSource <omero.model.LightSource>`
-  | instrument: :ref:`Instrument <omero.model.Instrument>` from :ref:`LightSource <omero.model.LightSource>`
-  | lotNumber: ``string`` (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | manufacturer: ``string`` (optional) from :ref:`LightSource <omero.model.LightSource>`
+  | annotationLinks: :ref:`LightSourceAnnotationLink <Hibernate version of class omero.model.LightSourceAnnotationLink>` (multiple) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | details.permissions.perm1: ``long`` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | instrument: :ref:`Instrument <Hibernate version of class omero.model.Instrument>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | lotNumber: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | manufacturer: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
   | map: list (multiple)
-  | model: ``string`` (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | power.unit: enumeration (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | power.value: ``double`` (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | serialNumber: ``string`` (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | version: ``integer`` (optional) from :ref:`LightSource <omero.model.LightSource>`
+  | model: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | power.unit: enumeration (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | power.value: ``double`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | serialNumber: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | version: ``integer`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
 
-.. _omero.model.GroupExperimenterMap:
+.. _Hibernate version of class omero.model.GroupExperimenterMap:
 
 GroupExperimenterMap
 """"""""""""""""""""
 
-Used by: :ref:`Experimenter.groupExperimenterMap <omero.model.Experimenter>`, :ref:`ExperimenterGroup.groupExperimenterMap <omero.model.ExperimenterGroup>`
+Used by: :ref:`Experimenter.groupExperimenterMap <Hibernate version of class omero.model.Experimenter>`, :ref:`ExperimenterGroup.groupExperimenterMap <Hibernate version of class omero.model.ExperimenterGroup>`
 
 Properties:
-  | child: :ref:`Experimenter <omero.model.Experimenter>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | child: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | owner: ``boolean``
-  | parent: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | parent: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.Illumination:
+.. _Hibernate version of class omero.model.Illumination:
 
 Illumination
 """"""""""""
 
-Used by: :ref:`LogicalChannel.illumination <omero.model.LogicalChannel>`
+Used by: :ref:`LogicalChannel.illumination <Hibernate version of class omero.model.LogicalChannel>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
 
-.. _omero.model.Image:
+.. _Hibernate version of class omero.model.Image:
 
 Image
 """""
 
-Used by: :ref:`DatasetImageLink.child <omero.model.DatasetImageLink>`, :ref:`Fileset.images <omero.model.Fileset>`, :ref:`ImageAnnotationLink.parent <omero.model.ImageAnnotationLink>`, :ref:`Pixels.image <omero.model.Pixels>`, :ref:`Roi.image <omero.model.Roi>`, :ref:`WellSample.image <omero.model.WellSample>`
+Used by: :ref:`DatasetImageLink.child <Hibernate version of class omero.model.DatasetImageLink>`, :ref:`Fileset.images <Hibernate version of class omero.model.Fileset>`, :ref:`ImageAnnotationLink.parent <Hibernate version of class omero.model.ImageAnnotationLink>`, :ref:`Pixels.image <Hibernate version of class omero.model.Pixels>`, :ref:`Roi.image <Hibernate version of class omero.model.Roi>`, :ref:`WellSample.image <Hibernate version of class omero.model.WellSample>`
 
 Properties:
   | acquisitionDate: ``timestamp`` (optional)
-  | annotationLinks: :ref:`ImageAnnotationLink <omero.model.ImageAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`ImageAnnotationLink <Hibernate version of class omero.model.ImageAnnotationLink>` (multiple)
   | archived: ``boolean`` (optional)
-  | datasetLinks: :ref:`DatasetImageLink <omero.model.DatasetImageLink>` (multiple)
+  | datasetLinks: :ref:`DatasetImageLink <Hibernate version of class omero.model.DatasetImageLink>` (multiple)
   | description: ``text`` (optional)
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | experiment: :ref:`Experiment <omero.model.Experiment>` (optional)
-  | fileset: :ref:`Fileset <omero.model.Fileset>` (optional)
-  | format: :ref:`Format <omero.model.Format>` (optional)
-  | imagingEnvironment: :ref:`ImagingEnvironment <omero.model.ImagingEnvironment>` (optional)
-  | instrument: :ref:`Instrument <omero.model.Instrument>` (optional)
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | experiment: :ref:`Experiment <Hibernate version of class omero.model.Experiment>` (optional)
+  | fileset: :ref:`Fileset <Hibernate version of class omero.model.Fileset>` (optional)
+  | format: :ref:`Format <Hibernate version of class omero.model.Format>` (optional)
+  | imagingEnvironment: :ref:`ImagingEnvironment <Hibernate version of class omero.model.ImagingEnvironment>` (optional)
+  | instrument: :ref:`Instrument <Hibernate version of class omero.model.Instrument>` (optional)
   | name: ``string``
-  | objectiveSettings: :ref:`ObjectiveSettings <omero.model.ObjectiveSettings>` (optional)
+  | objectiveSettings: :ref:`ObjectiveSettings <Hibernate version of class omero.model.ObjectiveSettings>` (optional)
   | partial: ``boolean`` (optional)
-  | pixels: :ref:`Pixels <omero.model.Pixels>` (multiple)
-  | rois: :ref:`Roi <omero.model.Roi>` (multiple)
-  | stageLabel: :ref:`StageLabel <omero.model.StageLabel>` (optional)
+  | pixels: :ref:`Pixels <Hibernate version of class omero.model.Pixels>` (multiple)
+  | rois: :ref:`Roi <Hibernate version of class omero.model.Roi>` (multiple)
+  | series: ``integer`` (optional)
+  | stageLabel: :ref:`StageLabel <Hibernate version of class omero.model.StageLabel>` (optional)
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
-  | wellSamples: :ref:`WellSample <omero.model.WellSample>` (multiple)
+  | wellSamples: :ref:`WellSample <Hibernate version of class omero.model.WellSample>` (multiple)
 
-.. _omero.model.ImageAnnotationLink:
+.. _Hibernate version of class omero.model.ImageAnnotationLink:
 
 ImageAnnotationLink
 """""""""""""""""""
 
-Used by: :ref:`Image.annotationLinks <omero.model.Image>`
+Used by: :ref:`Image.annotationLinks <Hibernate version of class omero.model.Image>`
 
 Properties:
-  | child: :ref:`Annotation <omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`Image <omero.model.Image>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`Image <Hibernate version of class omero.model.Image>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.ImagingEnvironment:
+.. _Hibernate version of class omero.model.ImagingEnvironment:
 
 ImagingEnvironment
 """"""""""""""""""
 
-Used by: :ref:`Image.imagingEnvironment <omero.model.Image>`
+Used by: :ref:`Image.imagingEnvironment <Hibernate version of class omero.model.Image>`
 
 Properties:
   | airPressure.unit: enumeration (optional)
   | airPressure.value: ``double`` (optional)
   | co2percent: ``double`` (optional)
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
   | humidity: ``double`` (optional)
   | map: list (multiple)
   | temperature.unit: enumeration (optional)
   | temperature.value: ``double`` (optional)
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.Immersion:
+.. _Hibernate version of class omero.model.Immersion:
 
 Immersion
 """""""""
 
-Used by: :ref:`Objective.immersion <omero.model.Objective>`
+Used by: :ref:`Objective.immersion <Hibernate version of class omero.model.Objective>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
 
-.. _omero.model.ImportJob:
+.. _Hibernate version of class omero.model.ImportJob:
 
 ImportJob
 """""""""
 
 Properties:
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Job <omero.model.Job>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Job <omero.model.Job>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Job <omero.model.Job>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Job <omero.model.Job>`
-  | details.permissions.perm1: ``long`` from :ref:`Job <omero.model.Job>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Job <omero.model.Job>`
-  | finished: ``timestamp`` (optional) from :ref:`Job <omero.model.Job>`
-  | groupname: ``string`` from :ref:`Job <omero.model.Job>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.permissions.perm1: ``long`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | finished: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | groupname: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
   | imageDescription: ``string``
   | imageName: ``string``
-  | message: ``string`` from :ref:`Job <omero.model.Job>`
-  | originalFileLinks: :ref:`JobOriginalFileLink <omero.model.JobOriginalFileLink>` (multiple) from :ref:`Job <omero.model.Job>`
-  | scheduledFor: ``timestamp`` from :ref:`Job <omero.model.Job>`
-  | started: ``timestamp`` (optional) from :ref:`Job <omero.model.Job>`
-  | status: :ref:`JobStatus <omero.model.JobStatus>` from :ref:`Job <omero.model.Job>`
-  | submitted: ``timestamp`` from :ref:`Job <omero.model.Job>`
-  | type: ``string`` from :ref:`Job <omero.model.Job>`
-  | username: ``string`` from :ref:`Job <omero.model.Job>`
-  | version: ``integer`` (optional) from :ref:`Job <omero.model.Job>`
+  | message: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | originalFileLinks: :ref:`JobOriginalFileLink <Hibernate version of class omero.model.JobOriginalFileLink>` (multiple) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | scheduledFor: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | started: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | status: :ref:`JobStatus <Hibernate version of class omero.model.JobStatus>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | submitted: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | type: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | username: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | version: ``integer`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
 
-.. _omero.model.IndexingJob:
+.. _Hibernate version of class omero.model.IndexingJob:
 
 IndexingJob
 """""""""""
 
 Properties:
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Job <omero.model.Job>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Job <omero.model.Job>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Job <omero.model.Job>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Job <omero.model.Job>`
-  | details.permissions.perm1: ``long`` from :ref:`Job <omero.model.Job>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Job <omero.model.Job>`
-  | finished: ``timestamp`` (optional) from :ref:`Job <omero.model.Job>`
-  | groupname: ``string`` from :ref:`Job <omero.model.Job>`
-  | message: ``string`` from :ref:`Job <omero.model.Job>`
-  | originalFileLinks: :ref:`JobOriginalFileLink <omero.model.JobOriginalFileLink>` (multiple) from :ref:`Job <omero.model.Job>`
-  | scheduledFor: ``timestamp`` from :ref:`Job <omero.model.Job>`
-  | started: ``timestamp`` (optional) from :ref:`Job <omero.model.Job>`
-  | status: :ref:`JobStatus <omero.model.JobStatus>` from :ref:`Job <omero.model.Job>`
-  | submitted: ``timestamp`` from :ref:`Job <omero.model.Job>`
-  | type: ``string`` from :ref:`Job <omero.model.Job>`
-  | username: ``string`` from :ref:`Job <omero.model.Job>`
-  | version: ``integer`` (optional) from :ref:`Job <omero.model.Job>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.permissions.perm1: ``long`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | finished: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | groupname: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | message: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | originalFileLinks: :ref:`JobOriginalFileLink <Hibernate version of class omero.model.JobOriginalFileLink>` (multiple) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | scheduledFor: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | started: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | status: :ref:`JobStatus <Hibernate version of class omero.model.JobStatus>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | submitted: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | type: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | username: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | version: ``integer`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
 
-.. _omero.model.Instrument:
+.. _Hibernate version of class omero.model.Instrument:
 
 Instrument
 """"""""""
 
-Used by: :ref:`Arc.instrument <omero.model.Arc>`, :ref:`Detector.instrument <omero.model.Detector>`, :ref:`Dichroic.instrument <omero.model.Dichroic>`, :ref:`Filament.instrument <omero.model.Filament>`, :ref:`Filter.instrument <omero.model.Filter>`, :ref:`FilterSet.instrument <omero.model.FilterSet>`, :ref:`GenericExcitationSource.instrument <omero.model.GenericExcitationSource>`, :ref:`Image.instrument <omero.model.Image>`, :ref:`InstrumentAnnotationLink.parent <omero.model.InstrumentAnnotationLink>`, :ref:`Laser.instrument <omero.model.Laser>`, :ref:`LightEmittingDiode.instrument <omero.model.LightEmittingDiode>`, :ref:`LightSource.instrument <omero.model.LightSource>`, :ref:`OTF.instrument <omero.model.OTF>`, :ref:`Objective.instrument <omero.model.Objective>`
+Used by: :ref:`Arc.instrument <Hibernate version of class omero.model.Arc>`, :ref:`Detector.instrument <Hibernate version of class omero.model.Detector>`, :ref:`Dichroic.instrument <Hibernate version of class omero.model.Dichroic>`, :ref:`Filament.instrument <Hibernate version of class omero.model.Filament>`, :ref:`Filter.instrument <Hibernate version of class omero.model.Filter>`, :ref:`FilterSet.instrument <Hibernate version of class omero.model.FilterSet>`, :ref:`GenericExcitationSource.instrument <Hibernate version of class omero.model.GenericExcitationSource>`, :ref:`Image.instrument <Hibernate version of class omero.model.Image>`, :ref:`InstrumentAnnotationLink.parent <Hibernate version of class omero.model.InstrumentAnnotationLink>`, :ref:`Laser.instrument <Hibernate version of class omero.model.Laser>`, :ref:`LightEmittingDiode.instrument <Hibernate version of class omero.model.LightEmittingDiode>`, :ref:`LightSource.instrument <Hibernate version of class omero.model.LightSource>`, :ref:`OTF.instrument <Hibernate version of class omero.model.OTF>`, :ref:`Objective.instrument <Hibernate version of class omero.model.Objective>`
 
 Properties:
-  | annotationLinks: :ref:`InstrumentAnnotationLink <omero.model.InstrumentAnnotationLink>` (multiple)
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | annotationLinks: :ref:`InstrumentAnnotationLink <Hibernate version of class omero.model.InstrumentAnnotationLink>` (multiple)
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | detector: :ref:`Detector <omero.model.Detector>` (multiple)
-  | dichroic: :ref:`Dichroic <omero.model.Dichroic>` (multiple)
-  | filter: :ref:`Filter <omero.model.Filter>` (multiple)
-  | filterSet: :ref:`FilterSet <omero.model.FilterSet>` (multiple)
-  | lightSource: :ref:`LightSource <omero.model.LightSource>` (multiple)
-  | microscope: :ref:`Microscope <omero.model.Microscope>` (optional)
-  | objective: :ref:`Objective <omero.model.Objective>` (multiple)
-  | otf: :ref:`OTF <omero.model.OTF>` (multiple)
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | detector: :ref:`Detector <Hibernate version of class omero.model.Detector>` (multiple)
+  | dichroic: :ref:`Dichroic <Hibernate version of class omero.model.Dichroic>` (multiple)
+  | filter: :ref:`Filter <Hibernate version of class omero.model.Filter>` (multiple)
+  | filterSet: :ref:`FilterSet <Hibernate version of class omero.model.FilterSet>` (multiple)
+  | lightSource: :ref:`LightSource <Hibernate version of class omero.model.LightSource>` (multiple)
+  | microscope: :ref:`Microscope <Hibernate version of class omero.model.Microscope>` (optional)
+  | objective: :ref:`Objective <Hibernate version of class omero.model.Objective>` (multiple)
+  | otf: :ref:`OTF <Hibernate version of class omero.model.OTF>` (multiple)
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.InstrumentAnnotationLink:
+.. _Hibernate version of class omero.model.InstrumentAnnotationLink:
 
 InstrumentAnnotationLink
 """"""""""""""""""""""""
 
-Used by: :ref:`Instrument.annotationLinks <omero.model.Instrument>`
+Used by: :ref:`Instrument.annotationLinks <Hibernate version of class omero.model.Instrument>`
 
 Properties:
-  | child: :ref:`Annotation <omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`Instrument <omero.model.Instrument>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`Instrument <Hibernate version of class omero.model.Instrument>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.IntegrityCheckJob:
+.. _Hibernate version of class omero.model.IntegrityCheckJob:
 
 IntegrityCheckJob
 """""""""""""""""
 
 Properties:
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Job <omero.model.Job>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Job <omero.model.Job>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Job <omero.model.Job>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Job <omero.model.Job>`
-  | details.permissions.perm1: ``long`` from :ref:`Job <omero.model.Job>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Job <omero.model.Job>`
-  | finished: ``timestamp`` (optional) from :ref:`Job <omero.model.Job>`
-  | groupname: ``string`` from :ref:`Job <omero.model.Job>`
-  | message: ``string`` from :ref:`Job <omero.model.Job>`
-  | originalFileLinks: :ref:`JobOriginalFileLink <omero.model.JobOriginalFileLink>` (multiple) from :ref:`Job <omero.model.Job>`
-  | scheduledFor: ``timestamp`` from :ref:`Job <omero.model.Job>`
-  | started: ``timestamp`` (optional) from :ref:`Job <omero.model.Job>`
-  | status: :ref:`JobStatus <omero.model.JobStatus>` from :ref:`Job <omero.model.Job>`
-  | submitted: ``timestamp`` from :ref:`Job <omero.model.Job>`
-  | type: ``string`` from :ref:`Job <omero.model.Job>`
-  | username: ``string`` from :ref:`Job <omero.model.Job>`
-  | version: ``integer`` (optional) from :ref:`Job <omero.model.Job>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.permissions.perm1: ``long`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | finished: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | groupname: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | message: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | originalFileLinks: :ref:`JobOriginalFileLink <Hibernate version of class omero.model.JobOriginalFileLink>` (multiple) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | scheduledFor: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | started: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | status: :ref:`JobStatus <Hibernate version of class omero.model.JobStatus>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | submitted: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | type: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | username: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | version: ``integer`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
 
-.. _omero.model.Job:
+.. _Hibernate version of class omero.model.Job:
 
 Job
 """
 
-Subclasses: :ref:`ImportJob <omero.model.ImportJob>`, :ref:`IndexingJob <omero.model.IndexingJob>`, :ref:`IntegrityCheckJob <omero.model.IntegrityCheckJob>`, :ref:`MetadataImportJob <omero.model.MetadataImportJob>`, :ref:`ParseJob <omero.model.ParseJob>`, :ref:`PixelDataJob <omero.model.PixelDataJob>`, :ref:`ScriptJob <omero.model.ScriptJob>`, :ref:`ThumbnailGenerationJob <omero.model.ThumbnailGenerationJob>`, :ref:`UploadJob <omero.model.UploadJob>`
+Subclasses: :ref:`ImportJob <Hibernate version of class omero.model.ImportJob>`, :ref:`IndexingJob <Hibernate version of class omero.model.IndexingJob>`, :ref:`IntegrityCheckJob <Hibernate version of class omero.model.IntegrityCheckJob>`, :ref:`MetadataImportJob <Hibernate version of class omero.model.MetadataImportJob>`, :ref:`ParseJob <Hibernate version of class omero.model.ParseJob>`, :ref:`PixelDataJob <Hibernate version of class omero.model.PixelDataJob>`, :ref:`ScriptJob <Hibernate version of class omero.model.ScriptJob>`, :ref:`ThumbnailGenerationJob <Hibernate version of class omero.model.ThumbnailGenerationJob>`, :ref:`UploadJob <Hibernate version of class omero.model.UploadJob>`
 
-Used by: :ref:`FilesetJobLink.child <omero.model.FilesetJobLink>`, :ref:`JobOriginalFileLink.parent <omero.model.JobOriginalFileLink>`
+Used by: :ref:`FilesetJobLink.child <Hibernate version of class omero.model.FilesetJobLink>`, :ref:`JobOriginalFileLink.parent <Hibernate version of class omero.model.JobOriginalFileLink>`
 
 Properties:
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
   | finished: ``timestamp`` (optional)
   | groupname: ``string``
   | message: ``string``
-  | originalFileLinks: :ref:`JobOriginalFileLink <omero.model.JobOriginalFileLink>` (multiple)
+  | originalFileLinks: :ref:`JobOriginalFileLink <Hibernate version of class omero.model.JobOriginalFileLink>` (multiple)
   | scheduledFor: ``timestamp``
   | started: ``timestamp`` (optional)
-  | status: :ref:`JobStatus <omero.model.JobStatus>`
+  | status: :ref:`JobStatus <Hibernate version of class omero.model.JobStatus>`
   | submitted: ``timestamp``
   | type: ``string``
   | username: ``string``
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.JobOriginalFileLink:
+.. _Hibernate version of class omero.model.JobOriginalFileLink:
 
 JobOriginalFileLink
 """""""""""""""""""
 
-Used by: :ref:`ImportJob.originalFileLinks <omero.model.ImportJob>`, :ref:`IndexingJob.originalFileLinks <omero.model.IndexingJob>`, :ref:`IntegrityCheckJob.originalFileLinks <omero.model.IntegrityCheckJob>`, :ref:`Job.originalFileLinks <omero.model.Job>`, :ref:`MetadataImportJob.originalFileLinks <omero.model.MetadataImportJob>`, :ref:`ParseJob.originalFileLinks <omero.model.ParseJob>`, :ref:`PixelDataJob.originalFileLinks <omero.model.PixelDataJob>`, :ref:`ScriptJob.originalFileLinks <omero.model.ScriptJob>`, :ref:`ThumbnailGenerationJob.originalFileLinks <omero.model.ThumbnailGenerationJob>`, :ref:`UploadJob.originalFileLinks <omero.model.UploadJob>`
+Used by: :ref:`ImportJob.originalFileLinks <Hibernate version of class omero.model.ImportJob>`, :ref:`IndexingJob.originalFileLinks <Hibernate version of class omero.model.IndexingJob>`, :ref:`IntegrityCheckJob.originalFileLinks <Hibernate version of class omero.model.IntegrityCheckJob>`, :ref:`Job.originalFileLinks <Hibernate version of class omero.model.Job>`, :ref:`MetadataImportJob.originalFileLinks <Hibernate version of class omero.model.MetadataImportJob>`, :ref:`ParseJob.originalFileLinks <Hibernate version of class omero.model.ParseJob>`, :ref:`PixelDataJob.originalFileLinks <Hibernate version of class omero.model.PixelDataJob>`, :ref:`ScriptJob.originalFileLinks <Hibernate version of class omero.model.ScriptJob>`, :ref:`ThumbnailGenerationJob.originalFileLinks <Hibernate version of class omero.model.ThumbnailGenerationJob>`, :ref:`UploadJob.originalFileLinks <Hibernate version of class omero.model.UploadJob>`
 
 Properties:
-  | child: :ref:`OriginalFile <omero.model.OriginalFile>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`OriginalFile <Hibernate version of class omero.model.OriginalFile>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`Job <omero.model.Job>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`Job <Hibernate version of class omero.model.Job>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.JobStatus:
+.. _Hibernate version of class omero.model.JobStatus:
 
 JobStatus
 """""""""
 
-Used by: :ref:`ImportJob.status <omero.model.ImportJob>`, :ref:`IndexingJob.status <omero.model.IndexingJob>`, :ref:`IntegrityCheckJob.status <omero.model.IntegrityCheckJob>`, :ref:`Job.status <omero.model.Job>`, :ref:`MetadataImportJob.status <omero.model.MetadataImportJob>`, :ref:`ParseJob.status <omero.model.ParseJob>`, :ref:`PixelDataJob.status <omero.model.PixelDataJob>`, :ref:`ScriptJob.status <omero.model.ScriptJob>`, :ref:`ThumbnailGenerationJob.status <omero.model.ThumbnailGenerationJob>`, :ref:`UploadJob.status <omero.model.UploadJob>`
+Used by: :ref:`ImportJob.status <Hibernate version of class omero.model.ImportJob>`, :ref:`IndexingJob.status <Hibernate version of class omero.model.IndexingJob>`, :ref:`IntegrityCheckJob.status <Hibernate version of class omero.model.IntegrityCheckJob>`, :ref:`Job.status <Hibernate version of class omero.model.Job>`, :ref:`MetadataImportJob.status <Hibernate version of class omero.model.MetadataImportJob>`, :ref:`ParseJob.status <Hibernate version of class omero.model.ParseJob>`, :ref:`PixelDataJob.status <Hibernate version of class omero.model.PixelDataJob>`, :ref:`ScriptJob.status <Hibernate version of class omero.model.ScriptJob>`, :ref:`ThumbnailGenerationJob.status <Hibernate version of class omero.model.ThumbnailGenerationJob>`, :ref:`UploadJob.status <Hibernate version of class omero.model.UploadJob>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
 
-.. _omero.model.Label:
+.. _Hibernate version of class omero.model.Label:
 
 Label
 """""
 
 Properties:
   | anchor: ``string`` (optional)
-  | annotationLinks: :ref:`ShapeAnnotationLink <omero.model.ShapeAnnotationLink>` (multiple) from :ref:`Shape <omero.model.Shape>`
+  | annotationLinks: :ref:`ShapeAnnotationLink <Hibernate version of class omero.model.ShapeAnnotationLink>` (multiple) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
   | baselineShift: ``string`` (optional)
   | decoration: ``string`` (optional)
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Shape <omero.model.Shape>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Shape <omero.model.Shape>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Shape <omero.model.Shape>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Shape <omero.model.Shape>`
-  | details.permissions.perm1: ``long`` from :ref:`Shape <omero.model.Shape>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Shape <omero.model.Shape>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.permissions.perm1: ``long`` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
   | direction: ``string`` (optional)
-  | fillColor: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fillRule: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontFamily: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontSize.unit: enumeration (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontSize.value: ``double`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontStretch: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontStyle: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontVariant: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontWeight: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | g: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
+  | fillColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fillRule: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontFamily: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontSize.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontSize.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontStretch: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontStyle: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontVariant: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontWeight: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | g: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
   | glyphOrientationVertical: ``integer`` (optional)
-  | locked: ``boolean`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | roi: :ref:`Roi <omero.model.Roi>` from :ref:`Shape <omero.model.Shape>`
-  | strokeColor: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeDashArray: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeLineCap: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeWidth.unit: enumeration (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <omero.model.Shape>`
+  | locked: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | roi: :ref:`Roi <Hibernate version of class omero.model.Roi>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeDashArray: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeLineCap: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeWidth.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
   | textValue: ``text`` (optional)
-  | theC: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | theT: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | theZ: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | transform: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | vectorEffect: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | version: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | visibility: ``boolean`` (optional) from :ref:`Shape <omero.model.Shape>`
+  | theC: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | theT: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | theZ: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | transform: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | vectorEffect: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | version: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | visibility: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
   | writingMode: ``string`` (optional)
   | x: ``double`` (optional)
   | y: ``double`` (optional)
 
-.. _omero.model.Laser:
+.. _Hibernate version of class omero.model.Laser:
 
 Laser
 """""
 
 Properties:
-  | annotationLinks: :ref:`LightSourceAnnotationLink <omero.model.LightSourceAnnotationLink>` (multiple) from :ref:`LightSource <omero.model.LightSource>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`LightSource <omero.model.LightSource>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`LightSource <omero.model.LightSource>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`LightSource <omero.model.LightSource>`
-  | details.permissions.perm1: ``long`` from :ref:`LightSource <omero.model.LightSource>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`LightSource <omero.model.LightSource>`
+  | annotationLinks: :ref:`LightSourceAnnotationLink <Hibernate version of class omero.model.LightSourceAnnotationLink>` (multiple) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | details.permissions.perm1: ``long`` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
   | frequencyMultiplication: ``integer`` (optional)
-  | instrument: :ref:`Instrument <omero.model.Instrument>` from :ref:`LightSource <omero.model.LightSource>`
-  | laserMedium: :ref:`LaserMedium <omero.model.LaserMedium>`
-  | lotNumber: ``string`` (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | manufacturer: ``string`` (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | model: ``string`` (optional) from :ref:`LightSource <omero.model.LightSource>`
+  | instrument: :ref:`Instrument <Hibernate version of class omero.model.Instrument>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | laserMedium: :ref:`LaserMedium <Hibernate version of class omero.model.LaserMedium>`
+  | lotNumber: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | manufacturer: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | model: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
   | pockelCell: ``boolean`` (optional)
-  | power.unit: enumeration (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | power.value: ``double`` (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | pulse: :ref:`Pulse <omero.model.Pulse>` (optional)
-  | pump: :ref:`LightSource <omero.model.LightSource>` (optional)
+  | power.unit: enumeration (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | power.value: ``double`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | pulse: :ref:`Pulse <Hibernate version of class omero.model.Pulse>` (optional)
+  | pump: :ref:`LightSource <Hibernate version of class omero.model.LightSource>` (optional)
   | repetitionRate.unit: enumeration (optional)
   | repetitionRate.value: ``double`` (optional)
-  | serialNumber: ``string`` (optional) from :ref:`LightSource <omero.model.LightSource>`
+  | serialNumber: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
   | tuneable: ``boolean`` (optional)
-  | type: :ref:`LaserType <omero.model.LaserType>`
-  | version: ``integer`` (optional) from :ref:`LightSource <omero.model.LightSource>`
+  | type: :ref:`LaserType <Hibernate version of class omero.model.LaserType>`
+  | version: ``integer`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
   | wavelength.unit: enumeration (optional)
   | wavelength.value: ``double`` (optional)
 
-.. _omero.model.LaserMedium:
+.. _Hibernate version of class omero.model.LaserMedium:
 
 LaserMedium
 """""""""""
 
-Used by: :ref:`Laser.laserMedium <omero.model.Laser>`
+Used by: :ref:`Laser.laserMedium <Hibernate version of class omero.model.Laser>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
 
-.. _omero.model.LaserType:
+.. _Hibernate version of class omero.model.LaserType:
 
 LaserType
 """""""""
 
-Used by: :ref:`Laser.type <omero.model.Laser>`
+Used by: :ref:`Laser.type <Hibernate version of class omero.model.Laser>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
 
-.. _omero.model.LightEmittingDiode:
+.. _Hibernate version of class omero.model.LightEmittingDiode:
 
 LightEmittingDiode
 """"""""""""""""""
 
 Properties:
-  | annotationLinks: :ref:`LightSourceAnnotationLink <omero.model.LightSourceAnnotationLink>` (multiple) from :ref:`LightSource <omero.model.LightSource>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`LightSource <omero.model.LightSource>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`LightSource <omero.model.LightSource>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`LightSource <omero.model.LightSource>`
-  | details.permissions.perm1: ``long`` from :ref:`LightSource <omero.model.LightSource>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`LightSource <omero.model.LightSource>`
-  | instrument: :ref:`Instrument <omero.model.Instrument>` from :ref:`LightSource <omero.model.LightSource>`
-  | lotNumber: ``string`` (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | manufacturer: ``string`` (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | model: ``string`` (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | power.unit: enumeration (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | power.value: ``double`` (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | serialNumber: ``string`` (optional) from :ref:`LightSource <omero.model.LightSource>`
-  | version: ``integer`` (optional) from :ref:`LightSource <omero.model.LightSource>`
+  | annotationLinks: :ref:`LightSourceAnnotationLink <Hibernate version of class omero.model.LightSourceAnnotationLink>` (multiple) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | details.permissions.perm1: ``long`` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | instrument: :ref:`Instrument <Hibernate version of class omero.model.Instrument>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | lotNumber: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | manufacturer: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | model: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | power.unit: enumeration (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | power.value: ``double`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | serialNumber: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | version: ``integer`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
 
-.. _omero.model.LightPath:
+.. _Hibernate version of class omero.model.LightPath:
 
 LightPath
 """""""""
 
-Used by: :ref:`LightPathAnnotationLink.parent <omero.model.LightPathAnnotationLink>`, :ref:`LightPathEmissionFilterLink.parent <omero.model.LightPathEmissionFilterLink>`, :ref:`LightPathExcitationFilterLink.parent <omero.model.LightPathExcitationFilterLink>`, :ref:`LogicalChannel.lightPath <omero.model.LogicalChannel>`
+Used by: :ref:`LightPathAnnotationLink.parent <Hibernate version of class omero.model.LightPathAnnotationLink>`, :ref:`LightPathEmissionFilterLink.parent <Hibernate version of class omero.model.LightPathEmissionFilterLink>`, :ref:`LightPathExcitationFilterLink.parent <Hibernate version of class omero.model.LightPathExcitationFilterLink>`, :ref:`LogicalChannel.lightPath <Hibernate version of class omero.model.LogicalChannel>`
 
 Properties:
-  | annotationLinks: :ref:`LightPathAnnotationLink <omero.model.LightPathAnnotationLink>` (multiple)
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | annotationLinks: :ref:`LightPathAnnotationLink <Hibernate version of class omero.model.LightPathAnnotationLink>` (multiple)
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | dichroic: :ref:`Dichroic <omero.model.Dichroic>` (optional)
-  | emissionFilterLink: :ref:`LightPathEmissionFilterLink <omero.model.LightPathEmissionFilterLink>` (multiple)
-  | excitationFilterLink: :ref:`LightPathExcitationFilterLink <omero.model.LightPathExcitationFilterLink>` (multiple)
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | dichroic: :ref:`Dichroic <Hibernate version of class omero.model.Dichroic>` (optional)
+  | emissionFilterLink: :ref:`LightPathEmissionFilterLink <Hibernate version of class omero.model.LightPathEmissionFilterLink>` (multiple)
+  | excitationFilterLink: :ref:`LightPathExcitationFilterLink <Hibernate version of class omero.model.LightPathExcitationFilterLink>` (multiple)
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.LightPathAnnotationLink:
+.. _Hibernate version of class omero.model.LightPathAnnotationLink:
 
 LightPathAnnotationLink
 """""""""""""""""""""""
 
-Used by: :ref:`LightPath.annotationLinks <omero.model.LightPath>`
+Used by: :ref:`LightPath.annotationLinks <Hibernate version of class omero.model.LightPath>`
 
 Properties:
-  | child: :ref:`Annotation <omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`LightPath <omero.model.LightPath>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`LightPath <Hibernate version of class omero.model.LightPath>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.LightPathEmissionFilterLink:
+.. _Hibernate version of class omero.model.LightPathEmissionFilterLink:
 
 LightPathEmissionFilterLink
 """""""""""""""""""""""""""
 
-Used by: :ref:`LightPath.emissionFilterLink <omero.model.LightPath>`
+Used by: :ref:`LightPath.emissionFilterLink <Hibernate version of class omero.model.LightPath>`
 
 Properties:
-  | child: :ref:`Filter <omero.model.Filter>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Filter <Hibernate version of class omero.model.Filter>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`LightPath <omero.model.LightPath>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`LightPath <Hibernate version of class omero.model.LightPath>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.LightPathExcitationFilterLink:
+.. _Hibernate version of class omero.model.LightPathExcitationFilterLink:
 
 LightPathExcitationFilterLink
 """""""""""""""""""""""""""""
 
-Used by: :ref:`LightPath.excitationFilterLink <omero.model.LightPath>`
+Used by: :ref:`LightPath.excitationFilterLink <Hibernate version of class omero.model.LightPath>`
 
 Properties:
-  | child: :ref:`Filter <omero.model.Filter>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Filter <Hibernate version of class omero.model.Filter>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`LightPath <omero.model.LightPath>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`LightPath <Hibernate version of class omero.model.LightPath>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.LightSettings:
+.. _Hibernate version of class omero.model.LightSettings:
 
 LightSettings
 """""""""""""
 
-Used by: :ref:`LogicalChannel.lightSourceSettings <omero.model.LogicalChannel>`, :ref:`MicrobeamManipulation.lightSourceSettings <omero.model.MicrobeamManipulation>`
+Used by: :ref:`LogicalChannel.lightSourceSettings <Hibernate version of class omero.model.LogicalChannel>`, :ref:`MicrobeamManipulation.lightSourceSettings <Hibernate version of class omero.model.MicrobeamManipulation>`
 
 Properties:
   | attenuation: ``double`` (optional)
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | lightSource: :ref:`LightSource <omero.model.LightSource>`
-  | microbeamManipulation: :ref:`MicrobeamManipulation <omero.model.MicrobeamManipulation>` (optional)
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | lightSource: :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | microbeamManipulation: :ref:`MicrobeamManipulation <Hibernate version of class omero.model.MicrobeamManipulation>` (optional)
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
   | wavelength.unit: enumeration (optional)
   | wavelength.value: ``double`` (optional)
 
-.. _omero.model.LightSource:
+.. _Hibernate version of class omero.model.LightSource:
 
 LightSource
 """""""""""
 
-Subclasses: :ref:`Arc <omero.model.Arc>`, :ref:`Filament <omero.model.Filament>`, :ref:`GenericExcitationSource <omero.model.GenericExcitationSource>`, :ref:`Laser <omero.model.Laser>`, :ref:`LightEmittingDiode <omero.model.LightEmittingDiode>`
+Subclasses: :ref:`Arc <Hibernate version of class omero.model.Arc>`, :ref:`Filament <Hibernate version of class omero.model.Filament>`, :ref:`GenericExcitationSource <Hibernate version of class omero.model.GenericExcitationSource>`, :ref:`Laser <Hibernate version of class omero.model.Laser>`, :ref:`LightEmittingDiode <Hibernate version of class omero.model.LightEmittingDiode>`
 
-Used by: :ref:`Instrument.lightSource <omero.model.Instrument>`, :ref:`Laser.pump <omero.model.Laser>`, :ref:`LightSettings.lightSource <omero.model.LightSettings>`, :ref:`LightSourceAnnotationLink.parent <omero.model.LightSourceAnnotationLink>`
+Used by: :ref:`Instrument.lightSource <Hibernate version of class omero.model.Instrument>`, :ref:`Laser.pump <Hibernate version of class omero.model.Laser>`, :ref:`LightSettings.lightSource <Hibernate version of class omero.model.LightSettings>`, :ref:`LightSourceAnnotationLink.parent <Hibernate version of class omero.model.LightSourceAnnotationLink>`
 
 Properties:
-  | annotationLinks: :ref:`LightSourceAnnotationLink <omero.model.LightSourceAnnotationLink>` (multiple)
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | annotationLinks: :ref:`LightSourceAnnotationLink <Hibernate version of class omero.model.LightSourceAnnotationLink>` (multiple)
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | instrument: :ref:`Instrument <omero.model.Instrument>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | instrument: :ref:`Instrument <Hibernate version of class omero.model.Instrument>`
   | lotNumber: ``string`` (optional)
   | manufacturer: ``string`` (optional)
   | model: ``string`` (optional)
@@ -1585,463 +1592,464 @@ Properties:
   | serialNumber: ``string`` (optional)
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.LightSourceAnnotationLink:
+.. _Hibernate version of class omero.model.LightSourceAnnotationLink:
 
 LightSourceAnnotationLink
 """""""""""""""""""""""""
 
-Used by: :ref:`Arc.annotationLinks <omero.model.Arc>`, :ref:`Filament.annotationLinks <omero.model.Filament>`, :ref:`GenericExcitationSource.annotationLinks <omero.model.GenericExcitationSource>`, :ref:`Laser.annotationLinks <omero.model.Laser>`, :ref:`LightEmittingDiode.annotationLinks <omero.model.LightEmittingDiode>`, :ref:`LightSource.annotationLinks <omero.model.LightSource>`
+Used by: :ref:`Arc.annotationLinks <Hibernate version of class omero.model.Arc>`, :ref:`Filament.annotationLinks <Hibernate version of class omero.model.Filament>`, :ref:`GenericExcitationSource.annotationLinks <Hibernate version of class omero.model.GenericExcitationSource>`, :ref:`Laser.annotationLinks <Hibernate version of class omero.model.Laser>`, :ref:`LightEmittingDiode.annotationLinks <Hibernate version of class omero.model.LightEmittingDiode>`, :ref:`LightSource.annotationLinks <Hibernate version of class omero.model.LightSource>`
 
 Properties:
-  | child: :ref:`Annotation <omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`LightSource <omero.model.LightSource>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`LightSource <Hibernate version of class omero.model.LightSource>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.Line:
+.. _Hibernate version of class omero.model.Line:
 
 Line
 """"
 
 Properties:
-  | annotationLinks: :ref:`ShapeAnnotationLink <omero.model.ShapeAnnotationLink>` (multiple) from :ref:`Shape <omero.model.Shape>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Shape <omero.model.Shape>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Shape <omero.model.Shape>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Shape <omero.model.Shape>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Shape <omero.model.Shape>`
-  | details.permissions.perm1: ``long`` from :ref:`Shape <omero.model.Shape>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Shape <omero.model.Shape>`
-  | fillColor: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fillRule: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontFamily: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontSize.unit: enumeration (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontSize.value: ``double`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontStretch: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontStyle: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontVariant: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontWeight: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | g: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | locked: ``boolean`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | roi: :ref:`Roi <omero.model.Roi>` from :ref:`Shape <omero.model.Shape>`
-  | strokeColor: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeDashArray: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeLineCap: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeWidth.unit: enumeration (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <omero.model.Shape>`
+  | annotationLinks: :ref:`ShapeAnnotationLink <Hibernate version of class omero.model.ShapeAnnotationLink>` (multiple) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.permissions.perm1: ``long`` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fillColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fillRule: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontFamily: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontSize.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontSize.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontStretch: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontStyle: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontVariant: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontWeight: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | g: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | locked: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | roi: :ref:`Roi <Hibernate version of class omero.model.Roi>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeDashArray: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeLineCap: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeWidth.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
   | textValue: ``text`` (optional)
-  | theC: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | theT: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | theZ: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | transform: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | vectorEffect: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | version: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | visibility: ``boolean`` (optional) from :ref:`Shape <omero.model.Shape>`
+  | theC: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | theT: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | theZ: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | transform: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | vectorEffect: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | version: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | visibility: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
   | x1: ``double`` (optional)
   | x2: ``double`` (optional)
   | y1: ``double`` (optional)
   | y2: ``double`` (optional)
 
-.. _omero.model.Link:
+.. _Hibernate version of class omero.model.Link:
 
 Link
 """"
 
 Properties:
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.ListAnnotation:
+.. _Hibernate version of class omero.model.ListAnnotation:
 
 ListAnnotation
 """"""""""""""
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <omero.model.Annotation>`
-  | description: ``text`` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.permissions.perm1: ``long`` from :ref:`Annotation <omero.model.Annotation>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Annotation <omero.model.Annotation>`
-  | ns: ``string`` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | version: ``integer`` (optional) from :ref:`Annotation <omero.model.Annotation>`
+  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | description: ``text`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.permissions.perm1: ``long`` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | name: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | ns: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | version: ``integer`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
 
-.. _omero.model.LogicalChannel:
+.. _Hibernate version of class omero.model.LogicalChannel:
 
 LogicalChannel
 """"""""""""""
 
-Used by: :ref:`Channel.logicalChannel <omero.model.Channel>`
+Used by: :ref:`Channel.logicalChannel <Hibernate version of class omero.model.Channel>`
 
 Properties:
-  | channels: :ref:`Channel <omero.model.Channel>` (multiple)
-  | contrastMethod: :ref:`ContrastMethod <omero.model.ContrastMethod>` (optional)
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | channels: :ref:`Channel <Hibernate version of class omero.model.Channel>` (multiple)
+  | contrastMethod: :ref:`ContrastMethod <Hibernate version of class omero.model.ContrastMethod>` (optional)
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | detectorSettings: :ref:`DetectorSettings <omero.model.DetectorSettings>` (optional)
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | detectorSettings: :ref:`DetectorSettings <Hibernate version of class omero.model.DetectorSettings>` (optional)
   | emissionWave.unit: enumeration (optional)
   | emissionWave.value: ``double`` (optional)
   | excitationWave.unit: enumeration (optional)
   | excitationWave.value: ``double`` (optional)
-  | filterSet: :ref:`FilterSet <omero.model.FilterSet>` (optional)
+  | filterSet: :ref:`FilterSet <Hibernate version of class omero.model.FilterSet>` (optional)
   | fluor: ``string`` (optional)
-  | illumination: :ref:`Illumination <omero.model.Illumination>` (optional)
-  | lightPath: :ref:`LightPath <omero.model.LightPath>` (optional)
-  | lightSourceSettings: :ref:`LightSettings <omero.model.LightSettings>` (optional)
-  | mode: :ref:`AcquisitionMode <omero.model.AcquisitionMode>` (optional)
+  | illumination: :ref:`Illumination <Hibernate version of class omero.model.Illumination>` (optional)
+  | lightPath: :ref:`LightPath <Hibernate version of class omero.model.LightPath>` (optional)
+  | lightSourceSettings: :ref:`LightSettings <Hibernate version of class omero.model.LightSettings>` (optional)
+  | mode: :ref:`AcquisitionMode <Hibernate version of class omero.model.AcquisitionMode>` (optional)
   | name: ``string`` (optional)
   | ndFilter: ``double`` (optional)
-  | otf: :ref:`OTF <omero.model.OTF>` (optional)
-  | photometricInterpretation: :ref:`PhotometricInterpretation <omero.model.PhotometricInterpretation>` (optional)
+  | otf: :ref:`OTF <Hibernate version of class omero.model.OTF>` (optional)
+  | photometricInterpretation: :ref:`PhotometricInterpretation <Hibernate version of class omero.model.PhotometricInterpretation>` (optional)
   | pinHoleSize.unit: enumeration (optional)
   | pinHoleSize.value: ``double`` (optional)
   | pockelCellSetting: ``integer`` (optional)
   | samplesPerPixel: ``integer`` (optional)
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.LongAnnotation:
+.. _Hibernate version of class omero.model.LongAnnotation:
 
 LongAnnotation
 """"""""""""""
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <omero.model.Annotation>`
-  | description: ``text`` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.permissions.perm1: ``long`` from :ref:`Annotation <omero.model.Annotation>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Annotation <omero.model.Annotation>`
+  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | description: ``text`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.permissions.perm1: ``long`` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
   | longValue: ``long`` (optional)
-  | ns: ``string`` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | version: ``integer`` (optional) from :ref:`Annotation <omero.model.Annotation>`
+  | name: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | ns: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | version: ``integer`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
 
-.. _omero.model.MapAnnotation:
+.. _Hibernate version of class omero.model.MapAnnotation:
 
 MapAnnotation
 """""""""""""
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <omero.model.Annotation>`
-  | description: ``text`` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.permissions.perm1: ``long`` from :ref:`Annotation <omero.model.Annotation>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Annotation <omero.model.Annotation>`
+  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | description: ``text`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.permissions.perm1: ``long`` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
   | mapValue: list (multiple)
-  | ns: ``string`` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | version: ``integer`` (optional) from :ref:`Annotation <omero.model.Annotation>`
+  | name: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | ns: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | version: ``integer`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
 
-.. _omero.model.Mask:
+.. _Hibernate version of class omero.model.Mask:
 
 Mask
 """"
 
 Properties:
-  | annotationLinks: :ref:`ShapeAnnotationLink <omero.model.ShapeAnnotationLink>` (multiple) from :ref:`Shape <omero.model.Shape>`
+  | annotationLinks: :ref:`ShapeAnnotationLink <Hibernate version of class omero.model.ShapeAnnotationLink>` (multiple) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
   | bytes: ``binary`` (optional)
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Shape <omero.model.Shape>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Shape <omero.model.Shape>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Shape <omero.model.Shape>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Shape <omero.model.Shape>`
-  | details.permissions.perm1: ``long`` from :ref:`Shape <omero.model.Shape>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Shape <omero.model.Shape>`
-  | fillColor: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fillRule: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontFamily: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontSize.unit: enumeration (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontSize.value: ``double`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontStretch: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontStyle: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontVariant: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontWeight: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | g: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.permissions.perm1: ``long`` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fillColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fillRule: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontFamily: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontSize.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontSize.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontStretch: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontStyle: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontVariant: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontWeight: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | g: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
   | height: ``double`` (optional)
-  | locked: ``boolean`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | pixels: :ref:`Pixels <omero.model.Pixels>` (optional)
-  | roi: :ref:`Roi <omero.model.Roi>` from :ref:`Shape <omero.model.Shape>`
-  | strokeColor: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeDashArray: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeLineCap: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeWidth.unit: enumeration (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <omero.model.Shape>`
+  | locked: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | pixels: :ref:`Pixels <Hibernate version of class omero.model.Pixels>` (optional)
+  | roi: :ref:`Roi <Hibernate version of class omero.model.Roi>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeDashArray: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeLineCap: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeWidth.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
   | textValue: ``text`` (optional)
-  | theC: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | theT: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | theZ: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | transform: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | vectorEffect: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | version: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | visibility: ``boolean`` (optional) from :ref:`Shape <omero.model.Shape>`
+  | theC: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | theT: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | theZ: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | transform: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | vectorEffect: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | version: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | visibility: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
   | width: ``double`` (optional)
   | x: ``double`` (optional)
   | y: ``double`` (optional)
 
-.. _omero.model.Medium:
+.. _Hibernate version of class omero.model.Medium:
 
 Medium
 """"""
 
-Used by: :ref:`ObjectiveSettings.medium <omero.model.ObjectiveSettings>`
+Used by: :ref:`ObjectiveSettings.medium <Hibernate version of class omero.model.ObjectiveSettings>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
 
-.. _omero.model.MetadataImportJob:
+.. _Hibernate version of class omero.model.MetadataImportJob:
 
 MetadataImportJob
 """""""""""""""""
 
 Properties:
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Job <omero.model.Job>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Job <omero.model.Job>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Job <omero.model.Job>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Job <omero.model.Job>`
-  | details.permissions.perm1: ``long`` from :ref:`Job <omero.model.Job>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Job <omero.model.Job>`
-  | finished: ``timestamp`` (optional) from :ref:`Job <omero.model.Job>`
-  | groupname: ``string`` from :ref:`Job <omero.model.Job>`
-  | message: ``string`` from :ref:`Job <omero.model.Job>`
-  | originalFileLinks: :ref:`JobOriginalFileLink <omero.model.JobOriginalFileLink>` (multiple) from :ref:`Job <omero.model.Job>`
-  | scheduledFor: ``timestamp`` from :ref:`Job <omero.model.Job>`
-  | started: ``timestamp`` (optional) from :ref:`Job <omero.model.Job>`
-  | status: :ref:`JobStatus <omero.model.JobStatus>` from :ref:`Job <omero.model.Job>`
-  | submitted: ``timestamp`` from :ref:`Job <omero.model.Job>`
-  | type: ``string`` from :ref:`Job <omero.model.Job>`
-  | username: ``string`` from :ref:`Job <omero.model.Job>`
-  | version: ``integer`` (optional) from :ref:`Job <omero.model.Job>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.permissions.perm1: ``long`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | finished: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | groupname: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | message: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | originalFileLinks: :ref:`JobOriginalFileLink <Hibernate version of class omero.model.JobOriginalFileLink>` (multiple) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | scheduledFor: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | started: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | status: :ref:`JobStatus <Hibernate version of class omero.model.JobStatus>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | submitted: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | type: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | username: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | version: ``integer`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
   | versionInfo: list (multiple)
 
-.. _omero.model.MicrobeamManipulation:
+.. _Hibernate version of class omero.model.MicrobeamManipulation:
 
 MicrobeamManipulation
 """""""""""""""""""""
 
-Used by: :ref:`Experiment.microbeamManipulation <omero.model.Experiment>`, :ref:`LightSettings.microbeamManipulation <omero.model.LightSettings>`
+Used by: :ref:`Experiment.microbeamManipulation <Hibernate version of class omero.model.Experiment>`, :ref:`LightSettings.microbeamManipulation <Hibernate version of class omero.model.LightSettings>`
 
 Properties:
   | description: ``text`` (optional)
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | experiment: :ref:`Experiment <omero.model.Experiment>`
-  | lightSourceSettings: :ref:`LightSettings <omero.model.LightSettings>` (multiple)
-  | type: :ref:`MicrobeamManipulationType <omero.model.MicrobeamManipulationType>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | experiment: :ref:`Experiment <Hibernate version of class omero.model.Experiment>`
+  | lightSourceSettings: :ref:`LightSettings <Hibernate version of class omero.model.LightSettings>` (multiple)
+  | type: :ref:`MicrobeamManipulationType <Hibernate version of class omero.model.MicrobeamManipulationType>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.MicrobeamManipulationType:
+.. _Hibernate version of class omero.model.MicrobeamManipulationType:
 
 MicrobeamManipulationType
 """""""""""""""""""""""""
 
-Used by: :ref:`MicrobeamManipulation.type <omero.model.MicrobeamManipulation>`
+Used by: :ref:`MicrobeamManipulation.type <Hibernate version of class omero.model.MicrobeamManipulation>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
 
-.. _omero.model.Microscope:
+.. _Hibernate version of class omero.model.Microscope:
 
 Microscope
 """"""""""
 
-Used by: :ref:`Instrument.microscope <omero.model.Instrument>`
+Used by: :ref:`Instrument.microscope <Hibernate version of class omero.model.Instrument>`
 
 Properties:
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
   | lotNumber: ``string`` (optional)
   | manufacturer: ``string`` (optional)
   | model: ``string`` (optional)
   | serialNumber: ``string`` (optional)
-  | type: :ref:`MicroscopeType <omero.model.MicroscopeType>`
+  | type: :ref:`MicroscopeType <Hibernate version of class omero.model.MicroscopeType>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.MicroscopeType:
+.. _Hibernate version of class omero.model.MicroscopeType:
 
 MicroscopeType
 """"""""""""""
 
-Used by: :ref:`Microscope.type <omero.model.Microscope>`
+Used by: :ref:`Microscope.type <Hibernate version of class omero.model.Microscope>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
 
-.. _omero.model.Namespace:
+.. _Hibernate version of class omero.model.Namespace:
 
 Namespace
 """""""""
 
-Used by: :ref:`NamespaceAnnotationLink.parent <omero.model.NamespaceAnnotationLink>`
+Used by: :ref:`NamespaceAnnotationLink.parent <Hibernate version of class omero.model.NamespaceAnnotationLink>`
 
 Properties:
-  | annotationLinks: :ref:`NamespaceAnnotationLink <omero.model.NamespaceAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`NamespaceAnnotationLink <Hibernate version of class omero.model.NamespaceAnnotationLink>` (multiple)
   | description: ``text`` (optional)
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
   | display: ``boolean`` (optional)
+  | displayName: ``string`` (optional)
   | keywords: list (optional)
   | multivalued: ``boolean`` (optional)
   | name: ``string``
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.NamespaceAnnotationLink:
+.. _Hibernate version of class omero.model.NamespaceAnnotationLink:
 
 NamespaceAnnotationLink
 """""""""""""""""""""""
 
-Used by: :ref:`Namespace.annotationLinks <omero.model.Namespace>`
+Used by: :ref:`Namespace.annotationLinks <Hibernate version of class omero.model.Namespace>`
 
 Properties:
-  | child: :ref:`Annotation <omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`Namespace <omero.model.Namespace>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`Namespace <Hibernate version of class omero.model.Namespace>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.Node:
+.. _Hibernate version of class omero.model.Node:
 
 Node
 """"
 
-Used by: :ref:`NodeAnnotationLink.parent <omero.model.NodeAnnotationLink>`, :ref:`Session.node <omero.model.Session>`, :ref:`Share.node <omero.model.Share>`
+Used by: :ref:`NodeAnnotationLink.parent <Hibernate version of class omero.model.NodeAnnotationLink>`, :ref:`Session.node <Hibernate version of class omero.model.Session>`, :ref:`Share.node <Hibernate version of class omero.model.Share>`
 
 Properties:
-  | annotationLinks: :ref:`NodeAnnotationLink <omero.model.NodeAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`NodeAnnotationLink <Hibernate version of class omero.model.NodeAnnotationLink>` (multiple)
   | conn: ``text``
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | down: ``timestamp`` (optional)
   | scale: ``integer`` (optional)
-  | sessions: :ref:`Session <omero.model.Session>` (multiple)
+  | sessions: :ref:`Session <Hibernate version of class omero.model.Session>` (multiple)
   | up: ``timestamp``
   | uuid: ``string``
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.NodeAnnotationLink:
+.. _Hibernate version of class omero.model.NodeAnnotationLink:
 
 NodeAnnotationLink
 """"""""""""""""""
 
-Used by: :ref:`Node.annotationLinks <omero.model.Node>`
+Used by: :ref:`Node.annotationLinks <Hibernate version of class omero.model.Node>`
 
 Properties:
-  | child: :ref:`Annotation <omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`Node <omero.model.Node>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`Node <Hibernate version of class omero.model.Node>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.NumericAnnotation:
+.. _Hibernate version of class omero.model.NumericAnnotation:
 
 NumericAnnotation
 """""""""""""""""
 
-Subclasses: :ref:`DoubleAnnotation <omero.model.DoubleAnnotation>`, :ref:`LongAnnotation <omero.model.LongAnnotation>`
+Subclasses: :ref:`DoubleAnnotation <Hibernate version of class omero.model.DoubleAnnotation>`, :ref:`LongAnnotation <Hibernate version of class omero.model.LongAnnotation>`
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <omero.model.Annotation>`
-  | description: ``text`` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.permissions.perm1: ``long`` from :ref:`Annotation <omero.model.Annotation>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Annotation <omero.model.Annotation>`
-  | ns: ``string`` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | version: ``integer`` (optional) from :ref:`Annotation <omero.model.Annotation>`
+  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | description: ``text`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.permissions.perm1: ``long`` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | name: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | ns: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | version: ``integer`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
 
-.. _omero.model.OTF:
+.. _Hibernate version of class omero.model.OTF:
 
 OTF
 """
 
-Used by: :ref:`Instrument.otf <omero.model.Instrument>`, :ref:`LogicalChannel.otf <omero.model.LogicalChannel>`
+Used by: :ref:`Instrument.otf <Hibernate version of class omero.model.Instrument>`, :ref:`LogicalChannel.otf <Hibernate version of class omero.model.LogicalChannel>`
 
 Properties:
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | filterSet: :ref:`FilterSet <omero.model.FilterSet>` (optional)
-  | instrument: :ref:`Instrument <omero.model.Instrument>`
-  | objective: :ref:`Objective <omero.model.Objective>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | filterSet: :ref:`FilterSet <Hibernate version of class omero.model.FilterSet>` (optional)
+  | instrument: :ref:`Instrument <Hibernate version of class omero.model.Instrument>`
+  | objective: :ref:`Objective <Hibernate version of class omero.model.Objective>`
   | opticalAxisAveraged: ``boolean``
   | path: ``string``
-  | pixelsType: :ref:`PixelsType <omero.model.PixelsType>`
+  | pixelsType: :ref:`PixelsType <Hibernate version of class omero.model.PixelsType>`
   | sizeX: ``integer``
   | sizeY: ``integer``
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.Objective:
+.. _Hibernate version of class omero.model.Objective:
 
 Objective
 """""""""
 
-Used by: :ref:`Instrument.objective <omero.model.Instrument>`, :ref:`OTF.objective <omero.model.OTF>`, :ref:`ObjectiveAnnotationLink.parent <omero.model.ObjectiveAnnotationLink>`, :ref:`ObjectiveSettings.objective <omero.model.ObjectiveSettings>`
+Used by: :ref:`Instrument.objective <Hibernate version of class omero.model.Instrument>`, :ref:`OTF.objective <Hibernate version of class omero.model.OTF>`, :ref:`ObjectiveAnnotationLink.parent <Hibernate version of class omero.model.ObjectiveAnnotationLink>`, :ref:`ObjectiveSettings.objective <Hibernate version of class omero.model.ObjectiveSettings>`
 
 Properties:
-  | annotationLinks: :ref:`ObjectiveAnnotationLink <omero.model.ObjectiveAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`ObjectiveAnnotationLink <Hibernate version of class omero.model.ObjectiveAnnotationLink>` (multiple)
   | calibratedMagnification: ``double`` (optional)
-  | correction: :ref:`Correction <omero.model.Correction>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | correction: :ref:`Correction <Hibernate version of class omero.model.Correction>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | immersion: :ref:`Immersion <omero.model.Immersion>`
-  | instrument: :ref:`Instrument <omero.model.Instrument>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | immersion: :ref:`Immersion <Hibernate version of class omero.model.Immersion>`
+  | instrument: :ref:`Instrument <Hibernate version of class omero.model.Instrument>`
   | iris: ``boolean`` (optional)
   | lensNA: ``double`` (optional)
   | lotNumber: ``string`` (optional)
@@ -2053,210 +2061,210 @@ Properties:
   | workingDistance.unit: enumeration (optional)
   | workingDistance.value: ``double`` (optional)
 
-.. _omero.model.ObjectiveAnnotationLink:
+.. _Hibernate version of class omero.model.ObjectiveAnnotationLink:
 
 ObjectiveAnnotationLink
 """""""""""""""""""""""
 
-Used by: :ref:`Objective.annotationLinks <omero.model.Objective>`
+Used by: :ref:`Objective.annotationLinks <Hibernate version of class omero.model.Objective>`
 
 Properties:
-  | child: :ref:`Annotation <omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`Objective <omero.model.Objective>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`Objective <Hibernate version of class omero.model.Objective>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.ObjectiveSettings:
+.. _Hibernate version of class omero.model.ObjectiveSettings:
 
 ObjectiveSettings
 """""""""""""""""
 
-Used by: :ref:`Image.objectiveSettings <omero.model.Image>`
+Used by: :ref:`Image.objectiveSettings <Hibernate version of class omero.model.Image>`
 
 Properties:
   | correctionCollar: ``double`` (optional)
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | medium: :ref:`Medium <omero.model.Medium>` (optional)
-  | objective: :ref:`Objective <omero.model.Objective>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | medium: :ref:`Medium <Hibernate version of class omero.model.Medium>` (optional)
+  | objective: :ref:`Objective <Hibernate version of class omero.model.Objective>`
   | refractiveIndex: ``double`` (optional)
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.OriginalFile:
+.. _Hibernate version of class omero.model.OriginalFile:
 
 OriginalFile
 """"""""""""
 
-Used by: :ref:`FileAnnotation.file <omero.model.FileAnnotation>`, :ref:`FilesetEntry.originalFile <omero.model.FilesetEntry>`, :ref:`JobOriginalFileLink.child <omero.model.JobOriginalFileLink>`, :ref:`OriginalFileAnnotationLink.parent <omero.model.OriginalFileAnnotationLink>`, :ref:`PixelsOriginalFileMap.parent <omero.model.PixelsOriginalFileMap>`, :ref:`Roi.source <omero.model.Roi>`
+Used by: :ref:`FileAnnotation.file <Hibernate version of class omero.model.FileAnnotation>`, :ref:`FilesetEntry.originalFile <Hibernate version of class omero.model.FilesetEntry>`, :ref:`JobOriginalFileLink.child <Hibernate version of class omero.model.JobOriginalFileLink>`, :ref:`OriginalFileAnnotationLink.parent <Hibernate version of class omero.model.OriginalFileAnnotationLink>`, :ref:`PixelsOriginalFileMap.parent <Hibernate version of class omero.model.PixelsOriginalFileMap>`, :ref:`Roi.source <Hibernate version of class omero.model.Roi>`
 
 Properties:
-  | annotationLinks: :ref:`OriginalFileAnnotationLink <omero.model.OriginalFileAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`OriginalFileAnnotationLink <Hibernate version of class omero.model.OriginalFileAnnotationLink>` (multiple)
   | atime: ``timestamp`` (optional)
   | ctime: ``timestamp`` (optional)
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
   | hash: ``string`` (optional)
-  | hasher: :ref:`ChecksumAlgorithm <omero.model.ChecksumAlgorithm>` (optional)
+  | hasher: :ref:`ChecksumAlgorithm <Hibernate version of class omero.model.ChecksumAlgorithm>` (optional)
   | mimetype: ``string`` (optional)
   | mtime: ``timestamp`` (optional)
   | name: ``string``
   | path: ``text``
-  | pixelsFileMaps: :ref:`PixelsOriginalFileMap <omero.model.PixelsOriginalFileMap>` (multiple)
+  | pixelsFileMaps: :ref:`PixelsOriginalFileMap <Hibernate version of class omero.model.PixelsOriginalFileMap>` (multiple)
   | size: ``long`` (optional)
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.OriginalFileAnnotationLink:
+.. _Hibernate version of class omero.model.OriginalFileAnnotationLink:
 
 OriginalFileAnnotationLink
 """"""""""""""""""""""""""
 
-Used by: :ref:`OriginalFile.annotationLinks <omero.model.OriginalFile>`
+Used by: :ref:`OriginalFile.annotationLinks <Hibernate version of class omero.model.OriginalFile>`
 
 Properties:
-  | child: :ref:`Annotation <omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`OriginalFile <omero.model.OriginalFile>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`OriginalFile <Hibernate version of class omero.model.OriginalFile>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.ParseJob:
+.. _Hibernate version of class omero.model.ParseJob:
 
 ParseJob
 """"""""
 
 Properties:
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Job <omero.model.Job>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Job <omero.model.Job>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Job <omero.model.Job>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Job <omero.model.Job>`
-  | details.permissions.perm1: ``long`` from :ref:`Job <omero.model.Job>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Job <omero.model.Job>`
-  | finished: ``timestamp`` (optional) from :ref:`Job <omero.model.Job>`
-  | groupname: ``string`` from :ref:`Job <omero.model.Job>`
-  | message: ``string`` from :ref:`Job <omero.model.Job>`
-  | originalFileLinks: :ref:`JobOriginalFileLink <omero.model.JobOriginalFileLink>` (multiple) from :ref:`Job <omero.model.Job>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.permissions.perm1: ``long`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | finished: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | groupname: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | message: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | originalFileLinks: :ref:`JobOriginalFileLink <Hibernate version of class omero.model.JobOriginalFileLink>` (multiple) from :ref:`Job <Hibernate version of class omero.model.Job>`
   | params: ``binary`` (optional)
-  | scheduledFor: ``timestamp`` from :ref:`Job <omero.model.Job>`
-  | started: ``timestamp`` (optional) from :ref:`Job <omero.model.Job>`
-  | status: :ref:`JobStatus <omero.model.JobStatus>` from :ref:`Job <omero.model.Job>`
-  | submitted: ``timestamp`` from :ref:`Job <omero.model.Job>`
-  | type: ``string`` from :ref:`Job <omero.model.Job>`
-  | username: ``string`` from :ref:`Job <omero.model.Job>`
-  | version: ``integer`` (optional) from :ref:`Job <omero.model.Job>`
+  | scheduledFor: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | started: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | status: :ref:`JobStatus <Hibernate version of class omero.model.JobStatus>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | submitted: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | type: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | username: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | version: ``integer`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
 
-.. _omero.model.Path:
+.. _Hibernate version of class omero.model.Path:
 
 Path
 """"
 
 Properties:
-  | annotationLinks: :ref:`ShapeAnnotationLink <omero.model.ShapeAnnotationLink>` (multiple) from :ref:`Shape <omero.model.Shape>`
+  | annotationLinks: :ref:`ShapeAnnotationLink <Hibernate version of class omero.model.ShapeAnnotationLink>` (multiple) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
   | d: ``text`` (optional)
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Shape <omero.model.Shape>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Shape <omero.model.Shape>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Shape <omero.model.Shape>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Shape <omero.model.Shape>`
-  | details.permissions.perm1: ``long`` from :ref:`Shape <omero.model.Shape>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Shape <omero.model.Shape>`
-  | fillColor: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fillRule: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontFamily: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontSize.unit: enumeration (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontSize.value: ``double`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontStretch: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontStyle: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontVariant: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontWeight: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | g: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | locked: ``boolean`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | roi: :ref:`Roi <omero.model.Roi>` from :ref:`Shape <omero.model.Shape>`
-  | strokeColor: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeDashArray: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeLineCap: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeWidth.unit: enumeration (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <omero.model.Shape>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.permissions.perm1: ``long`` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fillColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fillRule: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontFamily: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontSize.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontSize.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontStretch: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontStyle: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontVariant: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontWeight: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | g: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | locked: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | roi: :ref:`Roi <Hibernate version of class omero.model.Roi>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeDashArray: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeLineCap: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeWidth.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
   | textValue: ``text`` (optional)
-  | theC: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | theT: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | theZ: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | transform: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | vectorEffect: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | version: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | visibility: ``boolean`` (optional) from :ref:`Shape <omero.model.Shape>`
+  | theC: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | theT: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | theZ: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | transform: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | vectorEffect: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | version: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | visibility: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
 
-.. _omero.model.PhotometricInterpretation:
+.. _Hibernate version of class omero.model.PhotometricInterpretation:
 
 PhotometricInterpretation
 """""""""""""""""""""""""
 
-Used by: :ref:`LogicalChannel.photometricInterpretation <omero.model.LogicalChannel>`
+Used by: :ref:`LogicalChannel.photometricInterpretation <Hibernate version of class omero.model.LogicalChannel>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
 
-.. _omero.model.PixelDataJob:
+.. _Hibernate version of class omero.model.PixelDataJob:
 
 PixelDataJob
 """"""""""""
 
 Properties:
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Job <omero.model.Job>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Job <omero.model.Job>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Job <omero.model.Job>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Job <omero.model.Job>`
-  | details.permissions.perm1: ``long`` from :ref:`Job <omero.model.Job>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Job <omero.model.Job>`
-  | finished: ``timestamp`` (optional) from :ref:`Job <omero.model.Job>`
-  | groupname: ``string`` from :ref:`Job <omero.model.Job>`
-  | message: ``string`` from :ref:`Job <omero.model.Job>`
-  | originalFileLinks: :ref:`JobOriginalFileLink <omero.model.JobOriginalFileLink>` (multiple) from :ref:`Job <omero.model.Job>`
-  | scheduledFor: ``timestamp`` from :ref:`Job <omero.model.Job>`
-  | started: ``timestamp`` (optional) from :ref:`Job <omero.model.Job>`
-  | status: :ref:`JobStatus <omero.model.JobStatus>` from :ref:`Job <omero.model.Job>`
-  | submitted: ``timestamp`` from :ref:`Job <omero.model.Job>`
-  | type: ``string`` from :ref:`Job <omero.model.Job>`
-  | username: ``string`` from :ref:`Job <omero.model.Job>`
-  | version: ``integer`` (optional) from :ref:`Job <omero.model.Job>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.permissions.perm1: ``long`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | finished: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | groupname: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | message: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | originalFileLinks: :ref:`JobOriginalFileLink <Hibernate version of class omero.model.JobOriginalFileLink>` (multiple) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | scheduledFor: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | started: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | status: :ref:`JobStatus <Hibernate version of class omero.model.JobStatus>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | submitted: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | type: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | username: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | version: ``integer`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
 
-.. _omero.model.Pixels:
+.. _Hibernate version of class omero.model.Pixels:
 
 Pixels
 """"""
 
-Used by: :ref:`Channel.pixels <omero.model.Channel>`, :ref:`Image.pixels <omero.model.Image>`, :ref:`Mask.pixels <omero.model.Mask>`, :ref:`Pixels.relatedTo <omero.model.Pixels>`, :ref:`PixelsOriginalFileMap.child <omero.model.PixelsOriginalFileMap>`, :ref:`PlaneInfo.pixels <omero.model.PlaneInfo>`, :ref:`RenderingDef.pixels <omero.model.RenderingDef>`, :ref:`Thumbnail.pixels <omero.model.Thumbnail>`
+Used by: :ref:`Channel.pixels <Hibernate version of class omero.model.Channel>`, :ref:`Image.pixels <Hibernate version of class omero.model.Image>`, :ref:`Mask.pixels <Hibernate version of class omero.model.Mask>`, :ref:`Pixels.relatedTo <Hibernate version of class omero.model.Pixels>`, :ref:`PixelsOriginalFileMap.child <Hibernate version of class omero.model.PixelsOriginalFileMap>`, :ref:`PlaneInfo.pixels <Hibernate version of class omero.model.PlaneInfo>`, :ref:`RenderingDef.pixels <Hibernate version of class omero.model.RenderingDef>`, :ref:`Thumbnail.pixels <Hibernate version of class omero.model.Thumbnail>`
 
 Properties:
-  | channels: :ref:`Channel <omero.model.Channel>` (multiple)
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | channels: :ref:`Channel <Hibernate version of class omero.model.Channel>` (multiple)
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | dimensionOrder: :ref:`DimensionOrder <omero.model.DimensionOrder>`
-  | image: :ref:`Image <omero.model.Image>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | dimensionOrder: :ref:`DimensionOrder <Hibernate version of class omero.model.DimensionOrder>`
+  | image: :ref:`Image <Hibernate version of class omero.model.Image>`
   | methodology: ``string`` (optional)
   | physicalSizeX.unit: enumeration (optional)
   | physicalSizeX.value: ``double`` (optional)
@@ -2264,11 +2272,11 @@ Properties:
   | physicalSizeY.value: ``double`` (optional)
   | physicalSizeZ.unit: enumeration (optional)
   | physicalSizeZ.value: ``double`` (optional)
-  | pixelsFileMaps: :ref:`PixelsOriginalFileMap <omero.model.PixelsOriginalFileMap>` (multiple)
-  | pixelsType: :ref:`PixelsType <omero.model.PixelsType>`
-  | planeInfo: :ref:`PlaneInfo <omero.model.PlaneInfo>` (multiple)
-  | relatedTo: :ref:`Pixels <omero.model.Pixels>` (optional)
-  | settings: :ref:`RenderingDef <omero.model.RenderingDef>` (multiple)
+  | pixelsFileMaps: :ref:`PixelsOriginalFileMap <Hibernate version of class omero.model.PixelsOriginalFileMap>` (multiple)
+  | pixelsType: :ref:`PixelsType <Hibernate version of class omero.model.PixelsType>`
+  | planeInfo: :ref:`PlaneInfo <Hibernate version of class omero.model.PlaneInfo>` (multiple)
+  | relatedTo: :ref:`Pixels <Hibernate version of class omero.model.Pixels>` (optional)
+  | settings: :ref:`RenderingDef <Hibernate version of class omero.model.RenderingDef>` (multiple)
   | sha1: ``string``
   | significantBits: ``integer`` (optional)
   | sizeC: ``integer``
@@ -2276,64 +2284,64 @@ Properties:
   | sizeX: ``integer``
   | sizeY: ``integer``
   | sizeZ: ``integer``
-  | thumbnails: :ref:`Thumbnail <omero.model.Thumbnail>` (multiple)
+  | thumbnails: :ref:`Thumbnail <Hibernate version of class omero.model.Thumbnail>` (multiple)
   | timeIncrement.unit: enumeration (optional)
   | timeIncrement.value: ``double`` (optional)
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
   | waveIncrement: ``integer`` (optional)
   | waveStart: ``integer`` (optional)
 
-.. _omero.model.PixelsOriginalFileMap:
+.. _Hibernate version of class omero.model.PixelsOriginalFileMap:
 
 PixelsOriginalFileMap
 """""""""""""""""""""
 
-Used by: :ref:`OriginalFile.pixelsFileMaps <omero.model.OriginalFile>`, :ref:`Pixels.pixelsFileMaps <omero.model.Pixels>`
+Used by: :ref:`OriginalFile.pixelsFileMaps <Hibernate version of class omero.model.OriginalFile>`, :ref:`Pixels.pixelsFileMaps <Hibernate version of class omero.model.Pixels>`
 
 Properties:
-  | child: :ref:`Pixels <omero.model.Pixels>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Pixels <Hibernate version of class omero.model.Pixels>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`OriginalFile <omero.model.OriginalFile>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`OriginalFile <Hibernate version of class omero.model.OriginalFile>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.PixelsType:
+.. _Hibernate version of class omero.model.PixelsType:
 
 PixelsType
 """"""""""
 
-Used by: :ref:`OTF.pixelsType <omero.model.OTF>`, :ref:`Pixels.pixelsType <omero.model.Pixels>`
+Used by: :ref:`OTF.pixelsType <Hibernate version of class omero.model.OTF>`, :ref:`Pixels.pixelsType <Hibernate version of class omero.model.Pixels>`
 
 Properties:
   | bitSize: ``integer`` (optional)
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
 
-.. _omero.model.PlaneInfo:
+.. _Hibernate version of class omero.model.PlaneInfo:
 
 PlaneInfo
 """""""""
 
-Used by: :ref:`Pixels.planeInfo <omero.model.Pixels>`, :ref:`PlaneInfoAnnotationLink.parent <omero.model.PlaneInfoAnnotationLink>`
+Used by: :ref:`Pixels.planeInfo <Hibernate version of class omero.model.Pixels>`, :ref:`PlaneInfoAnnotationLink.parent <Hibernate version of class omero.model.PlaneInfoAnnotationLink>`
 
 Properties:
-  | annotationLinks: :ref:`PlaneInfoAnnotationLink <omero.model.PlaneInfoAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`PlaneInfoAnnotationLink <Hibernate version of class omero.model.PlaneInfoAnnotationLink>` (multiple)
   | deltaT.unit: enumeration (optional)
   | deltaT.value: ``double`` (optional)
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
   | exposureTime.unit: enumeration (optional)
   | exposureTime.value: ``double`` (optional)
-  | pixels: :ref:`Pixels <omero.model.Pixels>`
+  | pixels: :ref:`Pixels <Hibernate version of class omero.model.Pixels>`
   | positionX.unit: enumeration (optional)
   | positionX.value: ``double`` (optional)
   | positionY.unit: enumeration (optional)
@@ -2345,641 +2353,642 @@ Properties:
   | theZ: ``integer``
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.PlaneInfoAnnotationLink:
+.. _Hibernate version of class omero.model.PlaneInfoAnnotationLink:
 
 PlaneInfoAnnotationLink
 """""""""""""""""""""""
 
-Used by: :ref:`PlaneInfo.annotationLinks <omero.model.PlaneInfo>`
+Used by: :ref:`PlaneInfo.annotationLinks <Hibernate version of class omero.model.PlaneInfo>`
 
 Properties:
-  | child: :ref:`Annotation <omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`PlaneInfo <omero.model.PlaneInfo>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`PlaneInfo <Hibernate version of class omero.model.PlaneInfo>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.PlaneSlicingContext:
+.. _Hibernate version of class omero.model.PlaneSlicingContext:
 
 PlaneSlicingContext
 """""""""""""""""""
 
 Properties:
   | constant: ``boolean``
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`CodomainMapContext <omero.model.CodomainMapContext>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`CodomainMapContext <omero.model.CodomainMapContext>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`CodomainMapContext <omero.model.CodomainMapContext>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`CodomainMapContext <omero.model.CodomainMapContext>`
-  | details.permissions.perm1: ``long`` from :ref:`CodomainMapContext <omero.model.CodomainMapContext>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`CodomainMapContext <omero.model.CodomainMapContext>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
+  | details.permissions.perm1: ``long`` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
   | lowerLimit: ``integer``
   | planePrevious: ``integer``
   | planeSelected: ``integer``
-  | renderingDef: :ref:`RenderingDef <omero.model.RenderingDef>` from :ref:`CodomainMapContext <omero.model.CodomainMapContext>`
+  | renderingDef: :ref:`RenderingDef <Hibernate version of class omero.model.RenderingDef>` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
   | upperLimit: ``integer``
-  | version: ``integer`` (optional) from :ref:`CodomainMapContext <omero.model.CodomainMapContext>`
+  | version: ``integer`` (optional) from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
 
-.. _omero.model.Plate:
+.. _Hibernate version of class omero.model.Plate:
 
 Plate
 """""
 
-Used by: :ref:`PlateAcquisition.plate <omero.model.PlateAcquisition>`, :ref:`PlateAnnotationLink.parent <omero.model.PlateAnnotationLink>`, :ref:`ScreenPlateLink.child <omero.model.ScreenPlateLink>`, :ref:`Well.plate <omero.model.Well>`
+Used by: :ref:`PlateAcquisition.plate <Hibernate version of class omero.model.PlateAcquisition>`, :ref:`PlateAnnotationLink.parent <Hibernate version of class omero.model.PlateAnnotationLink>`, :ref:`ScreenPlateLink.child <Hibernate version of class omero.model.ScreenPlateLink>`, :ref:`Well.plate <Hibernate version of class omero.model.Well>`
 
 Properties:
-  | annotationLinks: :ref:`PlateAnnotationLink <omero.model.PlateAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`PlateAnnotationLink <Hibernate version of class omero.model.PlateAnnotationLink>` (multiple)
   | columnNamingConvention: ``string`` (optional)
   | columns: ``integer`` (optional)
   | defaultSample: ``integer`` (optional)
   | description: ``text`` (optional)
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
   | externalIdentifier: ``string`` (optional)
   | name: ``string``
-  | plateAcquisitions: :ref:`PlateAcquisition <omero.model.PlateAcquisition>` (multiple)
+  | plateAcquisitions: :ref:`PlateAcquisition <Hibernate version of class omero.model.PlateAcquisition>` (multiple)
   | rowNamingConvention: ``string`` (optional)
   | rows: ``integer`` (optional)
-  | screenLinks: :ref:`ScreenPlateLink <omero.model.ScreenPlateLink>` (multiple)
+  | screenLinks: :ref:`ScreenPlateLink <Hibernate version of class omero.model.ScreenPlateLink>` (multiple)
   | status: ``string`` (optional)
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
   | wellOriginX.unit: enumeration (optional)
   | wellOriginX.value: ``double`` (optional)
   | wellOriginY.unit: enumeration (optional)
   | wellOriginY.value: ``double`` (optional)
-  | wells: :ref:`Well <omero.model.Well>` (multiple)
+  | wells: :ref:`Well <Hibernate version of class omero.model.Well>` (multiple)
 
-.. _omero.model.PlateAcquisition:
+.. _Hibernate version of class omero.model.PlateAcquisition:
 
 PlateAcquisition
 """"""""""""""""
 
-Used by: :ref:`Plate.plateAcquisitions <omero.model.Plate>`, :ref:`PlateAcquisitionAnnotationLink.parent <omero.model.PlateAcquisitionAnnotationLink>`, :ref:`WellSample.plateAcquisition <omero.model.WellSample>`
+Used by: :ref:`Plate.plateAcquisitions <Hibernate version of class omero.model.Plate>`, :ref:`PlateAcquisitionAnnotationLink.parent <Hibernate version of class omero.model.PlateAcquisitionAnnotationLink>`, :ref:`WellSample.plateAcquisition <Hibernate version of class omero.model.WellSample>`
 
 Properties:
-  | annotationLinks: :ref:`PlateAcquisitionAnnotationLink <omero.model.PlateAcquisitionAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`PlateAcquisitionAnnotationLink <Hibernate version of class omero.model.PlateAcquisitionAnnotationLink>` (multiple)
   | description: ``text`` (optional)
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
   | endTime: ``timestamp`` (optional)
   | maximumFieldCount: ``integer`` (optional)
   | name: ``string`` (optional)
-  | plate: :ref:`Plate <omero.model.Plate>`
+  | plate: :ref:`Plate <Hibernate version of class omero.model.Plate>`
   | startTime: ``timestamp`` (optional)
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
-  | wellSample: :ref:`WellSample <omero.model.WellSample>` (multiple)
+  | wellSample: :ref:`WellSample <Hibernate version of class omero.model.WellSample>` (multiple)
 
-.. _omero.model.PlateAcquisitionAnnotationLink:
+.. _Hibernate version of class omero.model.PlateAcquisitionAnnotationLink:
 
 PlateAcquisitionAnnotationLink
 """"""""""""""""""""""""""""""
 
-Used by: :ref:`PlateAcquisition.annotationLinks <omero.model.PlateAcquisition>`
+Used by: :ref:`PlateAcquisition.annotationLinks <Hibernate version of class omero.model.PlateAcquisition>`
 
 Properties:
-  | child: :ref:`Annotation <omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`PlateAcquisition <omero.model.PlateAcquisition>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`PlateAcquisition <Hibernate version of class omero.model.PlateAcquisition>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.PlateAnnotationLink:
+.. _Hibernate version of class omero.model.PlateAnnotationLink:
 
 PlateAnnotationLink
 """""""""""""""""""
 
-Used by: :ref:`Plate.annotationLinks <omero.model.Plate>`
+Used by: :ref:`Plate.annotationLinks <Hibernate version of class omero.model.Plate>`
 
 Properties:
-  | child: :ref:`Annotation <omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`Plate <omero.model.Plate>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`Plate <Hibernate version of class omero.model.Plate>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.Point:
+.. _Hibernate version of class omero.model.Point:
 
 Point
 """""
 
 Properties:
-  | annotationLinks: :ref:`ShapeAnnotationLink <omero.model.ShapeAnnotationLink>` (multiple) from :ref:`Shape <omero.model.Shape>`
+  | annotationLinks: :ref:`ShapeAnnotationLink <Hibernate version of class omero.model.ShapeAnnotationLink>` (multiple) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
   | cx: ``double`` (optional)
   | cy: ``double`` (optional)
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Shape <omero.model.Shape>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Shape <omero.model.Shape>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Shape <omero.model.Shape>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Shape <omero.model.Shape>`
-  | details.permissions.perm1: ``long`` from :ref:`Shape <omero.model.Shape>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Shape <omero.model.Shape>`
-  | fillColor: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fillRule: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontFamily: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontSize.unit: enumeration (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontSize.value: ``double`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontStretch: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontStyle: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontVariant: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontWeight: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | g: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | locked: ``boolean`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | roi: :ref:`Roi <omero.model.Roi>` from :ref:`Shape <omero.model.Shape>`
-  | strokeColor: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeDashArray: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeLineCap: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeWidth.unit: enumeration (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <omero.model.Shape>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.permissions.perm1: ``long`` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fillColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fillRule: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontFamily: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontSize.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontSize.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontStretch: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontStyle: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontVariant: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontWeight: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | g: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | locked: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | roi: :ref:`Roi <Hibernate version of class omero.model.Roi>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeDashArray: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeLineCap: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeWidth.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
   | textValue: ``text`` (optional)
-  | theC: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | theT: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | theZ: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | transform: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | vectorEffect: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | version: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | visibility: ``boolean`` (optional) from :ref:`Shape <omero.model.Shape>`
+  | theC: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | theT: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | theZ: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | transform: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | vectorEffect: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | version: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | visibility: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
 
-.. _omero.model.Polygon:
+.. _Hibernate version of class omero.model.Polygon:
 
 Polygon
 """""""
 
 Properties:
-  | annotationLinks: :ref:`ShapeAnnotationLink <omero.model.ShapeAnnotationLink>` (multiple) from :ref:`Shape <omero.model.Shape>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Shape <omero.model.Shape>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Shape <omero.model.Shape>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Shape <omero.model.Shape>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Shape <omero.model.Shape>`
-  | details.permissions.perm1: ``long`` from :ref:`Shape <omero.model.Shape>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Shape <omero.model.Shape>`
-  | fillColor: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fillRule: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontFamily: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontSize.unit: enumeration (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontSize.value: ``double`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontStretch: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontStyle: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontVariant: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontWeight: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | g: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | locked: ``boolean`` (optional) from :ref:`Shape <omero.model.Shape>`
+  | annotationLinks: :ref:`ShapeAnnotationLink <Hibernate version of class omero.model.ShapeAnnotationLink>` (multiple) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.permissions.perm1: ``long`` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fillColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fillRule: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontFamily: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontSize.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontSize.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontStretch: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontStyle: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontVariant: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontWeight: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | g: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | locked: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
   | points: ``text`` (optional)
-  | roi: :ref:`Roi <omero.model.Roi>` from :ref:`Shape <omero.model.Shape>`
-  | strokeColor: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeDashArray: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeLineCap: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeWidth.unit: enumeration (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <omero.model.Shape>`
+  | roi: :ref:`Roi <Hibernate version of class omero.model.Roi>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeDashArray: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeLineCap: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeWidth.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
   | textValue: ``text`` (optional)
-  | theC: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | theT: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | theZ: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | transform: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | vectorEffect: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | version: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | visibility: ``boolean`` (optional) from :ref:`Shape <omero.model.Shape>`
+  | theC: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | theT: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | theZ: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | transform: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | vectorEffect: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | version: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | visibility: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
 
-.. _omero.model.Polyline:
+.. _Hibernate version of class omero.model.Polyline:
 
 Polyline
 """"""""
 
 Properties:
-  | annotationLinks: :ref:`ShapeAnnotationLink <omero.model.ShapeAnnotationLink>` (multiple) from :ref:`Shape <omero.model.Shape>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Shape <omero.model.Shape>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Shape <omero.model.Shape>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Shape <omero.model.Shape>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Shape <omero.model.Shape>`
-  | details.permissions.perm1: ``long`` from :ref:`Shape <omero.model.Shape>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Shape <omero.model.Shape>`
-  | fillColor: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fillRule: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontFamily: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontSize.unit: enumeration (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontSize.value: ``double`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontStretch: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontStyle: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontVariant: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontWeight: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | g: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | locked: ``boolean`` (optional) from :ref:`Shape <omero.model.Shape>`
+  | annotationLinks: :ref:`ShapeAnnotationLink <Hibernate version of class omero.model.ShapeAnnotationLink>` (multiple) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.permissions.perm1: ``long`` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fillColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fillRule: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontFamily: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontSize.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontSize.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontStretch: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontStyle: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontVariant: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontWeight: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | g: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | locked: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
   | points: ``text`` (optional)
-  | roi: :ref:`Roi <omero.model.Roi>` from :ref:`Shape <omero.model.Shape>`
-  | strokeColor: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeDashArray: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeLineCap: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeWidth.unit: enumeration (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <omero.model.Shape>`
+  | roi: :ref:`Roi <Hibernate version of class omero.model.Roi>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeDashArray: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeLineCap: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeWidth.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
   | textValue: ``text`` (optional)
-  | theC: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | theT: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | theZ: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | transform: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | vectorEffect: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | version: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | visibility: ``boolean`` (optional) from :ref:`Shape <omero.model.Shape>`
+  | theC: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | theT: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | theZ: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | transform: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | vectorEffect: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | version: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | visibility: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
 
-.. _omero.model.Project:
+.. _Hibernate version of class omero.model.Project:
 
 Project
 """""""
 
-Used by: :ref:`ProjectAnnotationLink.parent <omero.model.ProjectAnnotationLink>`, :ref:`ProjectDatasetLink.parent <omero.model.ProjectDatasetLink>`
+Used by: :ref:`ProjectAnnotationLink.parent <Hibernate version of class omero.model.ProjectAnnotationLink>`, :ref:`ProjectDatasetLink.parent <Hibernate version of class omero.model.ProjectDatasetLink>`
 
 Properties:
-  | annotationLinks: :ref:`ProjectAnnotationLink <omero.model.ProjectAnnotationLink>` (multiple)
-  | datasetLinks: :ref:`ProjectDatasetLink <omero.model.ProjectDatasetLink>` (multiple)
+  | annotationLinks: :ref:`ProjectAnnotationLink <Hibernate version of class omero.model.ProjectAnnotationLink>` (multiple)
+  | datasetLinks: :ref:`ProjectDatasetLink <Hibernate version of class omero.model.ProjectDatasetLink>` (multiple)
   | description: ``text`` (optional)
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
   | name: ``string``
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.ProjectAnnotationLink:
+.. _Hibernate version of class omero.model.ProjectAnnotationLink:
 
 ProjectAnnotationLink
 """""""""""""""""""""
 
-Used by: :ref:`Project.annotationLinks <omero.model.Project>`
+Used by: :ref:`Project.annotationLinks <Hibernate version of class omero.model.Project>`
 
 Properties:
-  | child: :ref:`Annotation <omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`Project <omero.model.Project>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`Project <Hibernate version of class omero.model.Project>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.ProjectDatasetLink:
+.. _Hibernate version of class omero.model.ProjectDatasetLink:
 
 ProjectDatasetLink
 """"""""""""""""""
 
-Used by: :ref:`Dataset.projectLinks <omero.model.Dataset>`, :ref:`Project.datasetLinks <omero.model.Project>`
+Used by: :ref:`Dataset.projectLinks <Hibernate version of class omero.model.Dataset>`, :ref:`Project.datasetLinks <Hibernate version of class omero.model.Project>`
 
 Properties:
-  | child: :ref:`Dataset <omero.model.Dataset>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Dataset <Hibernate version of class omero.model.Dataset>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`Project <omero.model.Project>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`Project <Hibernate version of class omero.model.Project>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.Pulse:
+.. _Hibernate version of class omero.model.Pulse:
 
 Pulse
 """""
 
-Used by: :ref:`Laser.pulse <omero.model.Laser>`
+Used by: :ref:`Laser.pulse <Hibernate version of class omero.model.Laser>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
 
-.. _omero.model.QuantumDef:
+.. _Hibernate version of class omero.model.QuantumDef:
 
 QuantumDef
 """"""""""
 
-Used by: :ref:`RenderingDef.quantization <omero.model.RenderingDef>`
+Used by: :ref:`RenderingDef.quantization <Hibernate version of class omero.model.RenderingDef>`
 
 Properties:
   | bitResolution: ``integer``
   | cdEnd: ``integer``
   | cdStart: ``integer``
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.Reagent:
+.. _Hibernate version of class omero.model.Reagent:
 
 Reagent
 """""""
 
-Used by: :ref:`ReagentAnnotationLink.parent <omero.model.ReagentAnnotationLink>`, :ref:`Screen.reagents <omero.model.Screen>`, :ref:`WellReagentLink.child <omero.model.WellReagentLink>`
+Used by: :ref:`ReagentAnnotationLink.parent <Hibernate version of class omero.model.ReagentAnnotationLink>`, :ref:`Screen.reagents <Hibernate version of class omero.model.Screen>`, :ref:`WellReagentLink.child <Hibernate version of class omero.model.WellReagentLink>`
 
 Properties:
-  | annotationLinks: :ref:`ReagentAnnotationLink <omero.model.ReagentAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`ReagentAnnotationLink <Hibernate version of class omero.model.ReagentAnnotationLink>` (multiple)
   | description: ``text`` (optional)
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
   | name: ``string`` (optional)
   | reagentIdentifier: ``string`` (optional)
-  | screen: :ref:`Screen <omero.model.Screen>`
+  | screen: :ref:`Screen <Hibernate version of class omero.model.Screen>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
-  | wellLinks: :ref:`WellReagentLink <omero.model.WellReagentLink>` (multiple)
+  | wellLinks: :ref:`WellReagentLink <Hibernate version of class omero.model.WellReagentLink>` (multiple)
 
-.. _omero.model.ReagentAnnotationLink:
+.. _Hibernate version of class omero.model.ReagentAnnotationLink:
 
 ReagentAnnotationLink
 """""""""""""""""""""
 
-Used by: :ref:`Reagent.annotationLinks <omero.model.Reagent>`
+Used by: :ref:`Reagent.annotationLinks <Hibernate version of class omero.model.Reagent>`
 
 Properties:
-  | child: :ref:`Annotation <omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`Reagent <omero.model.Reagent>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`Reagent <Hibernate version of class omero.model.Reagent>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.Rect:
+.. _Hibernate version of class omero.model.Rect:
 
 Rect
 """"
 
 Properties:
-  | annotationLinks: :ref:`ShapeAnnotationLink <omero.model.ShapeAnnotationLink>` (multiple) from :ref:`Shape <omero.model.Shape>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Shape <omero.model.Shape>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Shape <omero.model.Shape>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Shape <omero.model.Shape>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Shape <omero.model.Shape>`
-  | details.permissions.perm1: ``long`` from :ref:`Shape <omero.model.Shape>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Shape <omero.model.Shape>`
-  | fillColor: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fillRule: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontFamily: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontSize.unit: enumeration (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontSize.value: ``double`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontStretch: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontStyle: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontVariant: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | fontWeight: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | g: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
+  | annotationLinks: :ref:`ShapeAnnotationLink <Hibernate version of class omero.model.ShapeAnnotationLink>` (multiple) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.permissions.perm1: ``long`` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fillColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fillRule: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontFamily: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontSize.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontSize.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontStretch: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontStyle: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontVariant: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fontWeight: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | g: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
   | height: ``double`` (optional)
-  | locked: ``boolean`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | roi: :ref:`Roi <omero.model.Roi>` from :ref:`Shape <omero.model.Shape>`
+  | locked: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | roi: :ref:`Roi <Hibernate version of class omero.model.Roi>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
   | rx: ``double`` (optional)
-  | strokeColor: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeDashArray: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeLineCap: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeWidth.unit: enumeration (optional) from :ref:`Shape <omero.model.Shape>`
-  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <omero.model.Shape>`
+  | strokeColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeDashArray: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeLineCap: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeWidth.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
   | textValue: ``text`` (optional)
-  | theC: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | theT: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | theZ: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | transform: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | vectorEffect: ``string`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | version: ``integer`` (optional) from :ref:`Shape <omero.model.Shape>`
-  | visibility: ``boolean`` (optional) from :ref:`Shape <omero.model.Shape>`
+  | theC: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | theT: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | theZ: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | transform: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | vectorEffect: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | version: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | visibility: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
   | width: ``double`` (optional)
   | x: ``double`` (optional)
   | y: ``double`` (optional)
 
-.. _omero.model.RenderingDef:
+.. _Hibernate version of class omero.model.RenderingDef:
 
 RenderingDef
 """"""""""""
 
-Used by: :ref:`ChannelBinding.renderingDef <omero.model.ChannelBinding>`, :ref:`CodomainMapContext.renderingDef <omero.model.CodomainMapContext>`, :ref:`ContrastStretchingContext.renderingDef <omero.model.ContrastStretchingContext>`, :ref:`Pixels.settings <omero.model.Pixels>`, :ref:`PlaneSlicingContext.renderingDef <omero.model.PlaneSlicingContext>`, :ref:`ReverseIntensityContext.renderingDef <omero.model.ReverseIntensityContext>`
+Used by: :ref:`ChannelBinding.renderingDef <Hibernate version of class omero.model.ChannelBinding>`, :ref:`CodomainMapContext.renderingDef <Hibernate version of class omero.model.CodomainMapContext>`, :ref:`ContrastStretchingContext.renderingDef <Hibernate version of class omero.model.ContrastStretchingContext>`, :ref:`Pixels.settings <Hibernate version of class omero.model.Pixels>`, :ref:`PlaneSlicingContext.renderingDef <Hibernate version of class omero.model.PlaneSlicingContext>`, :ref:`ReverseIntensityContext.renderingDef <Hibernate version of class omero.model.ReverseIntensityContext>`
 
 Properties:
   | compression: ``double`` (optional)
   | defaultT: ``integer``
   | defaultZ: ``integer``
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | model: :ref:`RenderingModel <omero.model.RenderingModel>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | model: :ref:`RenderingModel <Hibernate version of class omero.model.RenderingModel>`
   | name: ``string`` (optional)
-  | pixels: :ref:`Pixels <omero.model.Pixels>`
-  | quantization: :ref:`QuantumDef <omero.model.QuantumDef>`
-  | spatialDomainEnhancement: :ref:`CodomainMapContext <omero.model.CodomainMapContext>` (multiple)
+  | pixels: :ref:`Pixels <Hibernate version of class omero.model.Pixels>`
+  | quantization: :ref:`QuantumDef <Hibernate version of class omero.model.QuantumDef>`
+  | spatialDomainEnhancement: :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>` (multiple)
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
-  | waveRendering: :ref:`ChannelBinding <omero.model.ChannelBinding>` (multiple)
+  | waveRendering: :ref:`ChannelBinding <Hibernate version of class omero.model.ChannelBinding>` (multiple)
 
-.. _omero.model.RenderingModel:
+.. _Hibernate version of class omero.model.RenderingModel:
 
 RenderingModel
 """"""""""""""
 
-Used by: :ref:`RenderingDef.model <omero.model.RenderingDef>`
+Used by: :ref:`RenderingDef.model <Hibernate version of class omero.model.RenderingDef>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
 
-.. _omero.model.ReverseIntensityContext:
+.. _Hibernate version of class omero.model.ReverseIntensityContext:
 
 ReverseIntensityContext
 """""""""""""""""""""""
 
 Properties:
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`CodomainMapContext <omero.model.CodomainMapContext>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`CodomainMapContext <omero.model.CodomainMapContext>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`CodomainMapContext <omero.model.CodomainMapContext>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`CodomainMapContext <omero.model.CodomainMapContext>`
-  | details.permissions.perm1: ``long`` from :ref:`CodomainMapContext <omero.model.CodomainMapContext>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`CodomainMapContext <omero.model.CodomainMapContext>`
-  | renderingDef: :ref:`RenderingDef <omero.model.RenderingDef>` from :ref:`CodomainMapContext <omero.model.CodomainMapContext>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
+  | details.permissions.perm1: ``long`` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
+  | renderingDef: :ref:`RenderingDef <Hibernate version of class omero.model.RenderingDef>` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
   | reverse: ``boolean``
-  | version: ``integer`` (optional) from :ref:`CodomainMapContext <omero.model.CodomainMapContext>`
+  | version: ``integer`` (optional) from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
 
-.. _omero.model.Roi:
+.. _Hibernate version of class omero.model.Roi:
 
 Roi
 """
 
-Used by: :ref:`Ellipse.roi <omero.model.Ellipse>`, :ref:`Image.rois <omero.model.Image>`, :ref:`Label.roi <omero.model.Label>`, :ref:`Line.roi <omero.model.Line>`, :ref:`Mask.roi <omero.model.Mask>`, :ref:`Path.roi <omero.model.Path>`, :ref:`Point.roi <omero.model.Point>`, :ref:`Polygon.roi <omero.model.Polygon>`, :ref:`Polyline.roi <omero.model.Polyline>`, :ref:`Rect.roi <omero.model.Rect>`, :ref:`RoiAnnotationLink.parent <omero.model.RoiAnnotationLink>`, :ref:`Shape.roi <omero.model.Shape>`
+Used by: :ref:`Ellipse.roi <Hibernate version of class omero.model.Ellipse>`, :ref:`Image.rois <Hibernate version of class omero.model.Image>`, :ref:`Label.roi <Hibernate version of class omero.model.Label>`, :ref:`Line.roi <Hibernate version of class omero.model.Line>`, :ref:`Mask.roi <Hibernate version of class omero.model.Mask>`, :ref:`Path.roi <Hibernate version of class omero.model.Path>`, :ref:`Point.roi <Hibernate version of class omero.model.Point>`, :ref:`Polygon.roi <Hibernate version of class omero.model.Polygon>`, :ref:`Polyline.roi <Hibernate version of class omero.model.Polyline>`, :ref:`Rect.roi <Hibernate version of class omero.model.Rect>`, :ref:`RoiAnnotationLink.parent <Hibernate version of class omero.model.RoiAnnotationLink>`, :ref:`Shape.roi <Hibernate version of class omero.model.Shape>`
 
 Properties:
-  | annotationLinks: :ref:`RoiAnnotationLink <omero.model.RoiAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`RoiAnnotationLink <Hibernate version of class omero.model.RoiAnnotationLink>` (multiple)
   | description: ``text`` (optional)
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | image: :ref:`Image <omero.model.Image>` (optional)
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | image: :ref:`Image <Hibernate version of class omero.model.Image>` (optional)
   | keywords: list (optional)
+  | name: ``string`` (optional)
   | namespaces: list (optional)
-  | shapes: :ref:`Shape <omero.model.Shape>` (multiple)
-  | source: :ref:`OriginalFile <omero.model.OriginalFile>` (optional)
+  | shapes: :ref:`Shape <Hibernate version of class omero.model.Shape>` (multiple)
+  | source: :ref:`OriginalFile <Hibernate version of class omero.model.OriginalFile>` (optional)
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.RoiAnnotationLink:
+.. _Hibernate version of class omero.model.RoiAnnotationLink:
 
 RoiAnnotationLink
 """""""""""""""""
 
-Used by: :ref:`Roi.annotationLinks <omero.model.Roi>`
+Used by: :ref:`Roi.annotationLinks <Hibernate version of class omero.model.Roi>`
 
 Properties:
-  | child: :ref:`Annotation <omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`Roi <omero.model.Roi>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`Roi <Hibernate version of class omero.model.Roi>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.Screen:
+.. _Hibernate version of class omero.model.Screen:
 
 Screen
 """"""
 
-Used by: :ref:`Reagent.screen <omero.model.Reagent>`, :ref:`ScreenAnnotationLink.parent <omero.model.ScreenAnnotationLink>`, :ref:`ScreenPlateLink.parent <omero.model.ScreenPlateLink>`
+Used by: :ref:`Reagent.screen <Hibernate version of class omero.model.Reagent>`, :ref:`ScreenAnnotationLink.parent <Hibernate version of class omero.model.ScreenAnnotationLink>`, :ref:`ScreenPlateLink.parent <Hibernate version of class omero.model.ScreenPlateLink>`
 
 Properties:
-  | annotationLinks: :ref:`ScreenAnnotationLink <omero.model.ScreenAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`ScreenAnnotationLink <Hibernate version of class omero.model.ScreenAnnotationLink>` (multiple)
   | description: ``text`` (optional)
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
   | name: ``string``
-  | plateLinks: :ref:`ScreenPlateLink <omero.model.ScreenPlateLink>` (multiple)
+  | plateLinks: :ref:`ScreenPlateLink <Hibernate version of class omero.model.ScreenPlateLink>` (multiple)
   | protocolDescription: ``string`` (optional)
   | protocolIdentifier: ``string`` (optional)
   | reagentSetDescription: ``string`` (optional)
   | reagentSetIdentifier: ``string`` (optional)
-  | reagents: :ref:`Reagent <omero.model.Reagent>` (multiple)
+  | reagents: :ref:`Reagent <Hibernate version of class omero.model.Reagent>` (multiple)
   | type: ``string`` (optional)
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.ScreenAnnotationLink:
+.. _Hibernate version of class omero.model.ScreenAnnotationLink:
 
 ScreenAnnotationLink
 """"""""""""""""""""
 
-Used by: :ref:`Screen.annotationLinks <omero.model.Screen>`
+Used by: :ref:`Screen.annotationLinks <Hibernate version of class omero.model.Screen>`
 
 Properties:
-  | child: :ref:`Annotation <omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`Screen <omero.model.Screen>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`Screen <Hibernate version of class omero.model.Screen>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.ScreenPlateLink:
+.. _Hibernate version of class omero.model.ScreenPlateLink:
 
 ScreenPlateLink
 """""""""""""""
 
-Used by: :ref:`Plate.screenLinks <omero.model.Plate>`, :ref:`Screen.plateLinks <omero.model.Screen>`
+Used by: :ref:`Plate.screenLinks <Hibernate version of class omero.model.Plate>`, :ref:`Screen.plateLinks <Hibernate version of class omero.model.Screen>`
 
 Properties:
-  | child: :ref:`Plate <omero.model.Plate>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Plate <Hibernate version of class omero.model.Plate>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`Screen <omero.model.Screen>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`Screen <Hibernate version of class omero.model.Screen>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.ScriptJob:
+.. _Hibernate version of class omero.model.ScriptJob:
 
 ScriptJob
 """""""""
 
 Properties:
   | description: ``string`` (optional)
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Job <omero.model.Job>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Job <omero.model.Job>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Job <omero.model.Job>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Job <omero.model.Job>`
-  | details.permissions.perm1: ``long`` from :ref:`Job <omero.model.Job>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Job <omero.model.Job>`
-  | finished: ``timestamp`` (optional) from :ref:`Job <omero.model.Job>`
-  | groupname: ``string`` from :ref:`Job <omero.model.Job>`
-  | message: ``string`` from :ref:`Job <omero.model.Job>`
-  | originalFileLinks: :ref:`JobOriginalFileLink <omero.model.JobOriginalFileLink>` (multiple) from :ref:`Job <omero.model.Job>`
-  | scheduledFor: ``timestamp`` from :ref:`Job <omero.model.Job>`
-  | started: ``timestamp`` (optional) from :ref:`Job <omero.model.Job>`
-  | status: :ref:`JobStatus <omero.model.JobStatus>` from :ref:`Job <omero.model.Job>`
-  | submitted: ``timestamp`` from :ref:`Job <omero.model.Job>`
-  | type: ``string`` from :ref:`Job <omero.model.Job>`
-  | username: ``string`` from :ref:`Job <omero.model.Job>`
-  | version: ``integer`` (optional) from :ref:`Job <omero.model.Job>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.permissions.perm1: ``long`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | finished: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | groupname: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | message: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | originalFileLinks: :ref:`JobOriginalFileLink <Hibernate version of class omero.model.JobOriginalFileLink>` (multiple) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | scheduledFor: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | started: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | status: :ref:`JobStatus <Hibernate version of class omero.model.JobStatus>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | submitted: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | type: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | username: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | version: ``integer`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
 
-.. _omero.model.Session:
+.. _Hibernate version of class omero.model.Session:
 
 Session
 """""""
 
-Subclasses: :ref:`Share <omero.model.Share>`
+Subclasses: :ref:`Share <Hibernate version of class omero.model.Share>`
 
-Used by: :ref:`Event.session <omero.model.Event>`, :ref:`Node.sessions <omero.model.Node>`, :ref:`SessionAnnotationLink.parent <omero.model.SessionAnnotationLink>`
+Used by: :ref:`Event.session <Hibernate version of class omero.model.Event>`, :ref:`Node.sessions <Hibernate version of class omero.model.Node>`, :ref:`SessionAnnotationLink.parent <Hibernate version of class omero.model.SessionAnnotationLink>`
 
 Properties:
-  | annotationLinks: :ref:`SessionAnnotationLink <omero.model.SessionAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`SessionAnnotationLink <Hibernate version of class omero.model.SessionAnnotationLink>` (multiple)
   | closed: ``timestamp`` (optional)
   | defaultEventType: ``string``
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | events: :ref:`Event <omero.model.Event>` (multiple)
+  | events: :ref:`Event <Hibernate version of class omero.model.Event>` (multiple)
   | message: ``text`` (optional)
-  | node: :ref:`Node <omero.model.Node>`
-  | owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | node: :ref:`Node <Hibernate version of class omero.model.Node>`
+  | owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | started: ``timestamp``
   | timeToIdle: ``long``
   | timeToLive: ``long``
@@ -2988,41 +2997,41 @@ Properties:
   | uuid: ``string``
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.SessionAnnotationLink:
+.. _Hibernate version of class omero.model.SessionAnnotationLink:
 
 SessionAnnotationLink
 """""""""""""""""""""
 
-Used by: :ref:`Session.annotationLinks <omero.model.Session>`, :ref:`Share.annotationLinks <omero.model.Share>`
+Used by: :ref:`Session.annotationLinks <Hibernate version of class omero.model.Session>`, :ref:`Share.annotationLinks <Hibernate version of class omero.model.Share>`
 
 Properties:
-  | child: :ref:`Annotation <omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`Session <omero.model.Session>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`Session <Hibernate version of class omero.model.Session>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.Shape:
+.. _Hibernate version of class omero.model.Shape:
 
 Shape
 """""
 
-Subclasses: :ref:`Ellipse <omero.model.Ellipse>`, :ref:`Label <omero.model.Label>`, :ref:`Line <omero.model.Line>`, :ref:`Mask <omero.model.Mask>`, :ref:`Path <omero.model.Path>`, :ref:`Point <omero.model.Point>`, :ref:`Polygon <omero.model.Polygon>`, :ref:`Polyline <omero.model.Polyline>`, :ref:`Rect <omero.model.Rect>`
+Subclasses: :ref:`Ellipse <Hibernate version of class omero.model.Ellipse>`, :ref:`Label <Hibernate version of class omero.model.Label>`, :ref:`Line <Hibernate version of class omero.model.Line>`, :ref:`Mask <Hibernate version of class omero.model.Mask>`, :ref:`Path <Hibernate version of class omero.model.Path>`, :ref:`Point <Hibernate version of class omero.model.Point>`, :ref:`Polygon <Hibernate version of class omero.model.Polygon>`, :ref:`Polyline <Hibernate version of class omero.model.Polyline>`, :ref:`Rect <Hibernate version of class omero.model.Rect>`
 
-Used by: :ref:`Roi.shapes <omero.model.Roi>`, :ref:`ShapeAnnotationLink.parent <omero.model.ShapeAnnotationLink>`
+Used by: :ref:`Roi.shapes <Hibernate version of class omero.model.Roi>`, :ref:`ShapeAnnotationLink.parent <Hibernate version of class omero.model.ShapeAnnotationLink>`
 
 Properties:
-  | annotationLinks: :ref:`ShapeAnnotationLink <omero.model.ShapeAnnotationLink>` (multiple)
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | annotationLinks: :ref:`ShapeAnnotationLink <Hibernate version of class omero.model.ShapeAnnotationLink>` (multiple)
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
   | fillColor: ``integer`` (optional)
   | fillRule: ``string`` (optional)
   | fontFamily: ``string`` (optional)
@@ -3034,7 +3043,7 @@ Properties:
   | fontWeight: ``string`` (optional)
   | g: ``string`` (optional)
   | locked: ``boolean`` (optional)
-  | roi: :ref:`Roi <omero.model.Roi>`
+  | roi: :ref:`Roi <Hibernate version of class omero.model.Roi>`
   | strokeColor: ``integer`` (optional)
   | strokeDashArray: ``string`` (optional)
   | strokeDashOffset: ``integer`` (optional)
@@ -3051,79 +3060,79 @@ Properties:
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
   | visibility: ``boolean`` (optional)
 
-.. _omero.model.ShapeAnnotationLink:
+.. _Hibernate version of class omero.model.ShapeAnnotationLink:
 
 ShapeAnnotationLink
 """""""""""""""""""
 
-Used by: :ref:`Ellipse.annotationLinks <omero.model.Ellipse>`, :ref:`Label.annotationLinks <omero.model.Label>`, :ref:`Line.annotationLinks <omero.model.Line>`, :ref:`Mask.annotationLinks <omero.model.Mask>`, :ref:`Path.annotationLinks <omero.model.Path>`, :ref:`Point.annotationLinks <omero.model.Point>`, :ref:`Polygon.annotationLinks <omero.model.Polygon>`, :ref:`Polyline.annotationLinks <omero.model.Polyline>`, :ref:`Rect.annotationLinks <omero.model.Rect>`, :ref:`Shape.annotationLinks <omero.model.Shape>`
+Used by: :ref:`Ellipse.annotationLinks <Hibernate version of class omero.model.Ellipse>`, :ref:`Label.annotationLinks <Hibernate version of class omero.model.Label>`, :ref:`Line.annotationLinks <Hibernate version of class omero.model.Line>`, :ref:`Mask.annotationLinks <Hibernate version of class omero.model.Mask>`, :ref:`Path.annotationLinks <Hibernate version of class omero.model.Path>`, :ref:`Point.annotationLinks <Hibernate version of class omero.model.Point>`, :ref:`Polygon.annotationLinks <Hibernate version of class omero.model.Polygon>`, :ref:`Polyline.annotationLinks <Hibernate version of class omero.model.Polyline>`, :ref:`Rect.annotationLinks <Hibernate version of class omero.model.Rect>`, :ref:`Shape.annotationLinks <Hibernate version of class omero.model.Shape>`
 
 Properties:
-  | child: :ref:`Annotation <omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`Shape <omero.model.Shape>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.Share:
+.. _Hibernate version of class omero.model.Share:
 
 Share
 """""
 
-Used by: :ref:`ShareMember.parent <omero.model.ShareMember>`
+Used by: :ref:`ShareMember.parent <Hibernate version of class omero.model.ShareMember>`
 
 Properties:
   | active: ``boolean``
-  | annotationLinks: :ref:`SessionAnnotationLink <omero.model.SessionAnnotationLink>` (multiple) from :ref:`Session <omero.model.Session>`
-  | closed: ``timestamp`` (optional) from :ref:`Session <omero.model.Session>`
+  | annotationLinks: :ref:`SessionAnnotationLink <Hibernate version of class omero.model.SessionAnnotationLink>` (multiple) from :ref:`Session <Hibernate version of class omero.model.Session>`
+  | closed: ``timestamp`` (optional) from :ref:`Session <Hibernate version of class omero.model.Session>`
   | data: ``binary``
-  | defaultEventType: ``string`` from :ref:`Session <omero.model.Session>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Session <omero.model.Session>`
-  | details.permissions.perm1: ``long`` from :ref:`Session <omero.model.Session>`
-  | events: :ref:`Event <omero.model.Event>` (multiple) from :ref:`Session <omero.model.Session>`
-  | group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
+  | defaultEventType: ``string`` from :ref:`Session <Hibernate version of class omero.model.Session>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Session <Hibernate version of class omero.model.Session>`
+  | details.permissions.perm1: ``long`` from :ref:`Session <Hibernate version of class omero.model.Session>`
+  | events: :ref:`Event <Hibernate version of class omero.model.Event>` (multiple) from :ref:`Session <Hibernate version of class omero.model.Session>`
+  | group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
   | itemCount: ``long``
-  | message: ``text`` (optional) from :ref:`Session <omero.model.Session>`
-  | node: :ref:`Node <omero.model.Node>` from :ref:`Session <omero.model.Session>`
-  | owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Session <omero.model.Session>`
-  | started: ``timestamp`` from :ref:`Session <omero.model.Session>`
-  | timeToIdle: ``long`` from :ref:`Session <omero.model.Session>`
-  | timeToLive: ``long`` from :ref:`Session <omero.model.Session>`
-  | userAgent: ``string`` (optional) from :ref:`Session <omero.model.Session>`
-  | userIP: ``string`` (optional) from :ref:`Session <omero.model.Session>`
-  | uuid: ``string`` from :ref:`Session <omero.model.Session>`
-  | version: ``integer`` (optional) from :ref:`Session <omero.model.Session>`
+  | message: ``text`` (optional) from :ref:`Session <Hibernate version of class omero.model.Session>`
+  | node: :ref:`Node <Hibernate version of class omero.model.Node>` from :ref:`Session <Hibernate version of class omero.model.Session>`
+  | owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Session <Hibernate version of class omero.model.Session>`
+  | started: ``timestamp`` from :ref:`Session <Hibernate version of class omero.model.Session>`
+  | timeToIdle: ``long`` from :ref:`Session <Hibernate version of class omero.model.Session>`
+  | timeToLive: ``long`` from :ref:`Session <Hibernate version of class omero.model.Session>`
+  | userAgent: ``string`` (optional) from :ref:`Session <Hibernate version of class omero.model.Session>`
+  | userIP: ``string`` (optional) from :ref:`Session <Hibernate version of class omero.model.Session>`
+  | uuid: ``string`` from :ref:`Session <Hibernate version of class omero.model.Session>`
+  | version: ``integer`` (optional) from :ref:`Session <Hibernate version of class omero.model.Session>`
 
-.. _omero.model.ShareMember:
+.. _Hibernate version of class omero.model.ShareMember:
 
 ShareMember
 """""""""""
 
 Properties:
-  | child: :ref:`Experimenter <omero.model.Experimenter>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
+  | child: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | parent: :ref:`Share <omero.model.Share>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | parent: :ref:`Share <Hibernate version of class omero.model.Share>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.StageLabel:
+.. _Hibernate version of class omero.model.StageLabel:
 
 StageLabel
 """"""""""
 
-Used by: :ref:`Image.stageLabel <omero.model.Image>`
+Used by: :ref:`Image.stageLabel <Hibernate version of class omero.model.Image>`
 
 Properties:
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
   | name: ``string``
   | positionX.unit: enumeration (optional)
   | positionX.value: ``double`` (optional)
@@ -3133,149 +3142,153 @@ Properties:
   | positionZ.value: ``double`` (optional)
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.StatsInfo:
+.. _Hibernate version of class omero.model.StatsInfo:
 
 StatsInfo
 """""""""
 
-Used by: :ref:`Channel.statsInfo <omero.model.Channel>`
+Used by: :ref:`Channel.statsInfo <Hibernate version of class omero.model.Channel>`
 
 Properties:
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
   | globalMax: ``double``
   | globalMin: ``double``
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.TagAnnotation:
+.. _Hibernate version of class omero.model.TagAnnotation:
 
 TagAnnotation
 """""""""""""
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <omero.model.Annotation>`
-  | description: ``text`` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.permissions.perm1: ``long`` from :ref:`Annotation <omero.model.Annotation>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Annotation <omero.model.Annotation>`
-  | ns: ``string`` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | textValue: ``text`` (optional) from :ref:`TextAnnotation <omero.model.TextAnnotation>`
-  | version: ``integer`` (optional) from :ref:`Annotation <omero.model.Annotation>`
+  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | description: ``text`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.permissions.perm1: ``long`` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | name: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | ns: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | textValue: ``text`` (optional) from :ref:`TextAnnotation <Hibernate version of class omero.model.TextAnnotation>`
+  | version: ``integer`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
 
-.. _omero.model.TermAnnotation:
+.. _Hibernate version of class omero.model.TermAnnotation:
 
 TermAnnotation
 """"""""""""""
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <omero.model.Annotation>`
-  | description: ``text`` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.permissions.perm1: ``long`` from :ref:`Annotation <omero.model.Annotation>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Annotation <omero.model.Annotation>`
-  | ns: ``string`` (optional) from :ref:`Annotation <omero.model.Annotation>`
+  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | description: ``text`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.permissions.perm1: ``long`` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | name: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | ns: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
   | termValue: ``text`` (optional)
-  | version: ``integer`` (optional) from :ref:`Annotation <omero.model.Annotation>`
+  | version: ``integer`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
 
-.. _omero.model.TextAnnotation:
+.. _Hibernate version of class omero.model.TextAnnotation:
 
 TextAnnotation
 """"""""""""""
 
-Subclasses: :ref:`CommentAnnotation <omero.model.CommentAnnotation>`, :ref:`TagAnnotation <omero.model.TagAnnotation>`, :ref:`XmlAnnotation <omero.model.XmlAnnotation>`
+Subclasses: :ref:`CommentAnnotation <Hibernate version of class omero.model.CommentAnnotation>`, :ref:`TagAnnotation <Hibernate version of class omero.model.TagAnnotation>`, :ref:`XmlAnnotation <Hibernate version of class omero.model.XmlAnnotation>`
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <omero.model.Annotation>`
-  | description: ``text`` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.permissions.perm1: ``long`` from :ref:`Annotation <omero.model.Annotation>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Annotation <omero.model.Annotation>`
-  | ns: ``string`` (optional) from :ref:`Annotation <omero.model.Annotation>`
+  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | description: ``text`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.permissions.perm1: ``long`` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | name: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | ns: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
   | textValue: ``text`` (optional)
-  | version: ``integer`` (optional) from :ref:`Annotation <omero.model.Annotation>`
+  | version: ``integer`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
 
-.. _omero.model.Thumbnail:
+.. _Hibernate version of class omero.model.Thumbnail:
 
 Thumbnail
 """""""""
 
-Used by: :ref:`Pixels.thumbnails <omero.model.Pixels>`
+Used by: :ref:`Pixels.thumbnails <Hibernate version of class omero.model.Pixels>`
 
 Properties:
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
   | mimeType: ``string``
-  | pixels: :ref:`Pixels <omero.model.Pixels>`
+  | pixels: :ref:`Pixels <Hibernate version of class omero.model.Pixels>`
   | ref: ``string`` (optional)
   | sizeX: ``integer``
   | sizeY: ``integer``
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.ThumbnailGenerationJob:
+.. _Hibernate version of class omero.model.ThumbnailGenerationJob:
 
 ThumbnailGenerationJob
 """"""""""""""""""""""
 
 Properties:
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Job <omero.model.Job>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Job <omero.model.Job>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Job <omero.model.Job>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Job <omero.model.Job>`
-  | details.permissions.perm1: ``long`` from :ref:`Job <omero.model.Job>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Job <omero.model.Job>`
-  | finished: ``timestamp`` (optional) from :ref:`Job <omero.model.Job>`
-  | groupname: ``string`` from :ref:`Job <omero.model.Job>`
-  | message: ``string`` from :ref:`Job <omero.model.Job>`
-  | originalFileLinks: :ref:`JobOriginalFileLink <omero.model.JobOriginalFileLink>` (multiple) from :ref:`Job <omero.model.Job>`
-  | scheduledFor: ``timestamp`` from :ref:`Job <omero.model.Job>`
-  | started: ``timestamp`` (optional) from :ref:`Job <omero.model.Job>`
-  | status: :ref:`JobStatus <omero.model.JobStatus>` from :ref:`Job <omero.model.Job>`
-  | submitted: ``timestamp`` from :ref:`Job <omero.model.Job>`
-  | type: ``string`` from :ref:`Job <omero.model.Job>`
-  | username: ``string`` from :ref:`Job <omero.model.Job>`
-  | version: ``integer`` (optional) from :ref:`Job <omero.model.Job>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.permissions.perm1: ``long`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | finished: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | groupname: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | message: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | originalFileLinks: :ref:`JobOriginalFileLink <Hibernate version of class omero.model.JobOriginalFileLink>` (multiple) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | scheduledFor: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | started: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | status: :ref:`JobStatus <Hibernate version of class omero.model.JobStatus>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | submitted: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | type: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | username: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | version: ``integer`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
 
-.. _omero.model.TimestampAnnotation:
+.. _Hibernate version of class omero.model.TimestampAnnotation:
 
 TimestampAnnotation
 """""""""""""""""""
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <omero.model.Annotation>`
-  | description: ``text`` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.permissions.perm1: ``long`` from :ref:`Annotation <omero.model.Annotation>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Annotation <omero.model.Annotation>`
-  | ns: ``string`` (optional) from :ref:`Annotation <omero.model.Annotation>`
+  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | description: ``text`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.permissions.perm1: ``long`` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | name: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | ns: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
   | timeValue: ``timestamp`` (optional)
-  | version: ``integer`` (optional) from :ref:`Annotation <omero.model.Annotation>`
+  | version: ``integer`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
 
-.. _omero.model.TransmittanceRange:
+.. _Hibernate version of class omero.model.TransmittanceRange:
 
 TransmittanceRange
 """"""""""""""""""
 
-Used by: :ref:`Filter.transmittanceRange <omero.model.Filter>`
+Used by: :ref:`Filter.transmittanceRange <Hibernate version of class omero.model.Filter>`
 
 Properties:
   | cutIn.unit: enumeration (optional)
@@ -3286,164 +3299,166 @@ Properties:
   | cutOut.value: ``double`` (optional)
   | cutOutTolerance.unit: enumeration (optional)
   | cutOutTolerance.value: ``double`` (optional)
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
   | transmittance: ``double`` (optional)
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.TypeAnnotation:
+.. _Hibernate version of class omero.model.TypeAnnotation:
 
 TypeAnnotation
 """"""""""""""
 
-Subclasses: :ref:`FileAnnotation <omero.model.FileAnnotation>`
+Subclasses: :ref:`FileAnnotation <Hibernate version of class omero.model.FileAnnotation>`
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <omero.model.Annotation>`
-  | description: ``text`` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.permissions.perm1: ``long`` from :ref:`Annotation <omero.model.Annotation>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Annotation <omero.model.Annotation>`
-  | ns: ``string`` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | version: ``integer`` (optional) from :ref:`Annotation <omero.model.Annotation>`
+  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | description: ``text`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.permissions.perm1: ``long`` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | name: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | ns: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | version: ``integer`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
 
-.. _omero.model.UploadJob:
+.. _Hibernate version of class omero.model.UploadJob:
 
 UploadJob
 """""""""
 
 Properties:
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Job <omero.model.Job>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Job <omero.model.Job>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Job <omero.model.Job>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Job <omero.model.Job>`
-  | details.permissions.perm1: ``long`` from :ref:`Job <omero.model.Job>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Job <omero.model.Job>`
-  | finished: ``timestamp`` (optional) from :ref:`Job <omero.model.Job>`
-  | groupname: ``string`` from :ref:`Job <omero.model.Job>`
-  | message: ``string`` from :ref:`Job <omero.model.Job>`
-  | originalFileLinks: :ref:`JobOriginalFileLink <omero.model.JobOriginalFileLink>` (multiple) from :ref:`Job <omero.model.Job>`
-  | scheduledFor: ``timestamp`` from :ref:`Job <omero.model.Job>`
-  | started: ``timestamp`` (optional) from :ref:`Job <omero.model.Job>`
-  | status: :ref:`JobStatus <omero.model.JobStatus>` from :ref:`Job <omero.model.Job>`
-  | submitted: ``timestamp`` from :ref:`Job <omero.model.Job>`
-  | type: ``string`` from :ref:`Job <omero.model.Job>`
-  | username: ``string`` from :ref:`Job <omero.model.Job>`
-  | version: ``integer`` (optional) from :ref:`Job <omero.model.Job>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.permissions.perm1: ``long`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | finished: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | groupname: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | message: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | originalFileLinks: :ref:`JobOriginalFileLink <Hibernate version of class omero.model.JobOriginalFileLink>` (multiple) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | scheduledFor: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | started: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | status: :ref:`JobStatus <Hibernate version of class omero.model.JobStatus>` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | submitted: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | type: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | username: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | version: ``integer`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
   | versionInfo: list (multiple)
 
-.. _omero.model.Well:
+.. _Hibernate version of class omero.model.Well:
 
 Well
 """"
 
-Used by: :ref:`Plate.wells <omero.model.Plate>`, :ref:`WellAnnotationLink.parent <omero.model.WellAnnotationLink>`, :ref:`WellReagentLink.parent <omero.model.WellReagentLink>`, :ref:`WellSample.well <omero.model.WellSample>`
+Used by: :ref:`Plate.wells <Hibernate version of class omero.model.Plate>`, :ref:`WellAnnotationLink.parent <Hibernate version of class omero.model.WellAnnotationLink>`, :ref:`WellReagentLink.parent <Hibernate version of class omero.model.WellReagentLink>`, :ref:`WellSample.well <Hibernate version of class omero.model.WellSample>`
 
 Properties:
   | alpha: ``integer`` (optional)
-  | annotationLinks: :ref:`WellAnnotationLink <omero.model.WellAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`WellAnnotationLink <Hibernate version of class omero.model.WellAnnotationLink>` (multiple)
   | blue: ``integer`` (optional)
   | column: ``integer`` (optional)
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
   | externalDescription: ``string`` (optional)
   | externalIdentifier: ``string`` (optional)
   | green: ``integer`` (optional)
-  | plate: :ref:`Plate <omero.model.Plate>`
-  | reagentLinks: :ref:`WellReagentLink <omero.model.WellReagentLink>` (multiple)
+  | plate: :ref:`Plate <Hibernate version of class omero.model.Plate>`
+  | reagentLinks: :ref:`WellReagentLink <Hibernate version of class omero.model.WellReagentLink>` (multiple)
   | red: ``integer`` (optional)
   | row: ``integer`` (optional)
   | status: ``string`` (optional)
   | type: ``string`` (optional)
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
-  | wellSamples: :ref:`WellSample <omero.model.WellSample>` (multiple)
+  | wellSamples: :ref:`WellSample <Hibernate version of class omero.model.WellSample>` (multiple)
 
-.. _omero.model.WellAnnotationLink:
+.. _Hibernate version of class omero.model.WellAnnotationLink:
 
 WellAnnotationLink
 """"""""""""""""""
 
-Used by: :ref:`Well.annotationLinks <omero.model.Well>`
+Used by: :ref:`Well.annotationLinks <Hibernate version of class omero.model.Well>`
 
 Properties:
-  | child: :ref:`Annotation <omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`Well <omero.model.Well>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`Well <Hibernate version of class omero.model.Well>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.WellReagentLink:
+.. _Hibernate version of class omero.model.WellReagentLink:
 
 WellReagentLink
 """""""""""""""
 
-Used by: :ref:`Reagent.wellLinks <omero.model.Reagent>`, :ref:`Well.reagentLinks <omero.model.Well>`
+Used by: :ref:`Reagent.wellLinks <Hibernate version of class omero.model.Reagent>`, :ref:`Well.reagentLinks <Hibernate version of class omero.model.Well>`
 
 Properties:
-  | child: :ref:`Reagent <omero.model.Reagent>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | child: :ref:`Reagent <Hibernate version of class omero.model.Reagent>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | parent: :ref:`Well <omero.model.Well>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | parent: :ref:`Well <Hibernate version of class omero.model.Well>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
 
-.. _omero.model.WellSample:
+.. _Hibernate version of class omero.model.WellSample:
 
 WellSample
 """"""""""
 
-Used by: :ref:`Image.wellSamples <omero.model.Image>`, :ref:`PlateAcquisition.wellSample <omero.model.PlateAcquisition>`, :ref:`Well.wellSamples <omero.model.Well>`
+Used by: :ref:`Image.wellSamples <Hibernate version of class omero.model.Image>`, :ref:`PlateAcquisition.wellSample <Hibernate version of class omero.model.PlateAcquisition>`, :ref:`Well.wellSamples <Hibernate version of class omero.model.Well>`
 
 Properties:
-  | details.creationEvent: :ref:`Event <omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <omero.model.Event>`
-  | image: :ref:`Image <omero.model.Image>`
-  | plateAcquisition: :ref:`PlateAcquisition <omero.model.PlateAcquisition>` (optional)
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | image: :ref:`Image <Hibernate version of class omero.model.Image>`
+  | plateAcquisition: :ref:`PlateAcquisition <Hibernate version of class omero.model.PlateAcquisition>` (optional)
   | posX.unit: enumeration (optional)
   | posX.value: ``double`` (optional)
   | posY.unit: enumeration (optional)
   | posY.value: ``double`` (optional)
   | timepoint: ``timestamp`` (optional)
   | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
-  | well: :ref:`Well <omero.model.Well>`
+  | well: :ref:`Well <Hibernate version of class omero.model.Well>`
 
-.. _omero.model.XmlAnnotation:
+.. _Hibernate version of class omero.model.XmlAnnotation:
 
 XmlAnnotation
 """""""""""""
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <omero.model.Annotation>`
-  | description: ``text`` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | details.creationEvent: :ref:`Event <omero.model.Event>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.externalInfo: :ref:`ExternalInfo <omero.model.ExternalInfo>` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | details.group: :ref:`ExperimenterGroup <omero.model.ExperimenterGroup>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.owner: :ref:`Experimenter <omero.model.Experimenter>` from :ref:`Annotation <omero.model.Annotation>`
-  | details.permissions.perm1: ``long`` from :ref:`Annotation <omero.model.Annotation>`
-  | details.updateEvent: :ref:`Event <omero.model.Event>` from :ref:`Annotation <omero.model.Annotation>`
-  | ns: ``string`` (optional) from :ref:`Annotation <omero.model.Annotation>`
-  | textValue: ``text`` (optional) from :ref:`TextAnnotation <omero.model.TextAnnotation>`
-  | version: ``integer`` (optional) from :ref:`Annotation <omero.model.Annotation>`
+  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | description: ``text`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.permissions.perm1: ``long`` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | name: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | ns: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | textValue: ``text`` (optional) from :ref:`TextAnnotation <Hibernate version of class omero.model.TextAnnotation>`
+  | version: ``integer`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
 


### PR DESCRIPTION
Now includes `Image.series`. Staged at https://www.openmicroscopy.org/site/support/omero5.1-staging/developers/Model/EveryObject.html.

--no-rebase and, one hopes, now finalized for 5.1