### PR TITLE
OME-TIFF specification: Allow use of BigTIFF file extensions

### DIFF
--- a/formats/ome-tiff/code.txt
+++ b/formats/ome-tiff/code.txt
@@ -28,21 +28,22 @@ the following steps are required:
 
 #. Read in the 8-byte header.
 #. Determine if the file is a valid TIFF, and if so, whether its byte
-   order is big endian or little endian. Bytes 0-1 must equal "II"
-   (little endian, "Intel") or "MM" (big endian, "Motorola"), which is
-   0x4D4D in the correct endian format.
-#. Check TIFF version.  Bytes 2-3 must equal 42 (0x2A) or 43 (0x2B)
+   order is big endian or little endian. Bytes 0–1 must equal "II"
+   (0x4949, little endian, "Intel") or "MM" (0x4D4D, big endian,
+   "Motorola").
+#. Check TIFF version.  Bytes 2–3 must equal 42 (0x2A) or 43 (0x2B)
    with the proper endianness, which are the TIFF specification or the
    newer BigTIFF specification, respectively.
 #. If the TIFF version is 0x2A, offsets are 4 bytes (32-bit).  If the
-   TIFF version is 0x2B, bytes 4-5 are the size of offsets in bytes
+   TIFF version is 0x2B, bytes 4–5 are the size of offsets in bytes
    (should be 0x0008 for 8-byte 64-bit offsets, but could be
    different), and bytes 6-7 are padding (should be 0x0000).
 #. Determine the byte offset into the file of the first IFD. For TIFF
-   version 0x2A, this information is stored in bytes 4-7, with the
+   version 0x2A, this information is stored in bytes 4–7, with the
    proper endianness.  For TIFF version 0x2B, this information is
    stored starting at byte 8, sized according to the specified offset
-   size and with the proper endianness.
+   size and with the proper endianness.  This will be bytes 8–15 for
+   8-byte offsets.
 #. Skip to the first IFD, and read in the IFD's header.
 #. Iterate through the directory entries looking for the
    ImageDescription (270) tag.

--- a/formats/ome-tiff/code.txt
+++ b/formats/ome-tiff/code.txt
@@ -28,11 +28,21 @@ the following steps are required:
 
 #. Read in the 8-byte header.
 #. Determine if the file is a valid TIFF, and if so, whether its byte
-   order is big endian or little endian. The first pair of bytes must
-   equal "II" (little endian, "Intel") or "MM" (big endian, "Motorola").
-   The next pair must equal 42 with the proper endianness.
-#. Determine the byte offset into the file of the first IFD. This
-   information is stored in bytes 4-7, with the proper endianness.
+   order is big endian or little endian. Bytes 0-1 must equal "II"
+   (little endian, "Intel") or "MM" (big endian, "Motorola"), which is
+   0x4D4D in the correct endian format.
+#. Check TIFF version.  Bytes 2-3 must equal 42 (0x2A) or 43 (0x2B)
+   with the proper endianness, which are the TIFF specification or the
+   newer BigTIFF specification, respectively.
+#. If the TIFF version is 0x2A, offsets are 4 bytes (32-bit).  If the
+   TIFF version is 0x2B, bytes 4-5 are the size of offsets in bytes
+   (should be 0x0008 for 8-byte 64-bit offsets, but could be
+   different), and bytes 6-7 are padding (should be 0x0000).
+#. Determine the byte offset into the file of the first IFD. For TIFF
+   version 0x2A, this information is stored in bytes 4-7, with the
+   proper endianness.  For TIFF version 0x2B, this information is
+   stored starting at byte 8, sized according to the specified offset
+   size.
 #. Skip to the first IFD, and read in the IFD's header.
 #. Iterate through the directory entries looking for the
    ImageDescription (270) tag.
@@ -51,6 +61,10 @@ with:
 ::
 
     tiffcomment file.ome.tif | xmlindent
+
+.. seealso::
+
+    `BigTIFF file format specification <http://bigtiff.org/#FILE_FORMAT>`__
 
 Modifying a TIFF comment
 ------------------------

