### PR TITLE
updating developers/web doc

### DIFF
--- a/omero/developers/Web.txt
+++ b/omero/developers/Web.txt
@@ -112,7 +112,7 @@ have OMERO.web running, you can view the page under
        def dataset(request, datasetId, conn=None, **kwargs):
            ds = conn.getObject("Dataset", datasetId)
            # generate html from template
-           return render_to_response('webtest/dataset.html', {'dataset': ds})
+           return render(request, 'webtest/dataset.html', {'dataset': ds})
 
 -  **Template:** The template web page, in
    omeroweb/webtest/templates/webtest/dataset.html

--- a/omero/developers/Web/CreateApp.txt
+++ b/omero/developers/Web/CreateApp.txt
@@ -136,6 +136,10 @@ Add the essential files to your app
             """
             return HttpResponse("Welcome to your app home-page!")
 
+For more details how to write Views, forms, using templates, etc. check
+:djangodoc:`Django documentation <intro/tutorial03/#write-your-first-view>`.
+
+
 Add your app to OMERO.web
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/omero/developers/Web/CreateApp.txt
+++ b/omero/developers/Web/CreateApp.txt
@@ -136,7 +136,7 @@ Add the essential files to your app
             """
             return HttpResponse("Welcome to your app home-page!")
 
-For more details how to write Views, forms, using templates, etc. check
+For more details on how to write Views, forms, using templates, etc. check
 :djangodoc:`Django documentation <intro/tutorial03/#write-your-first-view>`.
 
 

--- a/omero/developers/Web/CreateApp.txt
+++ b/omero/developers/Web/CreateApp.txt
@@ -136,7 +136,7 @@ Add the essential files to your app
             """
             return HttpResponse("Welcome to your app home-page!")
 
-For more details on how to write Views, forms, using templates, etc. check
+For more details on how to write views, forms, using templates, etc. check
 :djangodoc:`Django documentation <intro/tutorial03/#write-your-first-view>`.
 
 

--- a/omero/developers/Web/CreateApp.txt
+++ b/omero/developers/Web/CreateApp.txt
@@ -210,7 +210,7 @@ The following example can be found in the `webtest <https://github.com/openmicro
    ::
 
        from omeroweb.webclient.decorators import login_required
-       from django.shortcuts import render_to_response
+       from django.shortcuts import render
 
 
        @login_required()
@@ -222,7 +222,7 @@ The following example can be found in the `webtest <https://github.com/openmicro
            # 5 Z-planes
            z_indexes = [0, int(sizeZ*0.25), 
                     int(sizeZ*0.5), int(sizeZ*0.75), sizeZ-1]
-           return render_to_response('webtest/stack_preview.html',
+           return render(request, 'webtest/stack_preview.html',
                 {'imageId':imageId, 
                 'image_name':image_name, 
                 'z_indexes':z_indexes})

--- a/omero/developers/Web/WritingViews.txt
+++ b/omero/developers/Web/WritingViews.txt
@@ -47,7 +47,7 @@ passed to the function via the optional parameter ``conn=None``.
     @login_required()
     def dataset(request, datasetId, conn=None, **kwargs):
         ds = conn.getObject("Dataset", datasetId)
-        return render_to_response('webtest/dataset.html', {'dataset': ds})
+        return render(request, 'webtest/dataset.html', {'dataset': ds})
 
 .. figure:: /images/web-get-blitz-connection-flow.png
   :align: center


### PR DESCRIPTION
This PR update some sample code to the Django standards

To test it, for example create simple form and use ```render``` on HTTP POST. You should not get 403 as ```RequestContext``` is forced and ```{% csrf_token %}``` will be used.

cc @will-moore 
--no-rebase