### PR TITLE
Contributing cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ env:
   - SPHINXOPTS="-W" CLASSPATH="/usr/share/java/ant-contrib.jar"
 
 before_install:
-  - travis_retry sudo apt-get -y -f install graphviz
   - sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ trusty main universe"
   - travis_retry sudo apt-get update
   - travis_retry sudo apt-get -y install ant ant-contrib ant-optional

--- a/README.rst
+++ b/README.rst
@@ -62,13 +62,6 @@ To add the MacTeX fonts system-wide:
 * Navigate to ``/usr/local/texlive/2013/texmf-dist/fonts/opentype/public/tex-gyre``
   and click ``Open``. (Type ``/usr/local`` to get there initially.)
 
-Graphviz
---------
-
-The Contributing documentation now requires you to install
-`Graphviz <http://www.graphviz.org/Home.php>`_ to build the
-diagrams.
-
 Structure and organization
 ==========================
 

--- a/contributing/ci-bio-formats.txt
+++ b/contributing/ci-bio-formats.txt
@@ -6,47 +6,47 @@ All jobs are listed under the :jenkinsview:`Bio-Formats` view tab of Jenkins.
 .. list-table::
 	:header-rows: 1
 
-	- 	* Job task
+	-	* Job task
 		* 5.0.x series
 		* 5.1.x series
 
-	- 	* Builds the latest Bio-Formats artifacts
+	-	* Builds the latest Bio-Formats artifacts
 		* :term:`BIOFORMATS-5.0-latest`
 		* :term:`BIOFORMATS-5.1-latest`
 
-	- 	* Publishes the latest Bio-Formats to the OME artifactory
+	-	* Publishes the latest Bio-Formats to the OME artifactory
 		* :term:`BIOFORMATS-5.0-latest-maven`
 		* :term:`BIOFORMATS-5.1-latest-maven`
 
-	- 	* Builds the latest native C++ implementation for Bio-Formats
+	-	* Builds the latest native C++ implementation for Bio-Formats
 		*
 		* :term:`BIOFORMATS-5.1-latest-cpp`
 
-	- 	* Runs the daily Bio-Formats merge jobs
+	-	* Runs the daily Bio-Formats merge jobs
 		* :term:`BIOFORMATS-5.0-merge-daily`
 		* :term:`BIOFORMATS-5.1-merge-daily`
 
-	- 	* Builds the merge Bio-Formats artifacts
+	-	* Builds the merge Bio-Formats artifacts
 		* :term:`BIOFORMATS-5.0-merge-build`
 		* :term:`BIOFORMATS-5.1-merge-build`
 
-	- 	* Builds the merge native C++ implementation for Bio-Formats
+	-	* Builds the merge native C++ implementation for Bio-Formats
 		*
 		* :term:`BIOFORMATS-5.1-merge-cpp`
 
-	- 	* Runs the MATLAB tests
+	-	* Runs the MATLAB tests
 		* :term:`BIOFORMATS-5.0-merge-matlab`
 		* :term:`BIOFORMATS-5.1-merge-matlab`
 
-	- 	* Runs automated tests against the full repository on squig
+	-	* Runs automated tests against the full repository on squig
 		* :term:`BIOFORMATS-5.0-merge-full-repository`
 		* :term:`BIOFORMATS-5.1-merge-full-repository`
 
-	- 	* Runs automated tests against test_images_good on squig
+	-	* Runs automated tests against test_images_good on squig
 		* :term:`BIOFORMATS-5.0-merge-test_images_good`
 		* :term:`BIOFORMATS-5.1-merge-test_images_good`
 
-	- 	* Runs openBytes performance test
+	-	* Runs openBytes performance test
 		* :term:`BIOFORMATS-5.0-merge-openbytes-performance`
 		* :term:`BIOFORMATS-5.1-merge-openbytes-performance`
 
@@ -82,7 +82,7 @@ The branch for the 5.0.x series of Bio-Formats is dev_5_0.
 		   :term:`BIOFORMATS-5.0-merge-test_images_good` and
 		   BIOFORMATS-5.0-merge-performance
 
-        See :jenkinsjob:`the build graph <BIOFORMATS-5.0-merge-daily/lastSuccessfulBuild/BuildGraph>`
+		See :jenkinsjob:`the build graph <BIOFORMATS-5.0-merge-daily/lastSuccessfulBuild/BuildGraph>`
 
 	:jenkinsjob:`BIOFORMATS-5.0-merge-build`
 
@@ -166,7 +166,7 @@ The branch for the 5.1.x series of Bio-Formats is develop.
 		   :term:`BIOFORMATS-5.1-merge-test_images_good` and
 		   BIOFORMATS-5.1-merge-performance
 
-        See :jenkinsjob:`the build graph <BIOFORMATS-5.1-merge-daily/lastSuccessfulBuild/BuildGraph>`
+		See :jenkinsjob:`the build graph <BIOFORMATS-5.1-merge-daily/lastSuccessfulBuild/BuildGraph>`
 
 	:jenkinsjob:`BIOFORMATS-5.1-merge-build`
 

--- a/contributing/ci-bio-formats.txt
+++ b/contributing/ci-bio-formats.txt
@@ -50,92 +50,8 @@ All jobs are listed under the :jenkinsview:`Bio-Formats` view tab of Jenkins.
 		* :term:`BIOFORMATS-5.0-merge-openbytes-performance`
 		* :term:`BIOFORMATS-5.1-merge-openbytes-performance`
 
-4.4.x series
-^^^^^^^^^^^^
-
-.. digraph:: BIOFORMATS44latest
-
-   "BIOFORMATS-4.4-latest" -> "BIOFORMATS-4.4-latest-maven";
-
-   "BIOFORMATS-4.4-merge-daily" -> "BIOFORMATS-4.4-merge-docs";
-   "BIOFORMATS-4.4-merge-daily" -> "BIOFORMATS-4.4-merge-matlab";
-
-The branch for the 4.4.x series of Bio-Formats is dev_4_4.
-
-.. glossary::
-
-	:jenkinsjob:`BIOFORMATS-4.4-latest`
-
-		This job builds the dev_4_4 branch of Bio-Formats
-
-		#. |buildBF|
-		#. |testBF|
-
-	:jenkinsjob:`BIOFORMATS-4.4-latest-maven`
-
-		This job publishes the dev_4_4 branch of Bio-Formats to the LOCI Nexus
-		repository
-
-	:jenkinsjob:`BIOFORMATS-4.4-merge-daily`
-
-		This job merges the PRs opened against the dev_4_4 branch of
-		Bio-Formats by running basic unit tests, checking for open file
-		handles, and checking for regressions across a representative
-		subset of the data repository
-
-		#. |merge|
-		#. |buildBF|
-		#. |fulltestBF|
-
-	:jenkinsjob:`BIOFORMATS-4.4-merge-matlab`
-
-		This job runs the MATLAB tests of Bio-Formats
-
-		#. Collects the MATLAB artifacts and unit tests from
-		   :term:`BIOFORMATS-4.4-merge-daily`
-		#. Runs the MATLAB unit tests under
-		   :file:`components/bio-formats/test/matlab` and collect the results
-
-	:jenkinsjob:`BIOFORMATS-4.4-merge-full-repository`
-
-		This job is runs the automated tests against the full repository on
-		squig
-
-		#. |merge|
-		#. Runs tests against directories configured by
-		   ``--test dirname`` under :file:`/ome/data_repo/from_skyking/`
-
-	:jenkinsjob:`BIOFORMATS-4.4-merge-omero-openbytes`
-
-		This job runs OMERO openBytes tests against directories on squig
-
-		#. |merge|
-		#. Runs ``loci.tests.testng.OmeroOpenBytesTest`` tests against
-		   directories specified by :file:`BIOFORMATS-omero-openbytes.txt`
-
-	:jenkinsjob:`BIOFORMATS-4.4-merge-openbytes-performance`
-
-		This job runs openBytes performance tests against directories on squig
-
-		#. |merge|
-		#. Runs ``loci.tests.testng.OpenBytesPerformanceTest`` tests against
-		   directories specified by
-		   :file:`BIOFORMATS-openbytes-performance.txt`
-
 5.0.x series
 ^^^^^^^^^^^^
-
-.. digraph:: BIOFORMATS50latest
-
-   "BIOFORMATS-5.0-latest" -> "BIOFORMATS-5.0-latest-maven" -> "BIOFORMATS-5.0-latest-cppwrap";
-   "BIOFORMATS-5.0-latest" -> "BIOFORMATS-5.0-latest-docs-autogen";
-
-   "BIOFORMATS-5.0-merge-daily" -> "OME-5.0-merge-push";
-   "OME-5.0-merge-push" -> "BIOFORMATS-5.0-merge-build";
-   "OME-5.0-merge-push" -> "BIOFORMATS-5.0-merge-docs";
-   "OME-5.0-merge-push" -> "BIOFORMATS-5.0-merge-test_images_good";
-   "OME-5.0-merge-push" -> "BIOFORMATS-5.0-merge-performance";
-   "BIOFORMATS-5.0-merge-build" -> "BIOFORMATS-5.0-merge-matlab";
 
 The branch for the 5.0.x series of Bio-Formats is dev_5_0.
 
@@ -165,6 +81,8 @@ The branch for the 5.0.x series of Bio-Formats is dev_5_0.
 		   :term:`BIOFORMATS-5.0-merge-docs`,
 		   :term:`BIOFORMATS-5.0-merge-test_images_good` and
 		   BIOFORMATS-5.0-merge-performance
+
+        See :jenkinsjob:`the build graph <BIOFORMATS-5.0-merge-daily/lastSuccessfulBuild/BuildGraph>`
 
 	:jenkinsjob:`BIOFORMATS-5.0-merge-build`
 
@@ -214,22 +132,6 @@ The branch for the 5.0.x series of Bio-Formats is dev_5_0.
 5.1.x series
 ^^^^^^^^^^^^
 
