### PR TITLE
update 5.1 patch version to 1

### DIFF
--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -170,7 +170,7 @@ in a short time. The example below assumes you are upgrading from a
 .. parsed-literal::
 
     $ cd OMERO.server
-    $ psql -h localhost -U **db_user** **omero_database** < sql/psql/OMERO\ |version|\_\_0/OMERO\ |previousversion|\_\_0.sql
+    $ psql -h localhost -U **db_user** **omero_database** < sql/psql/OMERO\ |version|\_\_1/OMERO\ |previousversion|\_\_0.sql
     Password for user **db_user**:
     ...
     ...

--- a/omero/sysadmins/troubleshooting.txt
+++ b/omero/sysadmins/troubleshooting.txt
@@ -82,10 +82,10 @@ Unix account). This is done by setting the password in the database script:
 
    $ bin/omero db script
    Please enter omero.db.version [OMERO\ |version|\ ]: 
-   Please enter omero.db.patch [0]: 
+   Please enter omero.db.patch [1]: 
    Please enter password for new OMERO root user:       # root_password
    Please re-enter password for new OMERO root user:      # root_password
-   Saving to ~/OMERO\ |version|\ __0.sql
+   Saving to ~/OMERO\ |version|\ __1.sql
 
 Other OMERO users can be created via the OMERO.web admin tool. None of the 
 passwords have to be the same, in fact they should be different **unless you

--- a/omero/sysadmins/unix/server-install-homebrew.txt
+++ b/omero/sysadmins/unix/server-install-homebrew.txt
@@ -301,16 +301,16 @@ Now tell OMERO.server about our database.
 
     $ omero db script
     Please enter omero.db.version [OMERO\ |version|\ ]:
-    Please enter omero.db.patch [0]:
+    Please enter omero.db.patch [1]:
     Please enter password for new OMERO root user:       # root_password
     Please re-enter password for new OMERO root user:      # root_password
-    Saving to ~/OMERO\ |version|\ __0.sql
+    Saving to ~/OMERO\ |version|\ __1.sql
 
 Then enter the name of the .sql (see last line above) in the next command, to create the database:
 
 .. parsed-literal::
 
-    $ psql -h localhost -U db_user omero_database < OMERO\ |version|\ __0.sql
+    $ psql -h localhost -U db_user omero_database < OMERO\ |version|\ __1.sql
 
 Now create a location to store OMERO data, e.g.
 

--- a/omero/sysadmins/unix/server-installation.txt
+++ b/omero/sysadmins/unix/server-installation.txt
@@ -645,10 +645,10 @@ Configuration
         $ cd ~/omero/OMERO.server
         $ bin/omero db script
         Please enter omero.db.version [OMERO\ |version|\ ]: 
-        Please enter omero.db.patch [0]: 
+        Please enter omero.db.patch [1]: 
         Please enter password for new OMERO root user: # omero_root_password
         Please re-enter password for new OMERO root user: # omero_root_password
-        Saving to ~/Desktop/omero/OMERO\ |version|\ __0.sql
+        Saving to ~/Desktop/omero/OMERO\ |version|\ __1.sql
 
    .. warning:: **Security**
 
@@ -663,7 +663,7 @@ Configuration
 
     .. parsed-literal::
 
-        $ psql -h localhost -U db_user omero_database < OMERO\ |version|\ __0.sql
+        $ psql -h localhost -U db_user omero_database < OMERO\ |version|\ __1.sql
 
     At this point you should see some output from PostgreSQL as it
     installs the schema for new OMERO database.

--- a/omero/sysadmins/windows/server-installation.txt
+++ b/omero/sysadmins/windows/server-installation.txt
@@ -564,10 +564,10 @@ Installation
         C:\\> cd C:\\OMERO.server
         C:\\OMERO.server> bin\\omero db script
         Please enter omero.db.version [OMERO\ |version|\ ]: 
-        Please enter omero.db.patch [0]: 
+        Please enter omero.db.patch [1]: 
         Please enter password for new OMERO root user: # root_password
         Please re-enter password for new OMERO root user: # root_password
-        Saving to C:\\OMERO.server\\OMERO\ |version|\ __0.sql
+        Saving to C:\\OMERO.server\\OMERO\ |version|\ __1.sql
 
     The generated SQL file is found in the folder where you called the "omero  
     db script" command. This could cause a permission denied error in the 
@@ -604,7 +604,7 @@ Installation
 
        .. parsed-literal::
 
-           omero=> \\i C:/OMERO.server/OMERO\ |version|\ __0.sql
+           omero=> \\i C:/OMERO.server/OMERO\ |version|\ __1.sql
            ...
            ...
            omero=> \\q


### PR DESCRIPTION
Have the documentation show the correct patch version for the 5.1 release.

This is rather unfortunate, and should perhaps be reverted for 5.2.

--no-rebase