### PR TITLE
Add paragraph about memo file invalidation post-upgrade

### DIFF
--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -70,8 +70,8 @@ Memoization files invalidation
 All cached Bio-Formats memoization files created at import time will be
 invalidated by the server upgrade. This means the very first loading of each
 image after upgrade will be slower. After re-initialization, a new memoization
-file will be created and OMERO will be able to load images in a performant
-manner again.
+file will be automatically generated and OMERO will be able to load images in
+a performant manner again.
 
 Troubleshooting
 ^^^^^^^^^^^^^^^

--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -64,6 +64,15 @@ reason, it is possible that an update of OMERO will cause issues with an older
 version of a plugin. It is best when updating the server to also install any
 available plugin updates according to their own documentation.
 
+Memoization files invalidation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+All cached Bio-Formats memoization files created at import time will be
+invalidated by the server upgrade. This means the very first loading of each
+image after upgrade will be slower. After re-initialization, a new memoization
+file will be created and OMERO will be able to load images in a performant
+manner again.
+
 Troubleshooting
 ^^^^^^^^^^^^^^^
 
@@ -146,7 +155,7 @@ script aborts with a message warning how the "OMERO database character
 encoding must be UTF8". From :command:`psql`::
 
   # SELECT datname, pg_encoding_to_char(encoding) FROM pg_database;
-    datname   | pg_encoding_to_char 
+    datname   | pg_encoding_to_char
   ------------+---------------------
    template1  | UTF8
    template0  | UTF8


### PR DESCRIPTION
This notice should warn sysadmins of the memo file invalidation/re-generation post upgrade as noticed by @dominikl during testing. 

--no-rebase