-.. digraph:: BIOFORMATS51latest
-
-   "BIOFORMATS-5.1-latest" -> "BIOFORMATS-5.1-latest-maven" -> "BIOFORMATS-5.1-latest-cppwrap";
-   "BIOFORMATS-5.1-latest" -> "BIOFORMATS-5.1-latest-cpp";
-   "BIOFORMATS-5.1-latest" -> "BIOFORMATS-5.1-latest-docs-autogen";
-
-.. digraph:: BIOFORMATS51mergedaily
-
-   "BIOFORMATS-5.1-merge-daily" -> "OME-5.1-merge-push";
-   "OME-5.1-merge-push" -> "BIOFORMATS-5.1-merge-build";
-   "OME-5.1-merge-push" -> "BIOFORMATS-5.1-merge-cpp";
-   "OME-5.1-merge-push" -> "BIOFORMATS-5.1-merge-docs";
-   "OME-5.1-merge-push" -> "BIOFORMATS-5.1-merge-test_images_good";
-   "OME-5.1-merge-push" -> "BIOFORMATS-5.1-merge-performance";
-   "BIOFORMATS-5.1-merge-build" -> "BIOFORMATS-5.1-merge-matlab";
-
 The branch for the 5.1.x series of Bio-Formats is develop.
 
 .. glossary::
@@ -263,6 +165,8 @@ The branch for the 5.1.x series of Bio-Formats is develop.
 		   :term:`BIOFORMATS-5.1-merge-docs`,
 		   :term:`BIOFORMATS-5.1-merge-test_images_good` and
 		   BIOFORMATS-5.1-merge-performance
+
+        See :jenkinsjob:`the build graph <BIOFORMATS-5.1-merge-daily/lastSuccessfulBuild/BuildGraph>`
 
 	:jenkinsjob:`BIOFORMATS-5.1-merge-build`
 

--- a/contributing/ci-consortium.txt
+++ b/contributing/ci-consortium.txt
@@ -8,11 +8,11 @@ Jenkins.
 .. list-table::
 	:header-rows: 1
 
-	- 	* Partner project
+	-	* Partner project
 		* Latest jobs
 		* Release jobs
 
-	- 	* FLIMfit
+	-	* FLIMfit
 		* | :term:`FLIMfit-latest-mac`
 		  | :term:`FLIMfit-latest-win`
 		* | :term:`FLIMfit-release`
@@ -20,19 +20,19 @@ Jenkins.
 		  | :term:`FLIMfit-release-win`
 		  | :term:`FLIMfit-release-downloads`
 
-	- 	* OMERO.figure
+	-	* OMERO.figure
 		*
 		* :term:`FIGURE-release-downloads`
 
-	- 	* OMERO.mtools
+	-	* OMERO.mtools
 		*
 		* :term:`MTOOLS-release-downloads`
 
-	- 	* OMERO.webtagging
+	-	* OMERO.webtagging
 		*
 		* :term:`WEBTAGGING-release-downloads`
 
-	- 	* u-track
+	-	* u-track
 		* | :term:`U-TRACK-latest`
 		* | :term:`U-TRACK-release`
 		  | :term:`U-TRACK-release-downloads`
@@ -70,8 +70,8 @@ https://github.com/openmicroscopy/Imperial-FLIMfit
 		#. Trigger :term:`FLIMfit-release-mac` and
 		   :term:`FLIMfit-release-win`
 		#. Upon completion, trigger :term:`FLIMfit-release-downloads`
-        
-        See :jenkinsjob:`the build graph <FLIMfit-release/lastSuccessfulBuild/BuildGraph>`
+		
+		See :jenkinsjob:`the build graph <FLIMfit-release/lastSuccessfulBuild/BuildGraph>`
 
 	:jenkinsjob:`FLIMfit-release-mac`
 

--- a/contributing/ci-consortium.txt
+++ b/contributing/ci-consortium.txt
@@ -70,7 +70,7 @@ https://github.com/openmicroscopy/Imperial-FLIMfit
 		#. Trigger :term:`FLIMfit-release-mac` and
 		   :term:`FLIMfit-release-win`
 		#. Upon completion, trigger :term:`FLIMfit-release-downloads`
-
+        
         See :jenkinsjob:`the build graph <FLIMfit-release/lastSuccessfulBuild/BuildGraph>`
 
 	:jenkinsjob:`FLIMfit-release-mac`

--- a/contributing/ci-consortium.txt
+++ b/contributing/ci-consortium.txt
@@ -43,15 +43,6 @@ FLIMfit
 The source code for the FLIMfit is hosted under
 https://github.com/openmicroscopy/Imperial-FLIMfit
 
-.. digraph:: FLIMfit
-
-   "FLIMfit-latest-mac" -> "FLIMfit-latest-win";
-
-   "FLIMfit-release" -> "FLIMfit-release-mac";
-   "FLIMfit-release" -> "FLIMfit-release-win";
-   "FLIMfit-release-mac" -> "FLIMfit-release-downloads";
-   "FLIMfit-release-win" -> "FLIMfit-release-downloads";
-
 .. glossary::
 
 	:jenkinsjob:`FLIMfit-latest-mac`
@@ -79,6 +70,8 @@ https://github.com/openmicroscopy/Imperial-FLIMfit
 		#. Trigger :term:`FLIMfit-release-mac` and
 		   :term:`FLIMfit-release-win`
 		#. Upon completion, trigger :term:`FLIMfit-release-downloads`
+
+        See :jenkinsjob:`the build graph <FLIMfit-release/lastSuccessfulBuild/BuildGraph>`
 
 	:jenkinsjob:`FLIMfit-release-mac`
 

--- a/contributing/ci-docs.txt
+++ b/contributing/ci-docs.txt
@@ -8,48 +8,39 @@ tab of Jenkins.
 	:header-rows: 1
 
 	- 	* Job task
-		* 4.4.x series
 		* 5.0.x series
 		* 5.1.x series
 
 	- 	* Builds the OMERO documentation for publishing
-		* :term:`OMERO-4.4-release-docs`
 		* :term:`OMERO-5.0-release-docs`
 		* :term:`OMERO-5.1-release-docs`
 
 	- 	* Builds the Bio-Formats documentation for publishing
-		* :term:`BIOFORMATS-4.4-release-docs`
 		* :term:`BIOFORMATS-5.0-release-docs`
 		* :term:`BIOFORMATS-5.1-release-docs`
 
 	- 	* Builds the OMERO documentation for review
-		* :term:`OMERO-4.4-merge-docs`
 		* :term:`OMERO-5.0-merge-docs`
 		* :term:`OMERO-5.1-merge-docs`
 
 
 	- 	* Builds the Bio-Formats documentation for review
-		* :term:`BIOFORMATS-4.4-merge-docs`
 		* :term:`BIOFORMATS-5.0-merge-docs`
 		* :term:`BIOFORMATS-5.1-merge-docs`
 
 	- 	* Builds the auto-generated OMERO documentation
-		*
 		* :term:`OMERO-5.0-latest-docs-autogen`
 		* :term:`OMERO-5.1-latest-docs-autogen`
 
 	- 	* Builds the auto-generated OMERO documentation for review
-		*
 		* :term:`OMERO-5.0-merge-docs-autogen`
 		* :term:`OMERO-5.1-merge-docs-autogen`
 
 	- 	* Builds the auto-generated Bio-Formats documentation
-		*
 		* :term:`BIOFORMATS-5.0-latest-docs-autogen`
 		* :term:`BIOFORMATS-5.1-latest-docs-autogen`
 
 	- 	* Builds the auto-generated OMERO documentation for review
-		*
 		* :term:`BIOFORMATS-5.0-merge-docs-autogen`
 		* :term:`BIOFORMATS-5.1-merge-docs-autogen`
 
@@ -105,59 +96,6 @@ necromancer.openmicroscopy.org.uk under the
 :file:`/var/www/www.openmicroscopy.org/sphinx-docs` directory using the
 :program:`scc deploy` command. The :jenkinsjob:`OME-docs-deployment-setup` job
 is used to initialize new deployment folders.
-
-4.4.x series
-^^^^^^^^^^^^
-
-The branch for the 4.4.x series of the OMERO/Bio-Formats documentation is dev_4_4.
-
-.. glossary::
-
-	:jenkinsjob:`OMERO-4.4-release-docs`
-
-		This job is used to build the dev_4_4 of the OMERO documentation
-		and publish the official documentation for the current release of
-		OMERO
-
-		#. |sphinxbuild|
-		#. |linkcheck|
-		#. If the build is promoted,
-			#. |ssh-doc| :file:`omero-stable-release.tmp`
-			#. |deploy-doc| http://www.openmicroscopy.org/site/support/omero4/
-
-	:jenkinsjob:`BIOFORMATS-4.4-release-docs`
-
-		This job is used to build the dev_4_4 of the Bio-Formats
-		documentation and publish the official documentation for the current
-		release of Bio-Formats
-
-		#. |sphinxbuild|
-		#. |linkcheck|
-		#. If the build is promoted,
-			#. |ssh-doc| :file:`bf-stable-release.tmp`
-			#. |deploy-doc| http://www.openmicroscopy.org/site/support/bio-formats4/
-
-	:jenkinsjob:`OMERO-4.4-merge-docs`
-
-		This job is used to review the PRs opened against the dev_4_4
-		branch of the OMERO documentation
-
-		#. |merge|
-		#. |sphinxbuild|
-		#. |linkcheck|
-		#. |ssh-doc| :file:`omero-stable-staging.tmp`
-		#. |deploy-doc| http://www.openmicroscopy.org/site/support/omero4-staging/
-
-	:jenkinsjob:`BIOFORMATS-4.4-merge-docs`
-
-		This job is used to review the PRs opened against the dev_4_4
-		branch of the Bio-Formats documentation
-
-		#. |merge|
-		#. |sphinxbuild|
-		#. |linkcheck|
-		#. |ssh-doc| :file:`bf-stable-staging.tmp`
-		#. |deploy-doc| http://www.openmicroscopy.org/site/support/bio-formats4-staging/
 
 5.0.x series
 ^^^^^^^^^^^^

--- a/contributing/ci-introduction.txt
+++ b/contributing/ci-introduction.txt
@@ -29,12 +29,6 @@ Most of the OME code is split between four repositories: openmicroscopy.git_,
 bioformats.git_, scripts.git_, ome-documentation.git_. Each repository
 contains several development branches associated with development series:
 
-* The "dev_4_4" branch contains work on the 4.4.x series.
-
-  .. note::
-    This branch has now entered maintenance mode and should only be updated
-    for major bug fixes.
-
 * The "dev_5_0" branch contains work on the 5.0.x series.
 
 * The "develop" branch contains work on the 5.1.x series.
@@ -48,9 +42,6 @@ Labels
 ^^^^^^
 
 Labels are applied to PRs on GitHub under the “Issues” tab of each repository.
