### PR TITLE
CLI installation

### DIFF
--- a/omero/sysadmins/unix/server-installation.txt
+++ b/omero/sysadmins/unix/server-installation.txt
@@ -68,6 +68,8 @@ Fedora and Scientific Linux.
 
   where *package* is the package name to install.
 
+.. _server-requirements:
+
 Overview
 ^^^^^^^^
 

--- a/omero/users/cli/installation.txt
+++ b/omero/users/cli/installation.txt
@@ -11,7 +11,7 @@ Additionally, Ice_ must be installed on your machine::
     $ python -c "import Ice"
 
 Check :doc:`/sysadmins/version-requirements` for the minimum and maximum
-versions of both requirements
+versions of both requirements.
 
 The |CLI| is currently bundled:
 

--- a/omero/users/cli/installation.txt
+++ b/omero/users/cli/installation.txt
@@ -10,8 +10,8 @@ Additionally, Ice_ must be installed on your machine::
 
     $ python -c "import Ice"
 
-Check :doc:`/sysadmins/version-requirements` for the minimum and maximum
-versions of both requirements.
+Check the :ref:`server requirements <server-requirements>` for the minimum and
+maximum supported versions.
 
 The |CLI| is currently bundled:
 

--- a/omero/users/cli/installation.txt
+++ b/omero/users/cli/installation.txt
@@ -4,26 +4,37 @@ Installation
 Check you have Python_ installed by typing::
 
     $ python --version
-    Python 2.7.5+
+    Python 2.7.9
 
 Additionally, Ice_ must be installed on your machine::
 
     $ python -c "import Ice"
 
-The |CLI| is currently bundled with the OMERO.server. Download the version
-corresponding to your system from the :downloads:`OMERO downloads <>` page.
+Check :doc:`/sysadmins/version-requirements` for the minimum and maximum
+versions of both requirements
+
+The |CLI| is currently bundled:
+
+- with the OMERO.server including all functionalities of the |CLI|
+- with the OMERO.python including all functionalities of the |CLI| except for
+  the import functionality
+
+Download the version corresponding to your system from the
+:downloads:`OMERO downloads <>` page.
 
 .. note::
-	The |CLI| is bundled with the OMERO.server but that does not imply you
-	must use that directory as a server. You can download the server zip to a
-	number of machines and use the |CLI| commands from each machine to access
-	an existing OMERO instance.
+    The |CLI| is bundled with the OMERO.server but that does not imply you
+    must use that directory as a server. You can download the server zip to a
+    number of machines and use the |CLI| commands from each machine to access
+    an existing OMERO instance.
 
-Once the server is downloaded, the |CLI| is located under the :file:`bin/`
-directory::
+Once the correct bundle is downloaded, the Python libraries of the |CLI| are
+located under the :file:`lib/python` directory and the executable is under
+the :file:`bin` directory. To start the |CLI| in shell mode:
 
-    $ cd OMERO.server
-    $ bin/omero -h
-    OMERO Python Shell. Version 4.4.5-ice33
+.. parsed-literal::
+
+    $ bin/omero
+    OMERO Python Shell. Version |release|-ice35
     Type "help" for more information, "quit" or Ctrl-D to exit
     omero>


### PR DESCRIPTION
- Add link to version requirements
- Mark both OMERO.py and OMERO.server as CLI containers (with caveats)
- Fix CLI shell code block

/cc @ximenesuk
--no-rebase