### PR TITLE
remove volume viewer link from Win install page

### DIFF
--- a/omero/sysadmins/windows/server-installation.txt
+++ b/omero/sysadmins/windows/server-installation.txt
@@ -145,12 +145,10 @@ The following are optional depending on what services you require:
       - `PyTables page <https://pytables.github.io/downloads.html>`_
 
     * - scipy.ndimage
-      - :omero_plone:`Volume Viewer <volume-viewer-in-omero.web>` [2]_
       - `Numpy/Scipy page <http://www.scipy.org/Download>`_
 
 .. [1] May already have been installed as a dependency of Matplot Lib.
 
-.. [2] Allows larger volumes to be viewed in the :omero_plone:`Volume Viewer <volume-viewer-in-omero.web>`.
 
 PostgreSQL (9.2 or higher)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/omero/sysadmins/windows/server-installation.txt
+++ b/omero/sysadmins/windows/server-installation.txt
@@ -144,9 +144,6 @@ The following are optional depending on what services you require:
       - :doc:`OMERO.tables </sysadmins/server-tables>`
       - `PyTables page <https://pytables.github.io/downloads.html>`_
 
-    * - scipy.ndimage
-      - `Numpy/Scipy page <http://www.scipy.org/Download>`_
-
 .. [1] May already have been installed as a dependency of Matplot Lib.
 
 


### PR DESCRIPTION
Companion to #1206 to remove corresponding link from Windows installation page