-
-The 4.4.x series consists of PRs labeled with “dev_4_4”, which
-is the name of the branch which they will be merged into.
 
 The 5.0.x series consists of PRs labeled with “dev_5_0”, which is also
 the name of the branch which they will be merged into.

--- a/contributing/ci-omero.txt
+++ b/contributing/ci-omero.txt
@@ -23,7 +23,7 @@ OMERO jobs
 
 	- 	* Updates submodules
 		* :term:`OMERO-5.0-latest-submods`
-		* :term:`OMERO-5.0-latest-submods`
+		* :term:`OMERO-5.1-latest-submods`
 		*
 
 	- 	* Runs the daily OMERO merge builds
@@ -82,7 +82,7 @@ OMERO jobs
 
 	- 	* Installs OMERO using Homebrew
 		* :term:`OME-5.0-merge-homebrew`
-		*
+		* :term:`OME-5.1-merge-homebrew`
 		*
 
 	- 	* Push SNAPSHOTS to Maven
@@ -176,306 +176,170 @@ clients of the deployment jobs described above:
 		* 34064
 		* https://trout.openmicroscopy.org/breaking
 
-4.4.x series
-^^^^^^^^^^^^
-
-The branch for the 4.4.x series of OMERO is dev_4_4. All jobs
-are listed under the :jenkinsview:`4.4` view tab of Jenkins.
-
-.. glossary::
-
-	:jenkinsjob:`OMERO-4.4-latest-ice33`
-	:jenkinsjob:`OMERO-4.4-latest-ice34`
-	:jenkinsjob:`OMERO-4.4-latest-ice35`
-
-		These jobs build the dev_4_4 branch of OMERO with Ice 3.3, 3.4 or 3.5
-
-		#. |buildOMERO|
-		#. |archiveOMEROartifacts|
-		#. If the build is promoted, |promoteOMERO|
-
-	:jenkinsjob:`OMERO-4.4-latest-virtualbox`
-
-		This job builds a Virtual Appliance from the dev_4_4 branch of OMERO
-
-		#. |buildVM|
-
-	:jenkinsjob:`OMERO-4.4-merge-daily`
-
-		This job is used to review the PRs opened against the dev_4_4
-		branch of OMERO with Ice 3.3
-
-		#. |merge| and pushes the merged branch to
-		   snoopycrimecop/merge/dev_4_4/latest
-		#. |buildOMERO|
-		#. |archiveOMEROartifacts|
-		#. deploys the merge server on port 4064 of howe.openmicroscopy.org.uk
-
-	:jenkinsjob:`OMERO-4.4-merge-ice33`
-	:jenkinsjob:`OMERO-4.4-merge-ice34`
-	:jenkinsjob:`OMERO-4.4-merge-ice35`
-
-		These jobs build the OMERO components with Ice 3.3, 3.4 or 3.5
-
-		#. Checks out the merge/dev_4_4/latest branch of the
-		   snoopycrimecop fork of openmicroscopy.git_
-		#. |buildOMERO|
-		#. |archiveOMEROartifacts|
-
-	:jenkinsjob:`OMERO-4.4-merge-virtualbox`
-
-		This job builds a Virtual Appliance of OMERO
-
-		#. Checks out the merge/dev_4_4/latest branch of the
-		   snoopycrimecop fork of openmicroscopy.git_
-		#. |buildVM|
-
-	:jenkinsjob:`OMERO-4.4-merge-integration`
-
-		This job runs the integration tests of OMERO
-
-		#. |merge|
-		#. Builds OMERO.server and starts it
-		#. Runs the integration tests and collect the results (Java and
-		   Python)
-
-	:jenkinsjob:`OMERO-4.4-merge-integration-java`
-
-		This job collects the OmeroJava integration test results
-
-		#. Receives TestNG results from :term:`OMERO-4.4-merge-integration`,
-		#. Generates TestNG report
-
-	:jenkinsjob:`OMERO-4.4-merge-integration-python`
-
-		This job collects the OmeroPy integration test results
-
-		#. Receives pytest results from :term:`OMERO-4.4-merge-integration`,
-		#. Generates pytest report
-
-	:jenkinsjob:`OMERO-4.4-merge-integration-broken`
-
-		This job collects the OmeroJava integration test results
-
-		#. Receives TestNG results from :term:`OMERO-4.4-merge-integration`,
-		#. Generates TestNG report
-
-	:jenkinsjob:`OMERO-4.4-merge-robotframework`
-
-		This job runs the robot framework of OMERO
-
-		#. Checks out the merge/dev_4_4/latest branch of the
-		   snoopycrimecop fork of openmicroscopy.git_
-		#. Builds OMERO.server and starts it
-		#. Runs the robot framework tests and collect the results
-
-	:jenkinsjob:`OMERO-4.4-merge-matlab`
-
-		This job runs the OMERO.matlab tests
-
-		#. Checks out the merge/dev_4_4/latest branch of the
-		   snoopycrimecop fork of openmicroscopy.git_
-		#. Collects the MATLAB artifacts from :term:`OMERO-4.4-merge-daily`
-		#. Run the MATLAB unit tests under
-		   :file:`components/tools/OmeroM/test/unit` and collect the results
-
-	:jenkinsjob:`OMERO-4.4-latest-submods`
-
-		This job updates the submodules on the dev_4_4 branch
-
-		#. |updatesubmodules| and pushes the merged branch to
-		   snoopycrimecop/dev_4_4/latest/submodules
-		#. If the submodules are updated, opens a new PR or updates the
-		   existing dev_4_4 submodules PR
-
-	:jenkinsjob:`OME-4.4-merge-homebrew`
-
-		This job tests the installation of OMERO 4.4 using Homebrew
-
-		#. Cleans :file:`/usr/local`
-		#. Installs Homebrew
-		#. Runs :file:`docs/install/OMERO-homebrew-install.sh`
-
 5.0.x series
 ^^^^^^^^^^^^
 
 The branch for the 5.0.x series of OMERO is dev_5_0. All jobs are listed
 under the :jenkinsview:`5.0` view tab of Jenkins.
 
-.. digraph:: OMERO50jobs
-
-  "OMERO-5.0-latest" -> "OMERO-5.0-latest-deploy";
-  "OMERO-5.0-latest" -> "OMERO-5.0-latest-maven";
-  "OMERO-5.0-merge-daily" -> "OME-5.0-merge-push";
-  subgraph cluster_0 {
-    "OME-5.0-merge-push" -> "OMERO-5.0-merge-build";
-    "OMERO-5.0-merge-build" -> "OMERO-5.0-merge-deploy";
-    }
-  "OME-5.0-merge-push" -> "OMERO-5.0-merge-integration"
-  "OMERO-5.0-merge-deploy" -> "OMERO-5.0-merge-matlab"
-  "OMERO-5.0-merge-deploy" -> "OMERO-5.0-merge-maven"
-  "OMERO-5.0-merge-deploy" -> "OMERO-5.0-merge-robotframework"
-  "OMERO-5.0-merge-deploy" -> "OMERO-5.0-merge-doc"
-  "OMERO-5.0-merge-deploy" -> "OMERO-5.0-merge-upgrade"
-  "OMERO-5.0-merge-integration" -> "OMERO-5.0-merge-integration-broken";
-  "OMERO-5.0-merge-integration" -> "OMERO-5.0-merge-integration-java";
-  "OMERO-5.0-merge-integration" -> "OMERO-5.0-merge-integration-python";
-  "OMERO-5.0-merge-integration" -> "OMERO-5.0-merge-integration-web";
 
 .. glossary::
 
-	:jenkinsjob:`OMERO-5.0-latest`
+    :jenkinsjob:`OMERO-5.0-latest`
 
 
-		This job build the dev_5_0 branch of OMERO with Ice 3.3, 3.4 or 3.5
+        This job build the dev_5_0 branch of OMERO with Ice 3.3, 3.4 or 3.5
 
-		#. |buildOMERO|
-		#. |archiveOMEROartifacts|
+        #. |buildOMERO|
+        #. |archiveOMEROartifacts|
 
+        See :jenkinsjob:`the build graph <OMERO-5.0-latest/lastSuccessfulBuild/BuildGraph>`
 
-	:jenkinsjob:`OMERO-5.0-latest-deploy`
+    :jenkinsjob:`OMERO-5.0-latest-deploy`
 
-		This job deploys the latest 5.0.x server (see
-		:ref:`deployment_servers`)
+        This job deploys the latest 5.0.x server (see
+        :ref:`deployment_servers`)
 
-	:jenkinsjob:`OMERO-5.0-latest-submods`
+    :jenkinsjob:`OMERO-5.0-latest-submods`
 
-		This job updates the submodules on the dev_5_0 branch
+        This job updates the submodules on the dev_5_0 branch
 
-		#. |updatesubmodules| and pushes the merge branch to
-		   snoopycrimecop/dev_5_0/latest/submodules
-		#. If the submodules are updated, opens a new PR or updates the
-		   existing dev_5_0 submodules PR
+        #. |updatesubmodules| and pushes the merge branch to
+           snoopycrimecop/dev_5_0/latest/submodules
+        #. If the submodules are updated, opens a new PR or updates the
+           existing dev_5_0 submodules PR
 
-	:jenkinsjob:`OMERO-5.0-merge-daily`
+    :jenkinsjob:`OMERO-5.0-merge-daily`
 
-		This job triggers all the morning merge builds listed below
+        This job triggers all the morning merge builds listed below
 
-		#. Triggers :term:`OME-5.0-merge-push`
-		#. Triggers :term:`OMERO-5.0-merge-build` and
-		   :term:`OMERO-5.0-merge-integration`
-		#. Triggers :term:`OMERO-5.0-merge-deploy`
-		#. Triggers other downstream merge jobs
+        #. Triggers :term:`OME-5.0-merge-push`
+        #. Triggers :term:`OMERO-5.0-merge-build` and
+           :term:`OMERO-5.0-merge-integration`
+        #. Triggers :term:`OMERO-5.0-merge-deploy`
+        #. Triggers other downstream merge jobs
 
-	:jenkinsjob:`OME-5.0-merge-push`
+        See :jenkinsjob:`the build graph <OMERO-5.0-merge-daily/lastSuccessfulBuild/BuildGraph>`
 
-		This job merges all the dev_5_0 PRs
+    :jenkinsjob:`OME-5.0-merge-push`
 
