### PR TITLE
Adding better ulimit info & cross-references

### DIFF
--- a/omero/sysadmins/limitations.txt
+++ b/omero/sysadmins/limitations.txt
@@ -26,6 +26,8 @@ correctly. OpenJDK and OracleJDK versions 6 and 7 are also supported.
 Windows OS issues
 -----------------
 
+.. _windows-database-encoding:
+
 Failure response on import for new databases
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/omero/sysadmins/troubleshooting.txt
+++ b/omero/sysadmins/troubleshooting.txt
@@ -210,7 +210,7 @@ Other import errors
 Too many open files
 ^^^^^^^^^^^^^^^^^^^
 
-This is most often see as an error during importing and is caused by the
+This is most often seen as an error during importing and is caused by the
 number of opened files exceeding the limit imposed
 by your operating system. It might be due to OMERO leaking file
 descriptors; if you are not using the latest version, please upgrade,

--- a/omero/sysadmins/troubleshooting.txt
+++ b/omero/sysadmins/troubleshooting.txt
@@ -202,6 +202,68 @@ most likely cause is that your PYTHONPATH is not properly set.
    environment variable. See the Ice installation instructions for more
    information.
 
+Other import errors
+-------------------
+
+.. _ulimit:
+
+Too many open files
+^^^^^^^^^^^^^^^^^^^
+
+This is most often see as an error during importing and is caused by the
+number of opened files exceeding the limit imposed
+by your operating system. It might be due to OMERO leaking file
+descriptors; if you are not using the latest version, please upgrade,
+since a number of bugs which could cause this behavior have been fixed.
+It is also possible for buggy scripts which do not properly release
+resources to cause this error.
+
+To view the current per-process limit, run
+
+::
+
+            ulimit -Hn
+
+which will show the hard limit for the maximum number of file
+descriptors (-Sn will show the soft limit). This limit may be increased.
+On Linux, see ``/etc/security/limits.conf`` (global PAM per-user limits
+configuration); it is also possible to increase the limit in the shell
+with
+
+::
+
+            ulimit -n newlimit
+
+providing that you are uid 0 (other users can only increase the soft
+limit up to the hard limit). To view the system limit, run
+
+::
+
+            cat /proc/sys/fs/file-max
+
+**We recommend 8K as a minimum number of files limit for production systems,
+with 16K being reasonable for bigger machines.**
+
+On Mac OS X, the standard ulimit will not work properly. There are several
+different ways of setting the ulimit, depending upon the version of OS X
+you are using, but the most common are to edit ``sysctl.conf`` or
+``launchd.conf`` to raise the limit. However, note that both of these
+methods change the defaults for every process on the system, not just
+for a single user or service.
+
+Increasing the number of available filehandles via 'ulimit -n'
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ValueError: filedescriptor out of range in select() - this is a known issue in 
+Python versions prior to 2.7.0. See
+:ticket:`6201` and Python `Issue #3392
+<http://bugs.python.org/issue3392>`_ for more details.
+
+Windows import errors
+^^^^^^^^^^^^^^^^^^^^^
+
+See :ref:`windows-database-encoding`.
+
 DropBox fails to start: failed to get session
 ---------------------------------------------
 
@@ -237,8 +299,8 @@ wrong. See :ref:`search-failures` for more details.
 OMERO.web issues
 ----------------
 
-OMERO.web did not start on the production
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+OMERO.web did not start
+^^^^^^^^^^^^^^^^^^^^^^^
 
 -  If the Apache error logs contain lines of type
    ``Permission denied: access to xxx denied``, you need to check the
@@ -327,49 +389,3 @@ http://bugs.sun.com/bugdatabase/view\_bug.do?bug\_id=4751177 or this
 :ome-users:`ome-users thread <2009-March/001465.html>` on our mailing list for
 more information.
 
-Too many open files
-^^^^^^^^^^^^^^^^^^^
-
-This is caused by the number of opened files exceeding the limit imposed
-by your operating system. It might be due to OMERO leaking file
-descriptors; if you are not using the latest version, please upgrade,
-since a number of bugs which could cause this behavior have been fixed.
-It is also possible for buggy scripts which do not properly release
-resources to cause this to occur. To view the current per-process limit,
-run
-
-::
-
-            ulimit -Hn
-
-which will show the hard limit for the maximum number of file
-descriptors (-Sn will show the soft limit). This limit may be increased.
-On Linux, see ``/etc/security/limits.conf`` (global PAM per-user limits
-configuration); it is also possible to increase the limit in the shell
-with
-
-::
-
-            ulimit -n newlimit
-
-providing that you are uid 0 (other users can only increase the soft
-limit up to the hard limit). To view the system limit, run
-
-::
-
-            cat /proc/sys/fs/file-max
-
-On Mac OS X, the standard ulimit will not work properly. There are several
-different ways of setting the ulimit, depending upon the version of OS X
-you are using, but the most common are to edit ``sysctl.conf`` or
-``launchd.conf`` to raise the limit. However, note that both of these
-methods change the defaults for every process on the system, not just
-for a single user or service.
-
-Increasing the number of available filehandles via 'ulimit -n'
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-ValueError: filedescriptor out of range in select() - this is a known issue in 
-Python versions prior to 2.7.0. See
-:ticket:`6201` and Python `Issue #3392
-<http://bugs.python.org/issue3392>`_ for more details.

--- a/omero/sysadmins/unix/server-installation.txt
+++ b/omero/sysadmins/unix/server-installation.txt
@@ -727,12 +727,17 @@ Advanced configuration
 
 Once you have the base server running, you may want to try enabling
 some of the advanced features such as :doc:`/sysadmins/dropbox` or
-:doc:`/sysadmins/server-ldap`. If you have ***Flex data***, you may
+:doc:`/sysadmins/server-ldap`. If you have **Flex data**, you may
 want to watch :snapshot:`the HCS configuration screencast
 <movies/omero-4-1/mov/FlexPreview4.1-configuration.mov>`. See the
 :omero_plone:`Feature list <feature-list>` for more advanced features
 you may want to use, and :doc:`/sysadmins/config` on how to get the
 most out of your server.
+
+If your users are going to be importing many files in one go, for example
+multiple plates, you should make sure you set the maximum number of open files
+to a sensible level (i.e. at least 8K for production systems, 16K for bigger
+machines). See :ref:`ulimit` for more information.
 
 Troubleshooting
 ^^^^^^^^^^^^^^^

--- a/omero/sysadmins/windows/server-installation.txt
+++ b/omero/sysadmins/windows/server-installation.txt
@@ -586,6 +586,11 @@ See the :omero_plone:`Feature list <feature-list>` for more advanced
 features you may want to use, and :doc:`/sysadmins/config` on how to get the
 most out of your server.
 
+If your users are going to be importing many files in one go, for example
+multiple plates, you should make sure you set the maximum number of open files
+to a sensible level (i.e. at least 8K for production systems, 16K for bigger
+machines). See :ref:`ulimit` for more information.
+
 Troubleshooting
 ^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Re-arranged troubleshooting page and added mention of the ulimit issue to the server installation pages (I've stuck it under advanced configuration as it seemed the most logical place but I'm open to suggestions if others can think of a better place for it). Also added cross-reference to the Windows database encoding issue on the troubleshooting page and fixed the web subheading pointed out by Roger on a previous PR.