### PR TITLE
Document new OMERO_SESSIONDIR environment variable

### DIFF
--- a/omero/users/cli/sessions.txt
+++ b/omero/users/cli/sessions.txt
@@ -125,12 +125,13 @@ The location of the current session file can be retrieved using the
     /Users/ome/omero/sessions/localhost/root/aec828e1-79bf-41f3-91e6-a4ac76ff1cd5
 
 If you want to use a custom session directory, use the
-:envvar:`OMERO_SESSION_DIR` environment variable::
+:envvar:`OMERO_SESSIONDIR` environment variable::
 
-    $ export OMERO_SESSION_DIR=/tmp
-    $ bin/omero login
+    $ export OMERO_SESSIONDIR=/tmp/my_sessions
+    $ bin/omero login root@localhost:4064 -w omero
+    Created session bf7b9fee-5e3f-40fa-94a6-1e23ceb43dbd (root@localhost:4064). Idle timeout: 10.0 min. Current group: system
     $ bin/omero sessions file
-    /tmp/omero/sessions/localhost/root/aec828e1-79bf-41f3-91e6-a4ac76ff1cd5
+    /tmp/my_sessions/localhost/root/bf7b9fee-5e3f-40fa-94a6-1e23ceb43dbd
     $ bin/omero logout
 
 Switching current group

--- a/omero/users/cli/sessions.txt
+++ b/omero/users/cli/sessions.txt
@@ -134,6 +134,21 @@ If you want to use a custom session directory, use the
     /tmp/my_sessions/localhost/root/bf7b9fee-5e3f-40fa-94a6-1e23ceb43dbd
     $ bin/omero logout
 
+.. note::
+    The :envvar:`OMERO_SESSION_DIR` environment variable introduced in 5.1.0
+    to specify a custom sessions directory is deprecated in 5.1.1 and above in
+    favor of :envvar:`OMERO_SESSIONDIR`.
+
+    If you have been using :envvar:`OMERO_SESSION_DIR` and want to upgrade
+    your custom sessions directory without losing locally stored sessions:
+
+    - either set :envvar:`OMERO_SESSIONDIR` to point at the same location as
+      :file:`OMERO_SESSION_DIR/omero/sessions`
+    - or move all local sessions stored under the
+      :file:`OMERO_SESSION_DIR/omero/sessions` directory
+      under the :file:`OMERO_SESSION_DIR` directory and
+      replace :envvar:`OMERO_SESSION_DIR` by :envvar:`OMERO_SESSIONDIR`.
+
 Switching current group
 ^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
This should replace the deprecated OMERO_SESSION_DIR envvar
Documents code changes in https://github.com/openmicroscopy/openmicroscopy/pull/3742