### PR TITLE
CLI: minor fixes

### DIFF
--- a/omero/autogen_docs
+++ b/omero/autogen_docs
@@ -30,7 +30,7 @@ echo "Generating CLI admin ports help"
 (cd $WORKSPACE/OMERO.server && bin/omero admin ports -h) > omero/downloads/cli/admin-ports-help.txt
 
 echo "Generating DB script example"
-(cd $WORKSPACE/OMERO.server && bin/omero db script --password secretpassword 2>&1) | sed "s|$WORKSPACE|/home/omero|" > omero/downloads/cli/db-script-example.txt
+(cd $WORKSPACE && OMERO.server/bin/omero db script --password secretpassword 2>&1) | sed "s|$WORKSPACE|/home/omero|" > omero/downloads/cli/db-script-example.txt
 
 echo "Generating Web configuration templates"
 $WORKSPACE/OMERO.server/bin/omero web config nginx | sed "s|$WORKSPACE|/home/omero|" > omero/sysadmins/unix/nginx-omero.conf

--- a/omero/users/cli/overview.txt
+++ b/omero/users/cli/overview.txt
@@ -19,10 +19,33 @@ these sub-commands::
     $ bin/omero admin start -h
 
 The :program:`omero help` command can be used to get info on other commands or
-options::
+options.
 
-    $ bin/omero help debug       # debug is an option
-    $ bin/omero help admin       # same as bin/omero admin -h
+.. program:: omero help
+
+.. option:: command
+
+    Display the information on a particular command or option::
+
+        $ bin/omero help debug       # debug is an option
+        $ bin/omero help admin       # same as bin/omero admin -h
+
+.. option:: --all
+
+    Display the help for all available commands and options
+
+.. option:: --recursive
+
+    Recursively display the help of commands and/or options. This option can
+    be used with either the :option:`command` or the :option:`--all` option::
+
+        $ bin/omero help --all --recursive
+        $ bin/omero help user --recursive
+
+.. option:: --list
+
+    Display a list of all available commands and subcommands
+
 
 Command line workflow
 ^^^^^^^^^^^^^^^^^^^^^

--- a/omero/users/cli/tag.txt
+++ b/omero/users/cli/tag.txt
@@ -26,7 +26,7 @@ For both tags and tag sets, the name and description can be passed using the
 :option:`--name` and :option:`--desc` options::
 
 	$ bin/omero tag create --name my_tag --desc 'description of my_tag'
-	$ bin/omero tag createset --tag 1259 1260 tag_id_2 --name my_tag_set --desc 'description of my_tag_set'
+	$ bin/omero tag createset --tag 1259 1260 --name my_tag_set --desc 'description of my_tag_set'
 
 List tags
 ^^^^^^^^^


### PR DESCRIPTION
Minor fixes for the CLI documentation pages in preparation of 5.1.0
- fixes a command typo spotted by @manics 
- lists options for `bin/omero help`

--no-rebase