### PR TITLE
Add note about optionally deleting BioFormatsCache files

### DIFF
--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -73,6 +73,11 @@ image after upgrade will be slower. After re-initialization, a new memoization
 file will be automatically generated and OMERO will be able to load images in
 a performant manner again.
 
+These files are stored under ``BioFormatsCache`` in the OMERO data directory,
+e.g. ``/OMERO/BioFormatsCache``. You may see error messages in your log files
+when an old memoization file is found, to avoid these messages delete
+everything under this directory before starting the upgraded server.
+
 Troubleshooting
 ^^^^^^^^^^^^^^^
 

--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -75,7 +75,7 @@ a performant manner again.
 
 These files are stored under :file:`BioFormatsCache` in the OMERO data
 directory, e.g. :file:`/OMERO/BioFormatsCache`. You may see error messages in
-your log files when an old memoization file is found, to avoid these messages
+your log files when an old memoization file is found; to avoid these messages
 delete everything under this directory before starting the upgraded server.
 
 Troubleshooting

--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -73,10 +73,10 @@ image after upgrade will be slower. After re-initialization, a new memoization
 file will be automatically generated and OMERO will be able to load images in
 a performant manner again.
 
-These files are stored under ``BioFormatsCache`` in the OMERO data directory,
-e.g. ``/OMERO/BioFormatsCache``. You may see error messages in your log files
-when an old memoization file is found, to avoid these messages delete
-everything under this directory before starting the upgraded server.
+These files are stored under :file:`BioFormatsCache` in the OMERO data
+directory, e.g. :file:`/OMERO/BioFormatsCache`. You may see error messages in
+your log files when an old memoization file is found, to avoid these messages
+delete everything under this directory before starting the upgraded server.
 
 Troubleshooting
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
Following a 5.1 upgrade the Blitz log may have loads of ERRORs message about old memoization files. One way around this is to delete the BioFormatsCache directory.

--no-rebase