### PR TITLE
Making doc links 5.1 specific

### DIFF
--- a/common/conf.py
+++ b/common/conf.py
@@ -159,11 +159,11 @@ extlinks = {
     'schema_plone' : (oo_root + '/Schemas/%s', ''),
     'omero_plone' : (oo_site_root + '/products/omero/%s', ''),
     'secvuln' : (oo_root + '/info/vulnerabilities/%s', ''),
-    'omero_doc' : (oo_site_root + '/support/omero5/%s', ''),
+    'omero_doc' : (oo_site_root + '/support/omero5.1/%s', ''),
     'model_doc' : (oo_site_root + '/support/ome-model/%s', ''),
     'devs_doc' : (oo_site_root + '/support/contributing/%s', ''),
     'bf_plone' : (oo_site_root + '/products/bio-formats/%s', ''),
-    'bf_doc' : (oo_site_root + '/support/bio-formats5/%s', ''),
+    'bf_doc' : (oo_site_root + '/support/bio-formats5.1/%s', ''),
     'partner_plone' : (oo_site_root + '/products/partner/%s', ''),
     # Downloads
     'downloads' : (downloads_root + '/latest/omero5.1/%s', ''),

--- a/formats/developers/structured-annotations.txt
+++ b/formats/developers/structured-annotations.txt
@@ -11,7 +11,7 @@ Definitions functionality of prior schemas.
 
 For more information on SAs from an OMERO-centric perspective, see the
 :omero_doc:`OMERO page on structured
-annotations <developers/Modules/StructuredAnnotations.html>`.
+annotations <developers/Model/StructuredAnnotations.html>`.
 
 The structure of the SA used in the schema is shown below,
 along with all the possible attachment points in the model.


### PR DESCRIPTION
This makes all 5.1/2015-01 Model docs link to each other by specific branch, mostly so the new Model docs link to the m4 docs before we automatically redirect all the 5 links to 5.1