### PR TITLE
Small fixes and improvements to top_links docs

### DIFF
--- a/omero/developers/Web/CreateApp.txt
+++ b/omero/developers/Web/CreateApp.txt
@@ -332,7 +332,7 @@ of links at the top of the webclient main pages.
        $ bin/omero config append omero.web.ui.top_links '["Mobile", "webmobile_index"]'
 
    From OMERO 5.1, you can add additional attributes to links using the format ``['Link Text', 'link', attrs]``.
-   This can be used to add tool-tips and open the link in a new 'target' tab. For example:
+   This can be used to add tool-tips and open the link in a new "target" tab. For example:
 
    ::
 

--- a/omero/developers/Web/CreateApp.txt
+++ b/omero/developers/Web/CreateApp.txt
@@ -325,7 +325,7 @@ of links at the top of the webclient main pages.
 
 -  **Update configuration** Use the OMERO command line interface to append the link to the ``top_links`` list.
 
-   Links use the format ``["Label", "URL_name"]`` or , you can follow this example:
+   Links use the format ``["Label", "URL_name"]`` or you can follow this example:
 
    ::
 

--- a/omero/developers/Web/CreateApp.txt
+++ b/omero/developers/Web/CreateApp.txt
@@ -308,32 +308,35 @@ Users can then configure this on the command line as follows:
 OMERO.web top links
 ^^^^^^^^^^^^^^^^^^^
 
-You can configure :property:`omero.web.ui.top_links` to add a link to the list
+You can configure :property:`omero.web.ui.top_links` to add links to the list
 of links at the top of the webclient main pages.
 
 -  **Name your URL in urls.py** (optional). Preferably we use URL names to
    refer to URLs.
-   For example, the homepage of your app might be named like this in urls.py.
+   For example, the homepage of your app might be named like this in yourapp/urls.py.
 
    ::
 
        url( r'^$', views.index, name='webmobile_index' ),
 
 
--  **Update configuration** Use the OMERO command line interface to append the link or links to the appropriate list.
+   You can then refer to this link using this 'name', or you can simply use a full url for external links.
 
-To append a single link, using the format ``["Label", "URL_name"]`` or , you can follow this example:
 
-::
+-  **Update configuration** Use the OMERO command line interface to append the link to the ``top_links`` list.
 
-    $ bin/omero config append omero.web.ui.top_links '[["Mobile", "webmobile_index"]]'
+   Links use the format ``["Label", "URL_name"]`` or , you can follow this example:
 
-Multiple links can be appended in the same way. 
-You can also create **external** links using the format ``['Link Text', 'link', 'options']``. For example:
+   ::
 
-::
+       $ bin/omero config append omero.web.ui.top_links '["Mobile", "webmobile_index"]'
 
-    $ bin/omero config set omero.web.ui.top_links '[["Mobile", "webmobile_index"], ["Homepage", "http://...", {"title": "Homepage", "target": "new"} ]]'
+   From OMERO 5.1, you can add additional attributes to links using the format ``['Link Text', 'link', attrs]``.
+   This can be used to add tool-tips and open the link in a new 'target' tab. For example:
+
+   ::
+
+       $ bin/omero config append omero.web.ui.top_links '["Homepage", "http://myhome.com", {"title": "Homepage", "target": "new"}]'
 
 
 OMERO.web plugins


### PR DESCRIPTION
Updated the top_links docs to not use "set" command since this will remove default links.
Also improved layout (indentation) and description of new 'attrs' that can be added in 5.1.

--rebased-to #1154