-		#. |merge|
-		#. Pushes the branch to snoopycrimecop/merge/dev_5_0/latest
+        This job merges all the dev_5_0 PRs
 
-	:jenkinsjob:`OMERO-5.0-merge-build`
+        #. |merge|
+        #. Pushes the branch to snoopycrimecop/merge/dev_5_0/latest
 
-		This matrix job builds the OMERO components with Ice 3.3, 3.4 or 3.5
+    :jenkinsjob:`OMERO-5.0-merge-build`
 
-		#. Checks out the merge/dev_5_0/latest branch of the
-		   snoopycrimecop fork of openmicroscopy.git_
-		#. |buildOMERO| for each version of Ice
-		#. |buildVM|
-		#. |archiveOMEROartifacts|
+        This matrix job builds the OMERO components with Ice 3.3, 3.4 or 3.5
 
-	:jenkinsjob:`OMERO-5.0-merge-deploy`
+        #. Checks out the merge/dev_5_0/latest branch of the
+           snoopycrimecop fork of openmicroscopy.git_
+        #. |buildOMERO| for each version of Ice
+        #. |buildVM|
+        #. |archiveOMEROartifacts|
 
-		This job deploys the merge 5.0.x server (see
-		:ref:`deployment_servers`)
+    :jenkinsjob:`OMERO-5.0-merge-deploy`
 
-	:jenkinsjob:`OMERO-5.0-merge-integration`
+        This job deploys the merge 5.0.x server (see
+        :ref:`deployment_servers`)
 
-		This job runs the integration tests
+    :jenkinsjob:`OMERO-5.0-merge-integration`
 
-		#. Checks out the merge/dev_5_0/latest branch of the
-		   snoopycrimecop fork of openmicroscopy.git_
-		#. Builds OMERO.server and starts it
-		#. Runs the OMERO.java, OMERO.py and OMERO.web integration tests
-		#. Archives the results
-		#. Triggers downstream collection jobs:
-		   :term:`OMERO-5.0-merge-integration-broken`,
-		   :term:`OMERO-5.0-merge-integration-java`,
-		   :term:`OMERO-5.0-merge-integration-python`,
-		   :term:`OMERO-5.0-merge-integration-web`
+        This job runs the integration tests
 
-	:jenkinsjob:`OMERO-5.0-merge-integration-broken`
+        #. Checks out the merge/dev_5_0/latest branch of the
+           snoopycrimecop fork of openmicroscopy.git_
+        #. Builds OMERO.server and starts it
+        #. Runs the OMERO.java, OMERO.py and OMERO.web integration tests
+        #. Archives the results
+        #. Triggers downstream collection jobs:
+           :term:`OMERO-5.0-merge-integration-broken`,
+           :term:`OMERO-5.0-merge-integration-java`,
+           :term:`OMERO-5.0-merge-integration-python`,
+           :term:`OMERO-5.0-merge-integration-web`
 
-		This job collects the OMERO.java broken test results
+    :jenkinsjob:`OMERO-5.0-merge-integration-broken`
 
-		#. Receives TestNG results under
-		   :file:`components/tools/OmeroJava/target/reports/broken` from
-		   :term:`OMERO-5.0-merge-integration`,
-		#. Generates TestNG report
+        This job collects the OMERO.java broken test results
 
-	:jenkinsjob:`OMERO-5.0-merge-integration-java`
+        #. Receives TestNG results under
+           :file:`components/tools/OmeroJava/target/reports/broken` from
+           :term:`OMERO-5.0-merge-integration`,
+        #. Generates TestNG report
 
-		This job collects the OMERO.java integration test results
+    :jenkinsjob:`OMERO-5.0-merge-integration-java`
 
-		#. Receives TestNG results under
-		   :file:`components/tools/OmeroJava/target/reports/integration` from
-		   :term:`OMERO-5.0-merge-integration`,
-		#. Generates TestNG report
+        This job collects the OMERO.java integration test results
 
-	:jenkinsjob:`OMERO-5.0-merge-integration-python`
+        #. Receives TestNG results under
+           :file:`components/tools/OmeroJava/target/reports/integration` from
+           :term:`OMERO-5.0-merge-integration`,
+        #. Generates TestNG report
 
-		This job collects the OMERO.py integration test results
+    :jenkinsjob:`OMERO-5.0-merge-integration-python`
 
-		#. Receives pytest results under
-		   :file:`components/tools/OmeroPy/target/reports` from
-		   :term:`OMERO-5.0-merge-integration`,
-		#. Generates pytest report
+        This job collects the OMERO.py integration test results
 
-	:jenkinsjob:`OMERO-5.0-merge-integration-web`
+        #. Receives pytest results under
+           :file:`components/tools/OmeroPy/target/reports` from
+           :term:`OMERO-5.0-merge-integration`,
+        #. Generates pytest report
 
-		This job collects the OMERO.web integration test results
+    :jenkinsjob:`OMERO-5.0-merge-integration-web`
 
-		#. Receives pytest results under
-		   :file:`components/tools/OmeroWeb/target/reports` from
-		   :term:`OMERO-5.0-merge-integration`,
-		#. Generates pytest report
+        This job collects the OMERO.web integration test results
 
-	:jenkinsjob:`OMERO-5.0-merge-matlab`
+        #. Receives pytest results under
+           :file:`components/tools/OmeroWeb/target/reports` from
+           :term:`OMERO-5.0-merge-integration`,
+        #. Generates pytest report
 
-		This job runs the OMERO.matlab tests
+    :jenkinsjob:`OMERO-5.0-merge-matlab`
 
-		#. Checks out the merge/dev_5_0/latest branch of the
-		   snoopycrimecop fork of openmicroscopy.git_
-		#. Collects the MATLAB artifacts from :term:`OMERO-5.0-merge-build`
-		#. Run the MATLAB unit tests under
-		   :file:`components/tools/OmeroM/test/unit` and collect the results
+        This job runs the OMERO.matlab tests
 
-	:jenkinsjob:`OMERO-5.0-merge-maven`
+        #. Checks out the merge/dev_5_0/latest branch of the
+           snoopycrimecop fork of openmicroscopy.git_
+        #. Collects the MATLAB artifacts from :term:`OMERO-5.0-merge-build`
+        #. Run the MATLAB unit tests under
+           :file:`components/tools/OmeroM/test/unit` and collect the results
 
-		The same as :term:`OMERO-5.1-merge-maven`, but for 5.0.
+    :jenkinsjob:`OMERO-5.0-merge-maven`
 
-	:jenkinsjob:`OMERO-5.0-latest-maven`
+        The same as :term:`OMERO-5.1-merge-maven`, but for 5.0.
 
-		The same as :term:`OMERO-5.1-merge-maven`, but for 5.0 and pushes to `ome.snapshots`.
+    :jenkinsjob:`OMERO-5.0-latest-maven`
 
-	:jenkinsjob:`OMERO-5.0-merge-robotframework`
+        The same as :term:`OMERO-5.1-merge-maven`, but for 5.0 and pushes to `ome.snapshots`.
 
-		This job runs the robot framework tests of OMERO
+    :jenkinsjob:`OMERO-5.0-merge-robotframework`
 
-		#. Checks out the merge/dev_5_0/latest branch of the
-		   snoopycrimecop fork of openmicroscopy.git_
-		#. Builds OMERO.server and starts it
-		#. Runs the robot framework tests and collect the results
+        This job runs the robot framework tests of OMERO
 
-	:jenkinsjob:`OME-5.0-merge-homebrew`
+        #. Checks out the merge/dev_5_0/latest branch of the
+           snoopycrimecop fork of openmicroscopy.git_
+        #. Builds OMERO.server and starts it
+        #. Runs the robot framework tests and collect the results
 
-		This job tests the installation of OMERO 5.0 using Homebrew
+    :jenkinsjob:`OME-5.0-merge-homebrew`
 
-		#. Cleans :file:`/usr/local`
-		#. Installs Homebrew
-		#. Runs :file:`docs/install/OMERO-homebrew-install.sh`
+        This job tests the installation of OMERO 5.0 using Homebrew
 
-	:jenkinsjob:`OMERO-5.0-merge-upgrade`
+        #. Cleans :file:`/usr/local`
+        #. Installs Homebrew
+        #. Runs :file:`docs/install/OMERO-homebrew-install.sh`
 
-		This job tests the DB upgrade script from the last released 4.4.x
-		server or the 5.0.0-beta1 server
+    :jenkinsjob:`OMERO-5.0-merge-upgrade`
 
-		#. Initializes a database using the script from the last released 
-		   4.4.x server or the 5.0.0-beta1 server
-		#. Starts the OMERO server
-		#. Stops the OMERO server
-		#. Runs the upgrade script under :file:`sql/psql/OMERO5.0_0/`
-		#. Restarts the OMERO server
+        This job tests the DB upgrade script from the last released 4.4.x
+        server or the 5.0.0-beta1 server
+
+        #. Initializes a database using the script from the last released
+           4.4.x server or the 5.0.0-beta1 server
+        #. Starts the OMERO server
+        #. Stops the OMERO server
+        #. Runs the upgrade script under :file:`sql/psql/OMERO5.0_0/`
+        #. Restarts the OMERO server
 
 5.1.x series
 ^^^^^^^^^^^^
@@ -483,49 +347,26 @@ under the :jenkinsview:`5.0` view tab of Jenkins.
 The branch for the 5.1.x series of OMERO is develop. All jobs are listed
 under the :jenkinsview:`5.1` view tab of Jenkins.
 
-
-.. digraph:: OMERO51jobs
-
-  "OMERO-5.1-latest" -> "OMERO-5.1-latest-deploy";
-  "OMERO-5.1-latest" -> "OMERO-5.1-latest-deploy-win";
-  "OMERO-5.1-latest" -> "OMERO-5.1-latest-deploy-win2012";
-  "OMERO-5.1-latest" -> "OMERO-5.1-latest-maven";
-  "OMERO-5.1-merge-daily" -> "OME-5.1-merge-push"
-  subgraph cluster_0 {
-    "OME-5.1-merge-push" -> "OMERO-5.1-merge-build";
-    "OMERO-5.1-merge-build" -> "OMERO-5.1-merge-deploy";
-	"OMERO-5.1-merge-build" -> "OMERO-5.1-merge-deploy-win";
-	"OMERO-5.1-merge-build" -> "OMERO-5.1-merge-deploy-win2012";
-    }
-  "OME-5.1-merge-push" -> "OMERO-5.1-merge-integration"
-  "OMERO-5.1-merge-deploy" -> "OMERO-5.1-merge-docs"
-  "OMERO-5.1-merge-deploy" -> "OMERO-5.1-merge-matlab"
-  "OMERO-5.1-merge-deploy" -> "OMERO-5.1-merge-maven"
-  "OMERO-5.1-merge-deploy" -> "OMERO-5.1-merge-robotframework"
-  "OMERO-5.1-merge-deploy" -> "OMERO-5.1-merge-upgrade"
-  "OMERO-5.1-merge-integration" -> "OMERO-5.1-merge-integration-broken";
-  "OMERO-5.1-merge-integration" -> "OMERO-5.1-merge-integration-java";
-  "OMERO-5.1-merge-integration" -> "OMERO-5.1-merge-integration-python";
-  "OMERO-5.1-merge-integration" -> "OMERO-5.1-merge-integration-web";
-
 .. glossary::
 
