### PR TITLE
Updating pytables external link (rebased onto dev_5_0)

### DIFF
--- a/omero/sysadmins/unix/server-installation.txt
+++ b/omero/sysadmins/unix/server-installation.txt
@@ -201,7 +201,7 @@ The following Python packages are required:
 
     * - PyTables (2.1.0 or higher)
       - :doc:`OMERO.tables </sysadmins/server-tables>`
-      - `PyTables page <http://www.pytables.org/moin/Downloads>`_
+      - `PyTables page <https://pytables.github.io/downloads.html>`_
 
     * - scipy.ndimage
       - :omero_plone:`Volume Viewer <volume-viewer-in-omero.web>` [3]_

--- a/omero/sysadmins/windows/server-installation.txt
+++ b/omero/sysadmins/windows/server-installation.txt
@@ -148,7 +148,7 @@ The following are optional depending on what services you require:
 
     * - PyTables (2.1.0 or higher)
       - :doc:`OMERO.tables </sysadmins/server-tables>`
-      - `PyTables page <http://www.pytables.org/moin/Downloads>`_
+      - `PyTables page <https://pytables.github.io/downloads.html>`_
 
     * - scipy.ndimage
       - :omero_plone:`Volume Viewer <volume-viewer-in-omero.web>` [2]_


### PR DESCRIPTION
This is the same as gh-1119 but rebased onto dev_5_0.

---

See https://github.com/PyTables/PyTables/issues/420#issuecomment-75062287 - www.pytables.org is currently shutdown. This should make the build green again.
