### PR TITLE
Review CLI overview/sessions pages

### DIFF
--- a/omero/users/cli/overview.txt
+++ b/omero/users/cli/overview.txt
@@ -1,5 +1,5 @@
-Command line interface overview
--------------------------------
+Overview
+--------
 
 .. _cli_help:
 
@@ -18,7 +18,7 @@ these sub-commands::
     $ bin/omero admin -h
     $ bin/omero admin start -h
 
-The :omerocmd:`help` command can be used to get info on other commands or
+The :program:`omero help` command can be used to get info on other commands or
 options::
 
     $ bin/omero help debug       # debug is an option
@@ -30,34 +30,29 @@ Command line workflow
 There are three ways to use the command line tools:
 
 #.  By explicitly logging in to the server first i.e. by creating a session
-    using the :omerocmd:`login` command.
-    The connection parameters can be either passed directly in the connection
-    string::
+    using the :program:`omero login` command, e.g.::
 
         $ bin/omero login username@servername:4064
-
-    or using the :option:`-s`, :option:`-u` and :option:`-p` options::
-
-        $ bin/omero login -s servername -u username -p 4064
-
-    If no argument can be specified, the interface will ask for the
-    connection credentials::
-
-        $ bin/omero login
-        Previously logged in to localhost:4064 as root
-        Server: [localhost]
-        Username: [root]
         Password:
 
     During login, a session is created locally on disk and will remain active
     until you logout or it times out. You can then call the desired command,
-    e.g. the :omerocmd:`import` command::
+    e.g. the :program:`omero import` command::
 
         $ bin/omero import image.tiff
 
-#.  By passing the session arguments directly to the desired command, e.g.::
+#.  By passing the session arguments directly to the desired command. Most
+    commands support the same arguments as the :program:`omero login`::
 
         $ bin/omero -s servername -u username -p 4064 import image.tiff
+        Password:
+
+    The :option:`--sudo <omero login --sudo>` option is available to all
+    commands accepting connection arguments. For instance to import data for
+    user *username*::
+
+        $ bin/omero import --sudo root -s servername -u username image.tiff
+        Password for owner:
 
 #.  By calling the desired command without login arguments. You will be asked
     to login::
@@ -68,6 +63,6 @@ There are three ways to use the command line tools:
         Password:
 
 Once you are done with your work, you can terminate the current session if you
-wish using the :omerocmd:`logout` command::
+wish using the :program:`omero logout` command::
 
     $ bin/omero logout

--- a/omero/users/cli/overview.txt
+++ b/omero/users/cli/overview.txt
@@ -42,7 +42,7 @@ There are three ways to use the command line tools:
         $ bin/omero import image.tiff
 
 #.  By passing the session arguments directly to the desired command. Most
-    commands support the same arguments as the :program:`omero login`::
+    commands support the same arguments as :program:`omero login`::
 
         $ bin/omero -s servername -u username -p 4064 import image.tiff
         Password:

--- a/omero/users/cli/sessions.txt
+++ b/omero/users/cli/sessions.txt
@@ -13,7 +13,7 @@ Login
 
 The :program:`omero login` command is a shortcut for the
 :program:`omero sessions login` subcommand which creates a connection to the
-server. If no argument can be specified, the interface will ask for the
+server. If no argument is specified, the interface will ask for the
 connection credentials::
 
     $ bin/omero login
@@ -45,7 +45,7 @@ Some of the options available to the :program:`omero login` command are:
 
 .. option:: -u USER, --user USER
 
-    Set the name of the username::
+    Set the name of the user to connect as::
 
         $ bin/omero login -u username -s servername
         Password:
@@ -74,7 +74,7 @@ Some of the options available to the :program:`omero login` command are:
 
 .. option:: -w PASSWORD, --password PASSWORD
 
-    Set the password to use for the connection
+    Set the password to use for the connection.
 
 .. option:: --sudo ADMINUSER
 
@@ -101,7 +101,7 @@ command::
      localhost | root | system          | 1f800a16-1dc2-407a-8a85-fb44005306be | True      | Fri Nov 23 14:55:18 2012
     (2 rows)
 
-Sessions keys can then be reused to switch between stored sessions using the
+Session keys can then be reused to switch between stored sessions using the
 :option:`omero login -k` option::
 
     $ bin/omero sessions login -k 22fccb8b-d04c-49ec-9d52-116a163728ca

--- a/omero/users/cli/sessions.txt
+++ b/omero/users/cli/sessions.txt
@@ -1,16 +1,98 @@
 Manage sessions
 ---------------
 
