### PR TITLE
adjust server config link

### DIFF
--- a/omero/developers/Server/Properties.txt
+++ b/omero/developers/Server/Properties.txt
@@ -23,6 +23,9 @@ OMERO.server:
                                          (Name will change to "…default")
       etc/local.properties             - Local overrides for other properties (used by build only)
 
+The most useful of the properties are listed in a :doc:`glossary
+</sysadmins/config>`.
+
 During the build, these files get stored in the ``blitz.jar`` and are
 read-only. On creation of an :doc:`/developers/Server/Context`,
 the lookup for properties is (first wins):

--- a/omero/developers/Server/Properties.txt
+++ b/omero/developers/Server/Properties.txt
@@ -1,12 +1,6 @@
 Properties
 ==========
 
-As of milestone :milestone:`OMERO-Beta4`
-(:ticket:`800`), client usage of these properties has
-significantly changed. Please see the 
-:doc:`sysadmin documentation </sysadmins/index>`
-for how to configure your server installation.
-
 Under the :file:`etc/` directory in both the source and the binary
 distributions, several files are provided which help to configure
 OMERO.server:

--- a/omero/developers/Server/Properties.txt
+++ b/omero/developers/Server/Properties.txt
@@ -4,7 +4,7 @@ Properties
 As of milestone :milestone:`OMERO-Beta4`
 (:ticket:`800`), client usage of these properties has
 significantly changed. Please see the 
-:doc:`sysadmin documentation </sysadmins/server-overview>`
+:doc:`sysadmin documentation </sysadmins/index>`
 for how to configure your server installation.
 
 Under the :file:`etc/` directory in both the source and the binary


### PR DESCRIPTION
People wanting to know more about server configuration are probably better directed to the general sysadmin page than the overview. Staged at http://www.openmicroscopy.org/site/support/omero5.1-staging/developers/Server/Properties.html.

--no-rebase