### PR TITLE
Use Sphinx 1.2.3 for Travis build (rebased onto dev_5_0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   - travis_retry sudo apt-get -y install texlive-latex-extra texlive-fonts-recommended fonts-texgyre
   - sudo fc-cache -rsfv
   - fc-list
-  - sudo pip install scc Sphinx
+  - sudo pip install scc Sphinx==1.2.3
   - git config --global github.token 3bc7fc530b01081559eb911f59ccfec7f4fb2592
   - git config --global user.email snoopycrimecop@gmail.com
   - git config --global user.name 'Snoopy Crime Cop'


### PR DESCRIPTION
This is the same as gh-1134 but rebased onto dev_5_0.

---

Similar fix as in https://github.com/openmicroscopy/bioformats/pull/1657. Travis is currently failing because our documentation does not build cleanly with Sphinx 1.3.0
