### PR TITLE
Updating link to 5.0.x docs

### DIFF
--- a/omero/conf.py
+++ b/omero/conf.py
@@ -47,7 +47,7 @@ rst_prolog = """
 .. warning:: **This documentation is a PREVIEW for the as-yet unreleased OMERO 5.1. It is provided
     for the benefit of developers and should be considered a work in progress until the
     public release.** Please refer to the documentation for the `latest OMERO 5.0.x
-    version <http://www.openmicroscopy.org/site/support/omero5/>`_ or the
+    version <http://www.openmicroscopy.org/site/support/omero5.0/>`_ or the
     :legacy_plone:`previous versions <>` page to find documentation for the
     OMERO version you are using.
 """


### PR DESCRIPTION
This message is going once we release anyway, but thought I'd update it for the m4 docs just to avoid any confusion.