### PR TITLE
Update auto-generated documentation

### DIFF
--- a/omero/downloads/inplace/advanced-help.txt
+++ b/omero/downloads/inplace/advanced-help.txt
@@ -83,7 +83,7 @@ ADVANCED OPTIONS:
   ---------
 
     --qa-baseurl=ARG	Specify the base URL for reporting feedback
-  e.g. $ bin/omero import -- --qa-baseurl=https://qa.staging.openmicroscopy.org/qa
-       $ ./importer-cli --qa-baseurl=https://qa.staging.openmicroscopy.org/qa
+  e.g. $ bin/omero import broken_image.tif -- --email EMAIL --report --upload --logs --qa-baseurl=https://qa.staging.openmicroscopy.org/qa
+       $ ./importer-cli broken_image.tif --email EMAIL --report --upload --logs --qa-baseurl=https://qa.staging.openmicroscopy.org/qa
 
 Report bugs to <ome-users@lists.openmicroscopy.org.uk>

--- a/omero/sysadmins/unix/apache-fcgi-omero.conf
+++ b/omero/sysadmins/unix/apache-fcgi-omero.conf
@@ -6,7 +6,7 @@
 #  OmeroForceSSL - redirect all http requests to https
 
 ###
-### Example SSL stanza for OMERO.web created 2015-03-25 21:34:30.971682
+### Example SSL stanza for OMERO.web created 2015-03-31 16:22:30.166216
 ###
 
 # Eliminate overlap warnings with the default ssl vhost
@@ -49,7 +49,7 @@
 #</VirtualHost>
 
 ###
-### Stanza for OMERO.web created 2015-03-25 21:34:30.971682
+### Stanza for OMERO.web created 2015-03-31 16:22:30.166216
 ###
 
 RewriteEngine on

--- a/omero/sysadmins/unix/apache-omero.conf
+++ b/omero/sysadmins/unix/apache-omero.conf
@@ -8,7 +8,7 @@
 #  OmeroForceSSL - redirect all http requests to https
 
 ###
-### Example SSL stanza for OMERO.web created 2015-03-25 21:34:28.615238
+### Example SSL stanza for OMERO.web created 2015-03-31 16:22:27.752042
 ###
 
 # Eliminate overlap warnings with the default ssl vhost
@@ -51,7 +51,7 @@
 #</VirtualHost>
 
 ###
-### Stanza for OMERO.web created 2015-03-25 21:34:28.615238
+### Stanza for OMERO.web created 2015-03-31 16:22:27.752042
 ###
 
 FastCGIExternalServer "/home/omero/OMERO.server/var/omero.fcgi" -host 127.0.0.1:4080 -idle-timeout 60

--- a/omero/users/history.txt
+++ b/omero/users/history.txt
@@ -1,6 +1,41 @@
 OMERO version history
 =====================
 
+5.1.0 (April 2015)
+------------------
+
+A full, production-ready release of OMERO 5.1.0; updating the Data Model to
+the January 2015 schema, including support for units and new more
+flexible user-added metadata; and introducing new user features, new supported
+formats and many fixes and performance improvements:
+
+-  support for units throughout the Data Model allowing for example, pixel
+   sizes for electron microscopy to be stored in nanometers rather than being
+   set as micrometers
+-  new, searchable key-value pairs annotations for adding experimental
+   metadata (replacing OMERO.editor, which has been removed)
+-  improved workflow for rendering settings in the UI and parity between the
+   clients
+-  import images to OMERO from ImageJ and save ROIs and overlays from ImageJ
+   to OMERO
+-  importing as another user, previously only available for administrators, is
+   now usable by group owners as well, allowing you to import data that will
+   then be owned by the user you import it for
+-  improved performance for moving and deleting data
+-  removed the auto-levels calculation for initial rendering settings to
+   substantially speed up performance, by using the min/max pixel intensities,
+   or defaulting to full pixel range where min/max is unavailable
+-  import times are much improved for large datasets such as HCS and SPIM data
+-  improved performance for many file formats and new supported formats via
+   Bio-Formats (now over 140)
+-  new OMERO.mail feature lets admins configure the server to email users
+-  support for configuring the server download policy to control access to
+   original file download for public-facing OMERO.web deployments
+-  many developer updates such as removal of deprecated methods, and updates
+   to OMERO.web and the C++ implementation (see the 5.1.0-m1 to 5.1.0-m5
+   developer preview release details below and the 'What's New' for developers
+   page)
+
 5.1.0-m5 (March 2015)
 ---------------------
 


### PR DESCRIPTION
Repository: openmicroscopy/ome-documentation
Already up-to-date.



Generated by build [OMERO-5.1-latest-docs-autogen#534](https://ci.openmicroscopy.org/job/OMERO-5.1-latest-docs-autogen/534/).

----
--no-rebase