### PR TITLE
Add a note to double check OMERO.web config (rebased onto dev_5_0)

### DIFF
--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -71,7 +71,16 @@ show nothing.
 which has been significantly stream-lined. See :ref:`search-reindexing`
 for more information.
 
-Web Plugin Updates
+OMERO.web configuration
+^^^^^^^^^^^^^^^^^^^^^^^
+
+If you generated configuration stanzas using `bin/omero web config` which
+enable OMERO.web via Apache or Nginx, they may include hard-code links to
+your previous version of OMERO. We recommend using a future-proof symlink
+if possible, so that these stanzas do not need updating with each OMERO
+server upgrade. See also the :doc:`unix/install-web` page.
+
+Web Plugin updates
 ^^^^^^^^^^^^^^^^^^
 OMERO.web plugins are very closely integrated into the webclient. For this
 reason, it is possible that an update of OMERO will cause issues with an older

--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -75,7 +75,7 @@ OMERO.web configuration
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 If you generated configuration stanzas using :omerocmd:`web config` which
-enable OMERO.web via Apache or Nginx, they may include hard-code links to
+enable OMERO.web via Apache or Nginx, they may include hard-coded links to
 your previous version of OMERO. We recommend using a future-proof symlink
 if possible, so that these stanzas do not need updating with each OMERO
 server upgrade. See also the :doc:`unix/install-web` page.

--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -74,7 +74,7 @@ for more information.
 OMERO.web configuration
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-If you generated configuration stanzas using `bin/omero web config` which
+If you generated configuration stanzas using :omerocmd:`web config` which
 enable OMERO.web via Apache or Nginx, they may include hard-code links to
 your previous version of OMERO. We recommend using a future-proof symlink
 if possible, so that these stanzas do not need updating with each OMERO


### PR DESCRIPTION
This is the same as gh-1137 but rebased onto dev_5_0.

---

When upgrading our OMERO server from 5.0.0 to 5.0.8, I had an issue
where OMERO.web did not display things properly afterward. The problem
was that although we use a "future-proof" symlink, pointing the 'omero'
folder to whatever the current version is (e.g.,
OMERO.server-5.0.8-ice34-b60), the "bin/omero web config" configuration
stanza generator used the hardcoded version-specific folder name, which
I failed to adjust when I did the 5.0.0 install. So in short, my Apache
configuration was outdated.

Just another pitfall which might be worth mentioning in the upgrade
documentation, since there is already a handy checklist.
