### PR TITLE
remove out-of-date volume viewer link

### DIFF
--- a/omero/sysadmins/unix/server-installation.txt
+++ b/omero/sysadmins/unix/server-installation.txt
@@ -203,9 +203,6 @@ The following Python packages are required:
       - :doc:`OMERO.tables </sysadmins/server-tables>`
       - `PyTables page <https://pytables.github.io/downloads.html>`_
 
-    * - scipy.ndimage
-      - `Numpy/Scipy page <http://www.scipy.org/Download>`_
-
 .. [1] Make sure to have `libjpeg <http://libjpeg.sourceforge.net/>`_ installed when building `Pillow`_.
 
 .. [2] May already have been installed as a dependency of Matplot Lib.

--- a/omero/sysadmins/unix/server-installation.txt
+++ b/omero/sysadmins/unix/server-installation.txt
@@ -204,14 +204,11 @@ The following Python packages are required:
       - `PyTables page <https://pytables.github.io/downloads.html>`_
 
     * - scipy.ndimage
-      - :omero_plone:`Volume Viewer <volume-viewer-in-omero.web>` [3]_
       - `Numpy/Scipy page <http://www.scipy.org/Download>`_
 
 .. [1] Make sure to have `libjpeg <http://libjpeg.sourceforge.net/>`_ installed when building `Pillow`_.
 
 .. [2] May already have been installed as a dependency of Matplot Lib.
-
-.. [3] Allows larger volumes to be viewed in the :omero_plone:`Volume Viewer <volume-viewer-in-omero.web>`.
 
 .. note::
     Some of these can be ignored if you wish to forego some


### PR DESCRIPTION
We don't use volume viewer any more, I removed the product page yesterday so the links are dead now and need removing.
