### PR TITLE
Web python docs tweaks

### DIFF
--- a/omero/developers/Python.txt
+++ b/omero/developers/Python.txt
@@ -39,11 +39,13 @@ All the code examples below can be found at
 :sourcedir:`examples/Training/python`.
 
 
-Start by downloading the first example below: 
-:source:`examples/Training/python/Connect_To_OMERO.py` and edit the
-USERNAME and PASSWORD variables according to your log-in.
+If you want to run the examples, you will need to download and
+configure them to connect to your own server. E.g. ``HOST = "localhost"``
+You can edit ``HOST, PORT, USERNAME and PASSWORD`` in
+the ``Parse_OMERO_Properties.py`` file and these values will be imported
+into the other scripts.
 
-Then you can run the example:
+Then you can run the scripts:
 
 ::
 
@@ -52,9 +54,8 @@ Then you can run the example:
 If all goes well, you should be connected to your OMERO server and see some
 details of your session printed out.
 
-All the following code examples can be downloaded and run in the same way, and
-they will use the USERNAME and PASSWORD from the file you just edited.
-However, you will need to edit some other parameters, usually IDs from
+All the following code examples can be downloaded and run in the same way.
+Some scripts will also need editing of other parameters, usually IDs from
 Projects, Datasets, Images etc. You can use the OMERO.insight or OMERO.web
 client to choose suitable data IDs before editing and running the code
 samples.
@@ -65,26 +66,6 @@ Code samples
 
 Connect to OMERO
 ^^^^^^^^^^^^^^^^
-
-::
-
-    # These values will be imported by all the other training scripts.
-    HOST = 'localhost'
-    PORT = 4064
-    USERNAME = 'username'
-    PASSWORD = 'passwd' 
-
-::
-
-    from omero.gateway import BlitzGateway 
-
-::
-
-    if __name__ == '__main__':
-        """
-        NB: This block is only run when calling this file directly
-        and not when imported.
-        """ 
 
 ::
 

--- a/omero/developers/Web/CSRF.txt
+++ b/omero/developers/Web/CSRF.txt
@@ -35,8 +35,8 @@ POST, PUT and DELETE. These requests can then be protected as follows:
 
 - On each XMLHttpRequest set a custom X-CSRFToken header to the value of the
   CSRF token and pass the CSRF token in data with every AJAX POST request. If
-  your custom template already benefits from loading built-in
-  :ref:`jQuery <jquery_and_jquery_ui>` template you do not need to do
+  your custom template already benefits from
+  :ref:`loading built-in jQuery <jquery_and_jquery_ui>` template you do not need to do
   anything as it already loads ``webgateway/js/ome.csrf.js``. Otherwise simply
   import the script as follows:
 

--- a/omero/developers/Web/CreateApp.txt
+++ b/omero/developers/Web/CreateApp.txt
@@ -30,7 +30,7 @@ use the correct port number, E.g:
 When you edit and save your app, Django will automatically detect this and you
 only need to refresh your browser to see the changes.
 
-If you want to run OMERO.web from source code, see
+If you want to make changes to the OMERO.web code itself, you should see
 :doc:`/developers/Web/EditingOmeroWeb`.
 
 You can place your app anywhere on your :envvar:`PYTHONPATH`,

--- a/omero/developers/Web/CreateApp.txt
+++ b/omero/developers/Web/CreateApp.txt
@@ -264,6 +264,9 @@ homepage e.g. `<http://localhost:4080/webtest>`_ and you will
 see an introduction to some of them. This page tries to find random
 images and datasets from your OMERO server to use in the webtest examples.
 
+
+.. _jquery_and_jquery_ui:
+
 Using jQuery and jQuery UI from OMERO.web
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/omero/developers/Web/CreateApp.txt
+++ b/omero/developers/Web/CreateApp.txt
@@ -307,13 +307,14 @@ App settings
 ------------
 
 You can add settings to your app that allow configuration via the command line
-in the same way as for the base OMERO.web in omeroweb/settings.py.
-The list of CUSTOM_SETTINGS_MAPPINGS in omeroweb/settings.py code is a good
+in the same way as for the base OMERO.web.
+The list of ``CUSTOM_SETTINGS_MAPPINGS`` in
+:sourcedir:`components/tools/OmeroWeb/omeroweb/settings.py` is a good
 source for examples of the different data types and parsers you can use.
 
 For example, if you want to create a user-defined setting yourapp.foo,
 that contains a dictionary of key-value pairs, you can add to
-CUSTOM_SETTINGS_MAPPINGS in yourapp/settings.py:
+``CUSTOM_SETTINGS_MAPPINGS`` in ``yourapp/settings.py``:
 
 ::
 

--- a/omero/developers/Web/WritingTemplates.txt
+++ b/omero/developers/Web/WritingTemplates.txt
@@ -212,23 +212,3 @@ extent it (see above). In addition, they also add the following blocks:
 See 
 :source:`container3.html <components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/base/container3.html>` 
 for full template details.
-
-.. _jquery_and_jquery_ui:
-
-jQuery and jQuery UI
-^^^^^^^^^^^^^^^^^^^^
-
-If your application requires jQuery or jQuery UI libraries you can include
-them from internal resources by the following:
-
-::
-
-    {% include "webgateway/base/includes/script_src_jquery.html" %}
-    {% include "webgateway/base/includes/jquery-ui.html" %}
-
-
-.. note::
-
-    If your template extends
-    :source:`base_main.html <components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/base/base_main.html>`
-    both libraries are already there.

--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -254,8 +254,8 @@ If necessary ensure you have set up a regular task to clear out any stale
 OMERO.web session files as described in :ref:`unix_omero_web_maintenance`.
 
 
-Restart your database
-^^^^^^^^^^^^^^^^^^^^^
+Restart your server
+^^^^^^^^^^^^^^^^^^^
 
 -  Following a successful database upgrade, you can start the server.
 


### PR DESCRIPTION
Some minor docs tweaks from reading through docs (Web & Python mostly).

Biggest change is to the instructions for running Python code samples, following @sbesson's config changes. Other changes are just minor fixes.

--no-rebase