-	:jenkinsjob:`OMERO-5.1-latest`
+    :jenkinsjob:`OMERO-5.1-latest`
 
-		This job builds the develop branch of OMERO with Ice 3.4 or 3.5
+        This job builds the develop branch of OMERO with Ice 3.4 or 3.5
 
-		#. |buildOMERO|
-		#. |archiveOMEROartifacts|
+        #. |buildOMERO|
+        #. |archiveOMEROartifacts|
 
-	:jenkinsjob:`OMERO-5.1-latest-deploy`
+        See :jenkinsjob:`the build graph <OMERO-5.1-latest/lastSuccessfulBuild/BuildGraph>`
 
-		This job deploys the latest 5.1.x server (see
-		:ref:`deployment_servers`)
+    :jenkinsjob:`OMERO-5.1-latest-deploy`
 
-	:jenkinsjob:`OMERO-5.1-latest-deploy-win`
+        This job deploys the latest 5.1.x server (see
+        :ref:`deployment_servers`)
 
-		This job deploys the latest 5.1.x server on Windows (see
-		:ref:`deployment_servers`)
+    :jenkinsjob:`OMERO-5.1-latest-deploy-win`
+
+        This job deploys the latest 5.1.x server on Windows (see
+        :ref:`deployment_servers`)
 
 	:jenkinsjob:`OMERO-5.1-latest-deploy-win2012`
 
@@ -534,49 +375,51 @@ under the :jenkinsview:`5.1` view tab of Jenkins.
 
 	:jenkinsjob:`OMERO-5.1-latest-submods`
 
-		This job updates the submodules on the develop branch
+        This job updates the submodules on the develop branch
 
-		#. |updatesubmodules| and pushes the merge branch to
-		   snoopycrimecop/develop/latest/submodules
-		#. If the submodules are updated, opens a new PR or updates the
-		   existing develop submodules PR
+        #. |updatesubmodules| and pushes the merge branch to
+           snoopycrimecop/develop/latest/submodules
+        #. If the submodules are updated, opens a new PR or updates the
+           existing develop submodules PR
 
-	:jenkinsjob:`OMERO-5.1-merge-daily`
+    :jenkinsjob:`OMERO-5.1-merge-daily`
 
-		This job triggers all the morning merge builds listed below
+        This job triggers all the morning merge builds listed below
 
-		#. Triggers :term:`OME-5.1-merge-push`
-		#. Triggers :term:`OMERO-5.1-merge-build` and
-		   :term:`OMERO-5.1-merge-integration`
-		#. Triggers :term:`OMERO-5.1-merge-deploy`
-		#. Triggers other downstream merge jobs
+        #. Triggers :term:`OME-5.1-merge-push`
+        #. Triggers :term:`OMERO-5.1-merge-build` and
+           :term:`OMERO-5.1-merge-integration`
+        #. Triggers :term:`OMERO-5.1-merge-deploy`
+        #. Triggers other downstream merge jobs
 
-	:jenkinsjob:`OME-5.1-merge-push`
+        See :jenkinsjob:`the build graph <OMERO-5.1-merge-daily/lastSuccessfulBuild/BuildGraph>`
 
-		This job merges all the PRs opened against develop
+    :jenkinsjob:`OME-5.1-merge-push`
 
-		#. |merge|
-		#. Pushes the branch to snoopycrimecop/merge/develop/latest
+        This job merges all the PRs opened against develop
 
-	:jenkinsjob:`OMERO-5.1-merge-build`
+        #. |merge|
+        #. Pushes the branch to snoopycrimecop/merge/develop/latest
 
-		These jobs builds the OMERO components with Ice 3.4 or 3.5
+    :jenkinsjob:`OMERO-5.1-merge-build`
 
-		#. Checks out the merge/develop/latest branch of the
-		   snoopycrimecop fork of openmicroscopy.git_
-		#. |buildOMERO| for each version of Ice
-		#. |buildVM|
-		#. |archiveOMEROartifacts|
+        These jobs builds the OMERO components with Ice 3.4 or 3.5
 
-	:jenkinsjob:`OMERO-5.1-merge-deploy`
+        #. Checks out the merge/develop/latest branch of the
+           snoopycrimecop fork of openmicroscopy.git_
+        #. |buildOMERO| for each version of Ice
+        #. |buildVM|
+        #. |archiveOMEROartifacts|
 
-		This job deploys the merge 5.1.x server (see
-		:ref:`deployment_servers`)
+    :jenkinsjob:`OMERO-5.1-merge-deploy`
 
-	:jenkinsjob:`OMERO-5.1-merge-deploy-win`
+        This job deploys the merge 5.1.x server (see
+        :ref:`deployment_servers`)
 
-		This job deploys the merge 5.1.x server on Windows (see
-		:ref:`deployment_servers`)
+    :jenkinsjob:`OMERO-5.1-merge-deploy-win`
+
+        This job deploys the merge 5.1.x server on Windows (see
+        :ref:`deployment_servers`)
 
 	:jenkinsjob:`OMERO-5.1-merge-deploy-win2012`
 
@@ -585,94 +428,94 @@ under the :jenkinsview:`5.1` view tab of Jenkins.
 
 	:jenkinsjob:`OMERO-5.1-merge-integration`
 
-		This job runs the integration tests of OMERO
+        This job runs the integration tests of OMERO
 
-		#. Checks out the merge/develop/latest branch of the
-		   snoopycrimecop fork of openmicroscopy.git_
-		#. Builds OMERO.server and starts it
-		#. Runs the OMERO.java, OMERO.py and OMERO.web integration tests
-		#. Archives the results
-		#. Triggers downstream collection jobs:
-		   :term:`OMERO-5.1-merge-integration-broken`,
-		   :term:`OMERO-5.1-merge-integration-java`,
-		   :term:`OMERO-5.1-merge-integration-python`,
-		   :term:`OMERO-5.1-merge-integration-web`
+        #. Checks out the merge/develop/latest branch of the
+           snoopycrimecop fork of openmicroscopy.git_
+        #. Builds OMERO.server and starts it
+        #. Runs the OMERO.java, OMERO.py and OMERO.web integration tests
+        #. Archives the results
+        #. Triggers downstream collection jobs:
+           :term:`OMERO-5.1-merge-integration-broken`,
+           :term:`OMERO-5.1-merge-integration-java`,
+           :term:`OMERO-5.1-merge-integration-python`,
+           :term:`OMERO-5.1-merge-integration-web`
 
-	:jenkinsjob:`OMERO-5.1-merge-integration-broken`
+    :jenkinsjob:`OMERO-5.1-merge-integration-broken`
 
-		This job collects the OMERO.java broken test results
+        This job collects the OMERO.java broken test results
 
-		#. Receives TestNG results under
-		   :file:`components/tools/OmeroJava/target/reports/broken` from
-		   :term:`OMERO-5.1-merge-integration`,
-		#. Generates TestNG report
+        #. Receives TestNG results under
+           :file:`components/tools/OmeroJava/target/reports/broken` from
+           :term:`OMERO-5.1-merge-integration`,
+        #. Generates TestNG report
 
-	:jenkinsjob:`OMERO-5.1-merge-integration-java`
+    :jenkinsjob:`OMERO-5.1-merge-integration-java`
 
-		This job collects the OMERO.java integration test results
+        This job collects the OMERO.java integration test results
 
-		#. Receives TestNG results under
-		   :file:`components/tools/OmeroJava/target/reports/integration` from
-		   :term:`OMERO-5.1-merge-integration`,
-		#. Generates TestNG report
+        #. Receives TestNG results under
+           :file:`components/tools/OmeroJava/target/reports/integration` from
+           :term:`OMERO-5.1-merge-integration`,
+        #. Generates TestNG report
 
-	:jenkinsjob:`OMERO-5.1-merge-integration-python`
+    :jenkinsjob:`OMERO-5.1-merge-integration-python`
 
-		This job collects the OMERO.py integration test results
+        This job collects the OMERO.py integration test results
 
-		#. Receives pytest results under
-		   :file:`components/tools/OmeroPy/target/reports` from
-		   :term:`OMERO-5.1-merge-integration`,
-		#. Generates pytest report
+        #. Receives pytest results under
+           :file:`components/tools/OmeroPy/target/reports` from
+           :term:`OMERO-5.1-merge-integration`,
+        #. Generates pytest report
 
-	:jenkinsjob:`OMERO-5.1-merge-integration-web`
+    :jenkinsjob:`OMERO-5.1-merge-integration-web`
 
-		This job collects the OMERO.web integration test results
+        This job collects the OMERO.web integration test results
 
-		#. Receives pytest results under
-		   :file:`components/tools/OmeroWeb/target/reports` from
-		   :term:`OMERO-5.1-merge-integration`,
-		#. Generates pytest report
+        #. Receives pytest results under
+           :file:`components/tools/OmeroWeb/target/reports` from
+           :term:`OMERO-5.1-merge-integration`,
+        #. Generates pytest report
 
-	:jenkinsjob:`OMERO-5.1-merge-matlab`
+    :jenkinsjob:`OMERO-5.1-merge-matlab`
 
-		This job runs the OMERO.matlab tests
+        This job runs the OMERO.matlab tests
 
