### PR TITLE
Ignore pyc files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 venv
 .DS_Store
+*.pyc


### PR DESCRIPTION
Related to the failure of https://ci.openmicroscopy.org/job/OMERO-5.1-release/36/. /cc @joshmoore 

Dangling `pyc` files (`omero/conf_autogen.pyc`) broke the `git describe` logic. This commit is making sure these files are ignored.

--no-rebase