-The :omerocmd:`sessions` commands manage user sessions stored locally on disk.
+The :program:`omero sessions` plugin manage user sessions stored locally on
+disk.
 Several sessions can be active simultaneously, but only one will be used for a
 single invocation of `bin/omero`::
 
     $ bin/omero sessions -h
 
+Login
+^^^^^
+
+The :program:`omero login` command is a shortcut for the
+:program:`omero sessions login` subcommand which creates a connection to the
+server. If no argument can be specified, the interface will ask for the
+connection credentials::
+
+    $ bin/omero login
+    Previously logged in to localhost:4064 as root
+    Server: [localhost:4064]
+    Username: [root]
+    Password:
+
+Some of the options available to the :program:`omero login` command are:
+
+.. program:: omero login
+
+.. option:: connection
+
+    Pass a connection string under the form ``[USER@]SERVER[:PORT]`` to
+    instantiate a connection::
+
+        $ bin/omero login username@servername
+        Password:
+        $ bin/omero login username@servername:14064
+        Password:
+
+.. option:: -s SERVER, --server SERVER
+
+    Set the name of the server to connect to::
+
+        $ bin/omero login -s servername
+        Username: [username]
+
+.. option:: -u USER, --user USER
+
+    Set the name of the username::
+
+        $ bin/omero login -u username -s servername
+        Password:
+
+.. option:: -p PORT, --port PORT
+
+    Set the port to use for connection. Default: 4064::
+
+        $ bin/omero login -u username -s servername -p 14064
+        Password:
+
+.. option:: -g GROUP, --group GROUP
+
+    Set the group to use for initalizing a connection::
+
+        $ bin/omero login -u username -s servername -g my_group
+        Password:
+
+.. option:: -k KEY, --key KEY
+
+    Use a valid session key to join an existing connection.
+
+    This option only requires a server argument::
+
+        $ bin/omero login servername -k 22fccb8b-d04c-49ec-9d52-116a163728ca
+
+.. option:: -w PASSWORD, --password PASSWORD
+
+    Set the password to use for the connection
+
+.. option:: --sudo ADMINUSER
+
+    Create a connection as another user.
+
+    The sudo functionality is available to administrators as well as group
+    owners::
+
+        $ bin/omero login --sudo root -s servername -u username
+        Password for root:
+        $ bin/omero login --sudo owner -s servername -u username
+        Password for owner:
+
 Multiple sessions
 ^^^^^^^^^^^^^^^^^
 
-Stored sessions can be listed using the :omerocmd:`sessions list` command::
+Stored sessions can be listed using the :program:`omero sessions list`
+command::
 
     $ bin/omero sessions list
      Server    | User | Group           | Session                              | Active    | Started
@@ -19,7 +101,8 @@ Stored sessions can be listed using the :omerocmd:`sessions list` command::
      localhost | root | system          | 1f800a16-1dc2-407a-8a85-fb44005306be | True      | Fri Nov 23 14:55:18 2012
     (2 rows)
 
-Sessions keys can then be reused to switch between stored sessions::
+Sessions keys can then be reused to switch between stored sessions using the
+:option:`omero login -k` option::
 
     $ bin/omero sessions login -k 22fccb8b-d04c-49ec-9d52-116a163728ca
     Server: [localhost]
@@ -36,7 +119,7 @@ Sessions directory
 
 By default sessions are saved locally on disk under :file:`~/omero/sessions`.
 The location of the current session file can be retrieved using the
-:omerocmd:`sessions file` command::
+:program:`omero sessions file` command::
 
     $ bin/omero sessions file
     /Users/ome/omero/sessions/localhost/root/aec828e1-79bf-41f3-91e6-a4ac76ff1cd5
@@ -53,22 +136,8 @@ If you want to use a custom session directory, use the
 Switching current group
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-The sessions command can be used to switch the group of your current session::
+The :program:`sessions group` command can be used to switch the group of your
+current session::
 
     $ bin/omero group list          # list your groups
     $ bin/omero sessions group 2    # switch to group by ID or Name
-
-Sudo functionality
-^^^^^^^^^^^^^^^^^^
-
-Since 5.0.2, the CLI includes a sudo functionality for administrators allowing
-them to execute commands as another user. For example, to login as
-*username*, the root user can invoke the following command::
-
-    $ bin/omero login --sudo root -s servername -u username
-    Password for root:
-
-The :option:`--sudo` option is available to all commands accepting connection
-arguments. For instance to import data for user *username*::
-
-   $ bin/omero import --sudo root -s servername -u username image.tiff


### PR DESCRIPTION
See https://trello.com/c/Lo6MKBRY/298-5-1-cli

This page improves the `omero login` documentation and simplifies the overview section for the CLI.
As requested, the `-k KEY` argument should be better exposed with this change /cc @joshmoore.

--no-rebase