--- a/formats/ome-tiff/code.txt
+++ b/formats/ome-tiff/code.txt
@@ -42,7 +42,7 @@ the following steps are required:
    version 0x2A, this information is stored in bytes 4-7, with the
    proper endianness.  For TIFF version 0x2B, this information is
    stored starting at byte 8, sized according to the specified offset
-   size.
+   size and with the proper endianness.
 #. Skip to the first IFD, and read in the IFD's header.
 #. Iterate through the directory entries looking for the
    ImageDescription (270) tag.

--- a/formats/ome-tiff/specification.txt
+++ b/formats/ome-tiff/specification.txt
@@ -33,17 +33,20 @@ are stored within the TIFF structure, not the XML.
    OME-TIFF header
 
 
-The diagram :ref:`figure-tiff-header` (adapted from the TIFF specification) 
-shows the organization of a TIFF header along with the placement of the 
-OME-XML metadata block. A TIFF file can contain any number of IFDs, with each
-one specifying an image plane along with certain accompanying metadata
-such as pixel dimensions, physical dimensions, bit depth, color table,
-etc. One of the fields an IFD can contain is ImageDescription, which
-provides a place to write a comment describing the corresponding image
-plane. This field is a convenient place to store the OME-XML metadata
-block—any TIFF library capable of parsing IFDs and extracting an
-ImageDescription comment can easily obtain an OME-TIFF file's entire set
-of metadata as OME-XML.
+The diagram :ref:`figure-tiff-header` (adapted from the TIFF
+specification) shows the organization of a TIFF header along with the
+placement of the OME-XML metadata block.  Note this is for the TIFF
+standard specification only; the header structure is slightly
+different for BigTIFF; see the `BigTIFF file format specification
+<http://bigtiff.org/#FILE_FORMAT>`__. A TIFF file can contain any
+number of IFDs, with each one specifying an image plane along with
+certain accompanying metadata such as pixel dimensions, physical
+dimensions, bit depth, color table, etc. One of the fields an IFD can
+contain is ImageDescription, which provides a place to write a comment
+describing the corresponding image plane. This field is a convenient
+place to store the OME-XML metadata block—any TIFF library capable of
+parsing IFDs and extracting an ImageDescription comment can easily
+obtain an OME-TIFF file's entire set of metadata as OME-XML.
 
 .. note:: 
     A TIFF file contains one IFD per image plane, but the

--- a/formats/ome-tiff/specification.txt
+++ b/formats/ome-tiff/specification.txt
@@ -10,11 +10,16 @@ format. It assumes familiarity with both the
 Storing OME-XML within a TIFF
 -----------------------------
 
-An OME-TIFF dataset consists of one or more files in standard TIFF or 
-`BigTIFF format <http://bigtiff.org/>`_, with the extension ``.ome.tif`` or 
-``.ome.tiff``, and an identical (or in the case of multiple files, nearly 
-identical) string of OME-XML metadata embedded in the ImageDescription tag of 
-each file's first IFD (Image File Directory).
+An OME-TIFF dataset consists of one or more files in standard TIFF or
+`BigTIFF format <http://bigtiff.org/>`_, with the file extension
+``.ome.tif`` or ``.ome.tiff``, and an identical (or in the case of
+multiple files, nearly identical) string of OME-XML metadata embedded
+in the ImageDescription tag of each file's first IFD (Image File
+Directory).  BigTIFF file extensions are also permitted, with the file
+extension ``.ome.tf2``, ``.ome.tf8`` or ``.ome.btf``, but note these
+file extensions are an addition to the original specification, and
+software using an older version of the specification may not be able
+to handle these file extensions.
 
 This string is a standard block of OME-XML, except that instead of
 storing pixels as BinData elements with base64-encoded pixel data


### PR DESCRIPTION
- Correct some descriptions to take BigTIFF into account (non-breaking)
- Add `.ome.tf2`, `.ome.tf8` and `.ome.btf` file extensions (non-breaking for writers, but may cause problems with older readers)

--------

This is a proposed update to the OME-TIFF specification to allow the Bio-Formats readers and writers to be updated to use these extensions.  This will allow Bio-Formats' OMETiffWriter to enable use of BigTIFF when these extensions are used, and OMETiffReader to identify and read files using these extensions.

See also: https://github.com/openmicroscopy/bioformats/pull/1744

/cc @ehrenfeu 