### PR TITLE
Update BF cpp doc link in Model Docs

### DIFF
--- a/formats/ome-tiff/tools.txt
+++ b/formats/ome-tiff/tools.txt
@@ -21,8 +21,8 @@ line:
     $ identify -verbose
 
 If you are working in C/C++, we recommend the open source
-`LibTIFF <http://www.libtiff.org/>`_ library, or Bio-Formats via the
-:bf_doc:`Bio-Formats C++ bindings <developers/c-bindings.html>`.
+`LibTIFF <http://www.libtiff.org/>`_ library, or the new Bio-Formats
+:bf_doc:`native C++ implementation <developers/cpp/overview.html>`.
 
 If you are looking for a solution in Java, there are several options.
 Bio-Formats can read OME-TIFF files, as well as convert from many

--- a/formats/ome-tiff/tools.txt
+++ b/formats/ome-tiff/tools.txt
@@ -21,7 +21,9 @@ line:
     $ identify -verbose
 
 If you are working in C/C++, we recommend the open source
-`LibTIFF <http://www.libtiff.org/>`_ library, or the new Bio-Formats
+`LibTIFF <http://www.libtiff.org/>`_ library, the
+:bf_doc:`JACE C++ bindings <developers/jace/overview.html>` for Bio-Formats or
+the new Bio-Formats
 :bf_doc:`native C++ implementation <developers/cpp/overview.html>`.
 
 If you are looking for a solution in Java, there are several options.


### PR DESCRIPTION
See https://ci.openmicroscopy.org/view/Docs/job/FORMATS-merge-docs/631/warnings3Result/ - the BF cpp docs moving broke the link in the Model Docs. Given the 5.1 docs are now live since the m5 release, I thought it was fine to link to them now.

cc @rleigh-dundee 