-		#. Checks out the merge/develop/latest branch of the
-		   snoopycrimecop fork of openmicroscopy.git_
-		#. Collects the MATLAB artifacts from :term:`OMERO-5.1-merge-build`
-		#. Runs the MATLAB unit tests under
-		   :file:`components/tools/OmeroM/test/unit` and collect the results
+        #. Checks out the merge/develop/latest branch of the
+           snoopycrimecop fork of openmicroscopy.git_
+        #. Collects the MATLAB artifacts from :term:`OMERO-5.1-merge-build`
+        #. Runs the MATLAB unit tests under
+           :file:`components/tools/OmeroM/test/unit` and collect the results
 
-	:jenkinsjob:`OMERO-5.1-merge-maven`
+    :jenkinsjob:`OMERO-5.1-merge-maven`
 
-		This job is used to generate SNAPSHOT jars and push them to artifactory.
+        This job is used to generate SNAPSHOT jars and push them to artifactory.
 
-		#. Runs :file:`docs/hudson/OMERO.sh`
-		#. Executes the `release-hudson` target for the `ome.unstable` repository.
+        #. Runs :file:`docs/hudson/OMERO.sh`
+        #. Executes the `release-hudson` target for the `ome.unstable` repository.
 
-	:jenkinsjob:`OMERO-5.1-latest-maven`
+    :jenkinsjob:`OMERO-5.1-latest-maven`
 
-		The same as :term:`OMERO-5.1-merge-maven`, but pushes to `ome.snapshots`.
+        The same as :term:`OMERO-5.1-merge-maven`, but pushes to `ome.snapshots`.
 
-	:jenkinsjob:`OMERO-5.1-merge-robotframework`
+    :jenkinsjob:`OMERO-5.1-merge-robotframework`
 
-		This job runs the robot framework tests of OMERO
+        This job runs the robot framework tests of OMERO
 
-		#. Checks out the merge/develop/latest branch of the
-		   snoopycrimecop fork of openmicroscopy.git_
-		#. Builds OMERO.server and starts it
-		#. Runs the robot framework tests and collect the results
+        #. Checks out the merge/develop/latest branch of the
+           snoopycrimecop fork of openmicroscopy.git_
+        #. Builds OMERO.server and starts it
+        #. Runs the robot framework tests and collect the results
 
-	:jenkinsjob:`OMERO-5.1-merge-upgrade`
+    :jenkinsjob:`OMERO-5.1-merge-upgrade`
 
-		This job tests the DB upgrade script from the 5.0.0 server
+        This job tests the DB upgrade script from the 5.0.0 server
 
-		#. Initializes a database using the script from the 5.0.0 release
-		#. Starts the OMERO server
-		#. Stops the OMERO server
-		#. Runs the upgrade script under :file:`sql/psql/OMERO5.1_DEVx/`
-		#. Restarts the OMERO server
+        #. Initializes a database using the script from the 5.0.0 release
+        #. Starts the OMERO server
+        #. Stops the OMERO server
+        #. Runs the upgrade script under :file:`sql/psql/OMERO5.1_DEVx/`
+        #. Restarts the OMERO server
 
 .. _omero_breaking:
 
@@ -684,112 +527,98 @@ database upgrade. The branch for the breaking series of OMERO is develop. All
 breaking jobs are listed under the :jenkinsview:`Breaking` view tab of
 Jenkins.
 
-.. digraph:: OMERObreakingjobs
-
-  "OMERO-5.1-breaking-trigger" -> "OME-5.1-breaking-push";
-  subgraph cluster_0 {
-    "OME-5.1-breaking-push" -> "OMERO-5.1-breaking-build";
-    "OMERO-5.1-breaking-build" -> "OMERO-5.1-breaking-deploy";
-    }
-  "OME-5.1-breaking-push" -> "OMERO-5.1-breaking-integration";
-  "OMERO-5.1-breaking-deploy" -> "OMERO-5.1-breaking-upgrade";
-  "OMERO-5.1-breaking-integration" -> "OMERO-5.1-breaking-integration-broken";
-  "OMERO-5.1-breaking-integration" -> "OMERO-5.1-breaking-integration-java";
-  "OMERO-5.1-breaking-integration" -> "OMERO-5.1-breaking-integration-python";
-  "OMERO-5.1-breaking-integration" -> "OMERO-5.1-breaking-integration-web";
-
 .. glossary::
 
-	:jenkinsjob:`OMERO-5.1-breaking-trigger`
+    :jenkinsjob:`OMERO-5.1-breaking-trigger`
 
-		This job triggers all the breaking jobs listed below
+        This job triggers all the breaking jobs listed below
 
-		#. Triggers :term:`OME-5.1-breaking-push`
-		#. Triggers :term:`OMERO-5.1-breaking-build` and
-		   :term:`OMERO-5.1-breaking-integration`
-		#. Triggers :term:`OMERO-5.1-breaking-deploy`
-		#. Triggers other downstream breaking jobs
+        #. Triggers :term:`OME-5.1-breaking-push`
+        #. Triggers :term:`OMERO-5.1-breaking-build` and
+           :term:`OMERO-5.1-breaking-integration`
+        #. Triggers :term:`OMERO-5.1-breaking-deploy`
+        #. Triggers other downstream breaking jobs
 
-	:jenkinsjob:`OME-5.1-breaking-push`
+    :jenkinsjob:`OME-5.1-breaking-push`
 
-		This job merges all the breaking PRs
+        This job merges all the breaking PRs
 
-		#. |merge| including only PRs labeled as `breaking`
-		#. Push the branch to snoopycrimecop/merge/develop/breaking
+        #. |merge| including only PRs labeled as `breaking`
+        #. Push the branch to snoopycrimecop/merge/develop/breaking
 
-	:jenkinsjob:`OMERO-5.1-breaking-build`
+    :jenkinsjob:`OMERO-5.1-breaking-build`
 
-		This matrix jobs builds the OMERO components with Ice 3.4 or 3.5
+        This matrix jobs builds the OMERO components with Ice 3.4 or 3.5
 
-		#. Checks out the merge/develop/breaking branch of the
-		   snoopycrimecop fork of openmicroscopy.git_
-		#. |buildOMERO| for each version of Ice
-		#. |buildVM|
-		#. |archiveOMEROartifacts|
+        #. Checks out the merge/develop/breaking branch of the
+           snoopycrimecop fork of openmicroscopy.git_
+        #. |buildOMERO| for each version of Ice
+        #. |buildVM|
+        #. |archiveOMEROartifacts|
 
-	:jenkinsjob:`OMERO-5.1-breaking-deploy`
+    :jenkinsjob:`OMERO-5.1-breaking-deploy`
 
-		This job deploys the breaking server (see :ref:`deployment_servers`)
+        This job deploys the breaking server (see :ref:`deployment_servers`)
 
-	:jenkinsjob:`OMERO-5.1-breaking-integration`
+    :jenkinsjob:`OMERO-5.1-breaking-integration`
 
-		This job runs the integration tests of OMERO
+        This job runs the integration tests of OMERO
 
-		#. Checks out the merge/develop/breaking branch of the
-		   snoopycrimecop fork of openmicroscopy.git_
-		#. Builds OMERO.server and starts it
-		#. Runs the OMERO.java, OMERO.py and OMERO.web integration tests
-		#. Archives the results
-		#. Triggers downstream collection jobs:
-		   :term:`OMERO-5.1-breaking-integration-broken`,
-		   :term:`OMERO-5.1-breaking-integration-java`,
-		   :term:`OMERO-5.1-breaking-integration-python`,
-		   :term:`OMERO-5.1-breaking-integration-web`
+        #. Checks out the merge/develop/breaking branch of the
+           snoopycrimecop fork of openmicroscopy.git_
+        #. Builds OMERO.server and starts it
+        #. Runs the OMERO.java, OMERO.py and OMERO.web integration tests
+        #. Archives the results
+        #. Triggers downstream collection jobs:
+           :term:`OMERO-5.1-breaking-integration-broken`,
+           :term:`OMERO-5.1-breaking-integration-java`,
+           :term:`OMERO-5.1-breaking-integration-python`,
+           :term:`OMERO-5.1-breaking-integration-web`
 
-	:jenkinsjob:`OMERO-5.1-breaking-integration-broken`
+    :jenkinsjob:`OMERO-5.1-breaking-integration-broken`
 
-		This job collects the OMERO.java broken test results
+        This job collects the OMERO.java broken test results
 
-		#. Receives TestNG results under
-		   :file:`components/tools/OmeroJava/target/reports/broken` from
-		   :term:`OMERO-5.1-breaking-integration`,
-		#. Generates TestNG report
+        #. Receives TestNG results under
+           :file:`components/tools/OmeroJava/target/reports/broken` from
+           :term:`OMERO-5.1-breaking-integration`,
+        #. Generates TestNG report
 
-	:jenkinsjob:`OMERO-5.1-breaking-integration-java`
+    :jenkinsjob:`OMERO-5.1-breaking-integration-java`
 
-		This job collects the OMERO.java integration test results
+        This job collects the OMERO.java integration test results
 
-		#. Receives TestNG results under
-		   :file:`components/tools/OmeroJava/target/reports/integration` from
-		   :term:`OMERO-5.1-breaking-integration`,
-		#. Generates TestNG report
+        #. Receives TestNG results under
+           :file:`components/tools/OmeroJava/target/reports/integration` from
+           :term:`OMERO-5.1-breaking-integration`,
+        #. Generates TestNG report
 
-	:jenkinsjob:`OMERO-5.1-breaking-integration-python`
+    :jenkinsjob:`OMERO-5.1-breaking-integration-python`
 
-		This job collects the OMERO.py integration test results
+        This job collects the OMERO.py integration test results
 
-		#. Receives pytest results under
-		   :file:`components/tools/OmeroPy/target/reports` from
-		   :term:`OMERO-5.1-breaking-integration`,
-		#. Generates pytest report
+        #. Receives pytest results under
+           :file:`components/tools/OmeroPy/target/reports` from
+           :term:`OMERO-5.1-breaking-integration`,
+        #. Generates pytest report
 
-	:jenkinsjob:`OMERO-5.1-breaking-integration-web`
+    :jenkinsjob:`OMERO-5.1-breaking-integration-web`
 
-		This job collects the OMERO.web integration test results
+        This job collects the OMERO.web integration test results
 
-		#. Receives pytest results under
-		   :file:`components/tools/OmeroWeb/target/reports` from
-		   :term:`OMERO-5.1-breaking-integration`,
-		#. Generates pytest report
+        #. Receives pytest results under
+           :file:`components/tools/OmeroWeb/target/reports` from
+           :term:`OMERO-5.1-breaking-integration`,
+        #. Generates pytest report
 
-	:jenkinsjob:`OMERO-5.1-breaking-upgrade`
+    :jenkinsjob:`OMERO-5.1-breaking-upgrade`
 
-		This job tests the DB upgrade script from a 5.0.0 server and the
-		last patch number of the 5.1.x series
+        This job tests the DB upgrade script from a 5.0.0 server and the
+        last patch number of the 5.1.x series
 
-		#. Initializes a database using the script from the 5.0.0 release or
-		   the last patch number of the 5.1.x series
-		#. Starts the OMERO server
-		#. Stops the OMERO server
-		#. Runs the upgrade script under :file:`sql/psql/OMERO5.1_DEVx/`
-		#. Restarts the OMERO server
+        #. Initializes a database using the script from the 5.0.0 release or
+           the last patch number of the 5.1.x series
+        #. Starts the OMERO server
+        #. Stops the OMERO server
+        #. Runs the upgrade script under :file:`sql/psql/OMERO5.1_DEVx/`
+        #. Restarts the OMERO server

--- a/contributing/ci-omero.txt
+++ b/contributing/ci-omero.txt
@@ -2,95 +2,95 @@ OMERO jobs
 ----------
 
 .. list-table::
-	:header-rows: 1
+    :header-rows: 1
 
-	- 	* Job task
-		* 5.0.x series
-		* 5.1.x series
-		* Breaking series
+    -   * Job task
+        * 5.0.x series
+        * 5.1.x series
+        * Breaking series
 
-	- 	* Builds the latest OMERO artifacts
-		* :term:`OMERO-5.0-latest`
-		* :term:`OMERO-5.1-latest`
-		*
+    -   * Builds the latest OMERO artifacts
+        * :term:`OMERO-5.0-latest`
+        * :term:`OMERO-5.1-latest`
+        *
 
-	- 	* Deploys the latest OMERO server
-		* :term:`OMERO-5.0-latest-deploy`
-		* | :term:`OMERO-5.1-latest-deploy`
-		  | :term:`OMERO-5.1-latest-deploy-win`
-		  | :term:`OMERO-5.1-latest-deploy-win2012`
-		*
+    -   * Deploys the latest OMERO server
+        * :term:`OMERO-5.0-latest-deploy`
+        * | :term:`OMERO-5.1-latest-deploy`
+          | :term:`OMERO-5.1-latest-deploy-win`
+          | :term:`OMERO-5.1-latest-deploy-win2012`
+        *
 
-	- 	* Updates submodules
-		* :term:`OMERO-5.0-latest-submods`
-		* :term:`OMERO-5.1-latest-submods`
-		*
+    -   * Updates submodules
+        * :term:`OMERO-5.0-latest-submods`
+        * :term:`OMERO-5.1-latest-submods`
+        *
 
-	- 	* Runs the daily OMERO merge builds
-		* :term:`OMERO-5.0-merge-daily`
-		* :term:`OMERO-5.1-merge-daily`
-		* :term:`OMERO-5.1-breaking-trigger`
+    -   * Runs the daily OMERO merge builds
+        * :term:`OMERO-5.0-merge-daily`
+        * :term:`OMERO-5.1-merge-daily`
+        * :term:`OMERO-5.1-breaking-trigger`
 
-	- 	* Merges the PRs
-		* :term:`OME-5.0-merge-push`
-		* :term:`OME-5.1-merge-push`
-		* :term:`OME-5.1-breaking-push`
+    -   * Merges the PRs
+        * :term:`OME-5.0-merge-push`
+        * :term:`OME-5.1-merge-push`
+        * :term:`OME-5.1-breaking-push`
 
-	- 	* Builds the OMERO artifacts
-		* :term:`OMERO-5.0-merge-build`
-		* :term:`OMERO-5.1-merge-build`
-		* :term:`OMERO-5.1-breaking-build`
+    -   * Builds the OMERO artifacts
+        * :term:`OMERO-5.0-merge-build`
+        * :term:`OMERO-5.1-merge-build`
+        * :term:`OMERO-5.1-breaking-build`
 
-	- 	* Deploys the OMERO server
-		* :term:`OMERO-5.0-merge-deploy`
-		* | :term:`OMERO-5.1-merge-deploy`
-		  | :term:`OMERO-5.1-merge-deploy-win`
-		  | :term:`OMERO-5.1-merge-deploy-win2012`
-		* :term:`OMERO-5.1-breaking-deploy`
+    -   * Deploys the OMERO server
+        * :term:`OMERO-5.0-merge-deploy`
+        * | :term:`OMERO-5.1-merge-deploy`
+          | :term:`OMERO-5.1-merge-deploy-win`
+          | :term:`OMERO-5.1-merge-deploy-win2012`
+        * :term:`OMERO-5.1-breaking-deploy`
 
-	- 	* Runs the OMERO upgrade scripts
-		* :term:`OMERO-5.0-merge-upgrade`
-		* :term:`OMERO-5.1-merge-upgrade`
-		* :term:`OMERO-5.1-breaking-upgrade`
+    -   * Runs the OMERO upgrade scripts
+        * :term:`OMERO-5.0-merge-upgrade`
+        * :term:`OMERO-5.1-merge-upgrade`
+        * :term:`OMERO-5.1-breaking-upgrade`
 
-	- 	* Runs the OMERO integration tests
-		* | :term:`OMERO-5.0-merge-integration`
-		  | :term:`OMERO-5.0-merge-integration-broken`
-		  | :term:`OMERO-5.0-merge-integration-java`
-		  | :term:`OMERO-5.0-merge-integration-python`
-		  | :term:`OMERO-5.0-merge-integration-web`
-		* | :term:`OMERO-5.1-merge-integration`
-		  | :term:`OMERO-5.1-merge-integration-broken`
-		  | :term:`OMERO-5.1-merge-integration-java`
-		  | :term:`OMERO-5.1-merge-integration-python`
-		  | :term:`OMERO-5.1-merge-integration-web`
-		* | :term:`OMERO-5.1-breaking-integration`
-		  | :term:`OMERO-5.1-breaking-integration-broken`
-		  | :term:`OMERO-5.1-breaking-integration-java`
-		  | :term:`OMERO-5.1-breaking-integration-python`
-		  | :term:`OMERO-5.1-breaking-integration-web`
+    -   * Runs the OMERO integration tests
+        * | :term:`OMERO-5.0-merge-integration`
+          | :term:`OMERO-5.0-merge-integration-broken`
+          | :term:`OMERO-5.0-merge-integration-java`
+          | :term:`OMERO-5.0-merge-integration-python`
+          | :term:`OMERO-5.0-merge-integration-web`
+        * | :term:`OMERO-5.1-merge-integration`
+          | :term:`OMERO-5.1-merge-integration-broken`
+          | :term:`OMERO-5.1-merge-integration-java`
+          | :term:`OMERO-5.1-merge-integration-python`
+          | :term:`OMERO-5.1-merge-integration-web`
+        * | :term:`OMERO-5.1-breaking-integration`
+          | :term:`OMERO-5.1-breaking-integration-broken`
+          | :term:`OMERO-5.1-breaking-integration-java`
+          | :term:`OMERO-5.1-breaking-integration-python`
+          | :term:`OMERO-5.1-breaking-integration-web`
 
-	- 	* Runs the OMERO.matlab tests
-		* :term:`OMERO-5.0-merge-matlab`
-		* :term:`OMERO-5.1-merge-matlab`
-		*
+    -   * Runs the OMERO.matlab tests
+        * :term:`OMERO-5.0-merge-matlab`
+        * :term:`OMERO-5.1-merge-matlab`
+        *
 
-	- 	* Runs the robot framework tests
-		* :term:`OMERO-5.0-merge-robotframework`
-		* :term:`OMERO-5.1-merge-robotframework`
-		*
+    -   * Runs the robot framework tests
+        * :term:`OMERO-5.0-merge-robotframework`
+        * :term:`OMERO-5.1-merge-robotframework`
+        *
 
-	- 	* Installs OMERO using Homebrew
-		* :term:`OME-5.0-merge-homebrew`
-		* :term:`OME-5.1-merge-homebrew`
-		*
+    -   * Installs OMERO using Homebrew
+        * :term:`OME-5.0-merge-homebrew`
+        * :term:`OME-5.1-merge-homebrew`
+        *
 
-	- 	* Push SNAPSHOTS to Maven
-		* | :term:`OMERO-5.0-latest-maven`
-		  | :term:`OMERO-5.0-merge-maven`
-		* | :term:`OMERO-5.1-latest-maven`
-		  | :term:`OMERO-5.1-merge-maven`
-		*
+    -   * Push SNAPSHOTS to Maven
+        * | :term:`OMERO-5.0-latest-maven`
+          | :term:`OMERO-5.0-merge-maven`
+        * | :term:`OMERO-5.1-latest-maven`
+          | :term:`OMERO-5.1-merge-maven`
+        *
 
 .. _deployment_servers:
 
@@ -101,80 +101,80 @@ The table below lists all the hostnames, ports and URLs of the OMERO.web
 clients of the deployment jobs described above:
 
 .. list-table::
-	:header-rows: 1
-	:widths: 10,20,20,10,40
+    :header-rows: 1
+    :widths: 10,20,20,10,40
 
-	- 	* Series
-		* Deployment job
-		* Hostname
-		* Port
-		* Webclient
+    -   * Series
+        * Deployment job
+        * Hostname
+        * Port
+        * Webclient
 
-	- 	* 5.0.x
-		* :term:`OMERO-5.0-merge-deploy`
-		* octopus.openmicroscopy.org
-		* 4064
-		* https://octopus.openmicroscopy.org/merge
+    -   * 5.0.x
+        * :term:`OMERO-5.0-merge-deploy`
+        * octopus.openmicroscopy.org
+        * 4064
+        * https://octopus.openmicroscopy.org/merge
 
-	- 	* 5.0.x
-		* :term:`OMERO-5.0-latest-deploy`
-		* octopus.openmicroscopy.org
-		* 14064
-		* https://octopus.openmicroscopy.org/latest
+    -   * 5.0.x
+        * :term:`OMERO-5.0-latest-deploy`
+        * octopus.openmicroscopy.org
+        * 14064
+        * https://octopus.openmicroscopy.org/latest
 
-	- 	* 5.0.x
-		* :term:`OMERO-5.0-merge-integration`
-		* octopus.openmicroscopy.org
-		* 24064
-		* https://octopus.openmicroscopy.org/integration
+    -   * 5.0.x
+        * :term:`OMERO-5.0-merge-integration`
+        * octopus.openmicroscopy.org
+        * 24064
+        * https://octopus.openmicroscopy.org/integration
 
-	- 	* 5.1.x
-		* :term:`OMERO-5.1-merge-deploy`
-		* trout.openmicroscopy.org
-		* 4064
-		* https://trout.openmicroscopy.org/merge
+    -   * 5.1.x
+        * :term:`OMERO-5.1-merge-deploy`
+        * trout.openmicroscopy.org
+        * 4064
+        * https://trout.openmicroscopy.org/merge
 
-	- 	* 5.1.x
-		* :term:`OMERO-5.1-merge-deploy-win`
-		* hake.openmicroscopy.org
-		* 4064
-		* http://hake.openmicroscopy.org/merge
+    -   * 5.1.x
+        * :term:`OMERO-5.1-merge-deploy-win`
+        * hake.openmicroscopy.org
+        * 4064
+        * http://hake.openmicroscopy.org/merge
 
-	- 	* 5.1.x
-		* :term:`OMERO-5.1-merge-deploy-win2012`
-		* ome-w2012r2-01.openmicroscopy.org
-		* 4064
-		* http://ome-w2012r2-01.openmicroscopy.org/merge
+    -   * 5.1.x
+        * :term:`OMERO-5.1-merge-deploy-win2012`
+        * ome-w2012r2-01.openmicroscopy.org
+        * 4064
+        * http://ome-w2012r2-01.openmicroscopy.org/merge
 
-	- 	* 5.1.x
-		* :term:`OMERO-5.1-latest-deploy`
-		* trout.openmicroscopy.org
-		* 14064
-		* https://trout.openmicroscopy.org/latest
+    -   * 5.1.x
+        * :term:`OMERO-5.1-latest-deploy`
+        * trout.openmicroscopy.org
+        * 14064
+        * https://trout.openmicroscopy.org/latest
 
-	- 	* 5.1.x
-		* :term:`OMERO-5.1-latest-deploy-win`
-		* hake.openmicroscopy.org
-		* 14064
-		* http://hake.openmicroscopy.org/latest
+    -   * 5.1.x
+        * :term:`OMERO-5.1-latest-deploy-win`
+        * hake.openmicroscopy.org
+        * 14064
+        * http://hake.openmicroscopy.org/latest
 
-	- 	* 5.1.x
-		* :term:`OMERO-5.1-latest-deploy-win2012`
-		* ome-w2012r2-01.openmicroscopy.org
-		* 14064
-		* http://ome-w2012r2-01.openmicroscopy.org/latest
+    -   * 5.1.x
+        * :term:`OMERO-5.1-latest-deploy-win2012`
+        * ome-w2012r2-01.openmicroscopy.org
+        * 14064
+        * http://ome-w2012r2-01.openmicroscopy.org/latest
 
-	- 	* 5.1.x
-		* :term:`OMERO-5.1-merge-integration`
-		* trout.openmicroscopy.org
-		* 24064
-		* https://trout.openmicroscopy.org/integration
+    -   * 5.1.x
+        * :term:`OMERO-5.1-merge-integration`
+        * trout.openmicroscopy.org
+        * 24064
+        * https://trout.openmicroscopy.org/integration
 
-	- 	* Breaking
-		* :term:`OMERO-5.1-breaking-deploy`
-		* trout.openmicroscopy.org
-		* 34064
-		* https://trout.openmicroscopy.org/breaking
+    -   * Breaking
+        * :term:`OMERO-5.1-breaking-deploy`
+        * trout.openmicroscopy.org
+        * 34064
+        * https://trout.openmicroscopy.org/breaking
 
 5.0.x series
 ^^^^^^^^^^^^
@@ -326,8 +326,8 @@ under the :jenkinsview:`5.0` view tab of Jenkins.
         This job tests the installation of OMERO 5.0 using Homebrew
 
         #. Cleans :file:`/usr/local`
-        #. Installs Homebrew
-        #. Runs :file:`docs/install/OMERO-homebrew-install.sh`
+        #. Installs Homebrew from https://github.com/ome/omero-install
+        #. Installs OMERO via :file:`homebrew/install_omero50`
 
     :jenkinsjob:`OMERO-5.0-merge-upgrade`
 
@@ -368,12 +368,12 @@ under the :jenkinsview:`5.1` view tab of Jenkins.
         This job deploys the latest 5.1.x server on Windows (see
         :ref:`deployment_servers`)
 
-	:jenkinsjob:`OMERO-5.1-latest-deploy-win2012`
+    :jenkinsjob:`OMERO-5.1-latest-deploy-win2012`
 
-		This job deploys the latest 5.1.x server on Windows 2012
-		(see :ref:`deployment_servers`)
+        This job deploys the latest 5.1.x server on Windows 2012
+        (see :ref:`deployment_servers`)
 
-	:jenkinsjob:`OMERO-5.1-latest-submods`
+    :jenkinsjob:`OMERO-5.1-latest-submods`
 
         This job updates the submodules on the develop branch
 
@@ -421,12 +421,12 @@ under the :jenkinsview:`5.1` view tab of Jenkins.
         This job deploys the merge 5.1.x server on Windows (see
         :ref:`deployment_servers`)
 
-	:jenkinsjob:`OMERO-5.1-merge-deploy-win2012`
+    :jenkinsjob:`OMERO-5.1-merge-deploy-win2012`
 
-		This job deploys the merge 5.1.x server on Windows 2012
-		(see :ref:`deployment_servers`)
+        This job deploys the merge 5.1.x server on Windows 2012
+        (see :ref:`deployment_servers`)
 
-	:jenkinsjob:`OMERO-5.1-merge-integration`
+    :jenkinsjob:`OMERO-5.1-merge-integration`
 
         This job runs the integration tests of OMERO
 
@@ -506,6 +506,14 @@ under the :jenkinsview:`5.1` view tab of Jenkins.
            snoopycrimecop fork of openmicroscopy.git_
         #. Builds OMERO.server and starts it
         #. Runs the robot framework tests and collect the results
+
+    :jenkinsjob:`OME-5.1-merge-homebrew`
+
+        This job tests the installation of OMERO 5.0 using Homebrew
+
+        #. Cleans :file:`/usr/local`
+        #. Installs Homebrew from https://github.com/ome/omero-install
+        #. Installs OMERO via :file:`homebrew/install_omero51`
 
     :jenkinsjob:`OMERO-5.1-merge-upgrade`
 

--- a/contributing/ci-release.txt
+++ b/contributing/ci-release.txt
@@ -70,21 +70,6 @@ clients of the deployment jobs described above:
 5.0.x series
 ^^^^^^^^^^^^
 
-.. digraph:: OME50releasejobs
-
-  subgraph cluster_0 {
-    "OME-5.0-release-push" -> "OMERO-5.0-release";
-    "OME-5.0-release-push" -> "BIOFORMATS-5.0-release";
-  }
-  "OME-5.0-release-trigger" -> "OME-5.0-release-push" [lhead=cluster_0];
-  "OME-5.0-release-push" -> "OMERO-5.0-release-integration";
-  "OMERO-5.0-release" -> "OMERO-5.0-release-downloads";
-  "BIOFORMATS-5.0-release" -> "BIOFORMATS-5.0-release-downloads";
-  "OMERO-5.0-release-integration" -> "OMERO-5.0-release-integration-broken";
-  "OMERO-5.0-release-integration" -> "OMERO-5.0-release-integration-java";
-  "OMERO-5.0-release-integration" -> "OMERO-5.0-release-integration-python";
-  "OMERO-5.0-release-integration" -> "OMERO-5.0-release-integration-web";
-
 .. glossary::
 
     :jenkinsjob:`OME-5.0-release-trigger`
@@ -104,6 +89,8 @@ clients of the deployment jobs described above:
         #. Triggers :term:`OMERO-5.0-release-integration`
         #. Triggers :term:`OMERO-5.0-release` and
            :term:`BIOFORMATS-5.0-release`
+
+        See :jenkinsjob:`the build graph <OME-5.0-release-trigger/lastSuccessfulBuild/BuildGraph>`
 
     :jenkinsjob:`OME-5.0-release-push`
 
@@ -215,30 +202,6 @@ clients of the deployment jobs described above:
 5.1.x series
 ^^^^^^^^^^^^
 
-.. digraph:: OME51releasejobs
-
-  compound=true;
-  subgraph cluster0 {
-    "OME-5.1-release-push" -> "OMERO-5.1-release";
-    label = "OMERO-5.1-release-trigger";
-    
-  }
-  subgraph cluster1 {
-    "BIOFORMATS-5.1-release-java" -> "BIOFORMATS-5.1-release-cpp";
-    label = "BIOFORMATS-5.1-release";
-  }
-  
-  "OME-5.1-release-push" -> "BIOFORMATS-5.1-release-java" [lhead=cluster1];
-  "OME-5.1-release-push" -> "OMERO-5.1-release-integration";
-  "OMERO-5.1-release" -> "OMERO-5.1-release-downloads";
-  
-  "BIOFORMATS-5.1-release-java" -> "BIOFORMATS-5.1-release-downloads";
-  "BIOFORMATS-5.1-release-cpp" -> "BIOFORMATS-5.1-release-cpp-downloads";
-  "OMERO-5.1-release-integration" -> "OMERO-5.1-release-integration-broken";
-  "OMERO-5.1-release-integration" -> "OMERO-5.1-release-integration-java";
-  "OMERO-5.1-release-integration" -> "OMERO-5.1-release-integration-python";
-  "OMERO-5.1-release-integration" -> "OMERO-5.1-release-integration-web";
-
 .. glossary::
 
     :jenkinsjob:`OME-5.1-release-trigger`
@@ -257,6 +220,8 @@ clients of the deployment jobs described above:
         #. Triggers :term:`OMERO-5.1-release-integration`
         #. Triggers :term:`OMERO-5.1-release` and
            :term:`BIOFORMATS-5.1-release`
+
+        See :jenkinsjob:`the build graph <OME-5.1-release-trigger/lastSuccessfulBuild/BuildGraph>`
 
     :jenkinsjob:`OME-5.1-release-push`
 


### PR DESCRIPTION
This PR:

- removes the usage of `graphviz` in the Contributing documentation
- removes all CI jobs related to the 4.4.x development line
