### PR TITLE
CLI envvars 5.1.2

### DIFF
--- a/omero/developers/Modules/TempFileManager.txt
+++ b/omero/developers/Modules/TempFileManager.txt
@@ -7,7 +7,7 @@ with a best-effort guarantee of deleting the resources on exit. The
 manager searches three locations in order, taking the first which allows
 lockable write-access (See :ticket:`1653`):
 
--  The environment property setting ``OMERO_TEMPDIR``
+-  The environment property setting :envvar:`OMERO_TMPDIR`
 -  The user's home directory, for example specified in Java via
    ``System.getProperty("user.home")``
 -  The system temp directory, in Java

--- a/omero/sysadmins/system-requirements.txt
+++ b/omero/sysadmins/system-requirements.txt
@@ -75,7 +75,7 @@ the user's HOME directory in :file:`$HOME/omero/tmp`,
 :file:`$HOME\\omero\\sessions`). If your home
 directory is stored on a network, possibly NFS mounted (or similar),
 then these temporary files are being written and read over the
-network. This can slow access down.  The :envvar:`OMERO_TEMPDIR`
+network. This can slow access down.  The :envvar:`OMERO_TMPDIR`
 environment variable may used to set the directory used for temporary
 files, for example on fast local storage.
 

--- a/omero/sysadmins/system-requirements.txt
+++ b/omero/sysadmins/system-requirements.txt
@@ -64,20 +64,46 @@ The recommended client specification is:
 
 Large imports may require 4GB RAM.
 
+.. _client_directories:
+
 Client configuration
 ^^^^^^^^^^^^^^^^^^^^
 
 When performing some operations the clients make use of temporary file
-storage and log directories. By default these files are stored below
-the user's HOME directory in :file:`$HOME/omero/tmp`,
-:file:`$HOME/omero/log`, and :file:`$HOME/omero/sessions`
-(resp. :file:`$HOME\\omero\\tmp`, :file:`$HOME\\omero\\log`, and
-:file:`$HOME\\omero\\sessions`). If your home
-directory is stored on a network, possibly NFS mounted (or similar),
-then these temporary files are being written and read over the
-network. This can slow access down.  The :envvar:`OMERO_TMPDIR`
-environment variable may used to set the directory used for temporary
-files, for example on fast local storage.
+storage and log directories. The table below indicates the default values for
+each directory and the environment variables allowing to set their locations:
+
+.. list-table::
+  :header-rows: 1
+
+  - * Directory
+    * Environment variable
+    * Default (Linux)
+    * Default (Windows)
+  - * OMERO user directory
+    * :envvar:`OMERO_USERDIR`
+    * :file:`$HOME/omero`
+    * :file:`%HOMEPATH%\\omero`
+  - * Temporary files
+    * :envvar:`OMERO_TMPDIR`
+    * :file:`$HOME/omero/tmp`
+    * :file:`%HOMEPATH%\\omero\\tmp`
+  - * Local sessions
+    * :envvar:`OMERO_SESSIONDIR`
+    * :file:`$HOME/omero/sessions`
+    * :file:`%HOMEPATH%\\omero\\sessions`
+  - * Log files
+    *
+    * :file:`$HOME/omero/log`
+    * :file:`%HOMEPATH%\\omero\log`
+
+
+If your home directory is stored on a network, possibly NFS mounted (or similar), then these temporary files are being written and read over the
+network. This can slow access down.
+
+.. seealso::
+   :ref:`client_performance`
+       Troubleshooting section about client performance issues on NFS
 
 Software
 --------

--- a/omero/sysadmins/system-requirements.txt
+++ b/omero/sysadmins/system-requirements.txt
@@ -71,7 +71,7 @@ Client configuration
 
 When performing some operations the clients make use of temporary file
 storage and log directories. The table below indicates the default values for
-each directory and the environment variables allowing to set their locations:
+each directory and the environment variables for overriding their locations:
 
 .. list-table::
   :header-rows: 1

--- a/omero/sysadmins/system-requirements.txt
+++ b/omero/sysadmins/system-requirements.txt
@@ -76,10 +76,10 @@ each directory and the environment variables allowing to set their locations:
 .. list-table::
   :header-rows: 1
 
-  - * Directory
+  - * Client directory
     * Environment variable
-    * Default (Linux)
-    * Default (Windows)
+    * Default location (UNIX)
+    * Default location (Windows)
   - * OMERO user directory
     * :envvar:`OMERO_USERDIR`
     * :file:`$HOME/omero`
@@ -97,6 +97,8 @@ each directory and the environment variables allowing to set their locations:
     * :file:`$HOME/omero/log`
     * :file:`%HOMEPATH%\\omero\log`
 
+Note that setting :envvar:`OMERO_USERDIR` will also change the default location
+for the temporary files and the local sessions.
 
 If your home directory is stored on a network, possibly NFS mounted (or similar), then these temporary files are being written and read over the
 network. This can slow access down.

--- a/omero/sysadmins/system-requirements.txt
+++ b/omero/sysadmins/system-requirements.txt
@@ -73,6 +73,8 @@ When performing some operations the clients make use of temporary file
 storage and log directories. The table below indicates the default values for
 each directory and the environment variables for overriding their locations:
 
+.. tabularcolumns:: |l|l|l|l|
+
 .. list-table::
   :header-rows: 1
 

--- a/omero/sysadmins/system-requirements.txt
+++ b/omero/sysadmins/system-requirements.txt
@@ -97,7 +97,7 @@ each directory and the environment variables for overriding their locations:
   - * Log files
     *
     * :file:`$HOME/omero/log`
-    * :file:`%HOMEPATH%\\omero\log`
+    * :file:`%HOMEPATH%\\omero\\log`
 
 Note that setting :envvar:`OMERO_USERDIR` will also change the default location
 for the temporary files and the local sessions.

--- a/omero/sysadmins/troubleshooting.txt
+++ b/omero/sysadmins/troubleshooting.txt
@@ -333,8 +333,8 @@ more details. There are a few known possibilities:
 
 .. _client_performance:
 
-Performance issues with the clients
------------------------------------
+Troubleshooting performance issues with the clients
+---------------------------------------------------
 
 If you are having issues with slowdown and timeouts in the clients, there are
 three things to check:
@@ -356,9 +356,9 @@ the server makes heavier use of these folders than the clients, if the
 OMERO.server user directory is stored on a network drive then slow performance
 can occur.
 
-To resolve this, you can define an :envvar:`OMERO_TMPDIR` environment
-variable pointing to a temporary directory located on the local file system
-(e.g. :file:`/tmp/omero_tmp`).
+To resolve this, define the :envvar:`OMERO_TMPDIR` environment variable
+to point at a temporary directory located on the local file system
+(e.g. :file:`/tmp/omero`).
 
 Other issues
 ------------

--- a/omero/sysadmins/troubleshooting.txt
+++ b/omero/sysadmins/troubleshooting.txt
@@ -331,6 +331,8 @@ more details. There are a few known possibilities:
    (:doc:`UNIX instructions <unix/install-web>` or :doc:`Windows instructions 
    <windows/install-web>`).
 
+.. _client_performance:
+
 Performance issues with the clients
 -----------------------------------
 
@@ -344,14 +346,15 @@ three things to check:
 
 In the final case, two issues arise. Firstly, when performing some operations,
 the clients make use of temporary file storage and log directories, as
-described in the client configuration section of :doc:`system-requirements`.
+described in the :ref:`client_directories` section of
+:doc:`system-requirements`.
 If your home directory is stored on a network, possibly NFS mounted (or
 similar), then these temporary files are being written and read over the
 network which can slow access down. Secondly, the OMERO.server also accesses
-the ``$HOME/omero/tmp`` and ``$HOME/omero/log`` folders of the user the server
-process is running as. As the server makes heavier use of these folders than
-the clients, if the OMERO.server user's home(~) is stored on a network drive
-then slow performance can occur.
+the temporary and log folders of the user the server process is running as. As
+the server makes heavier use of these folders than the clients, if the
+OMERO.server user directory is stored on a network drive then slow performance
+can occur.
 
 To resolve this, you can define an :envvar:`OMERO_TMPDIR` environment
 variable pointing to a temporary directory located on the local file system

--- a/omero/sysadmins/troubleshooting.txt
+++ b/omero/sysadmins/troubleshooting.txt
@@ -353,9 +353,9 @@ process is running as. As the server makes heavier use of these folders than
 the clients, if the OMERO.server user's home(~) is stored on a network drive
 then slow performance can occur.
 
-To resolve this, you can define an :envvar:`OMERO_TEMPDIR` environment
+To resolve this, you can define an :envvar:`OMERO_TMPDIR` environment
 variable pointing to a temporary directory located on the local file system
-(e.g. `/tmp/`).
+(e.g. :file:`/tmp/omero_tmp`).
 
 Other issues
 ------------

--- a/omero/sysadmins/unix/server-installation.txt
+++ b/omero/sysadmins/unix/server-installation.txt
@@ -451,7 +451,7 @@ The following environment variables may be configured:
   This is not strictly required, but may be set for convenience to
   point to the OMERO server installation, and is used in this
   documentation as a shorthand for the installation path.
-:envvar:`OMERO_TEMPDIR`
+:envvar:`OMERO_TMPDIR`
   Directory used for temporary files. If the home directory of the
   user running the OMERO server is located on a slow filesystem, such
   as NFS, this may be used to store the temporary files on fast local

--- a/omero/sysadmins/windows/server-installation.txt
+++ b/omero/sysadmins/windows/server-installation.txt
@@ -336,7 +336,7 @@ The OMERO.server also accesses the :file:`omero\\tmp` and
 process**. As the server makes heavier use of these folders than the clients,
 if that user's home folder is stored on a network the server can be
 slowed down. To get around this for the OMERO.server you can define an
-``OMERO_TEMPDIR`` environment variable pointing to a temporary directory
+:envvar:`OMERO_TMPDIR` environment variable pointing to a temporary directory
 located on the local file system e.g. :file:`C:\\tmp\\`.
 
 Installation

--- a/omero/users/cli/overview.txt
+++ b/omero/users/cli/overview.txt
@@ -25,10 +25,16 @@ options.
 
 .. option:: command
 
-    Display the information on a particular command or option::
+    Display the information on a particular command::
 
-        $ bin/omero help debug       # debug is an option
         $ bin/omero help admin       # same as bin/omero admin -h
+
+    In addition to the |CLI| commands which can be listed using
+    :option:`--list`, :program:`omero help` can be used to retrieve information
+    about the `debug` and `env` options::
+
+        $ bin/omero help debug     # display help about debugging options
+        $ bin/omero help env       # display help about environment variables
 
 .. option:: --all
 

--- a/omero/users/cli/sessions.txt
+++ b/omero/users/cli/sessions.txt
@@ -117,14 +117,25 @@ Session keys can then be reused to switch between stored sessions using the
 Sessions directory
 ^^^^^^^^^^^^^^^^^^
 
-By default sessions are saved locally on disk under :file:`~/omero/sessions`.
+By default sessions are saved locally on disk under the OMERO user directory
+located at :file:`~/omero/sessions`.
 The location of the current session file can be retrieved using the
 :program:`omero sessions file` command::
 
     $ bin/omero sessions file
     /Users/ome/omero/sessions/localhost/root/aec828e1-79bf-41f3-91e6-a4ac76ff1cd5
 
-If you want to use a custom session directory, use the
+To customize the OMERO user directory, use the :envvar:`OMERO_USERDIR`
+environment variable::
+
+    $ export OMERO_USERDIR=/tmp/omero_dir
+    $ bin/omero login root@localhost:4064 -w omero
+    Created session bf7b9fee-5e3f-40fa-94a6-1e23ceb43dbd (root@localhost:4064). Idle timeout: 10.0 min. Current group: system
+    $ bin/omero sessions file
+ /tmp/omero_dir/omero/sessions/localhost/root/bf7b9fee-5e3f-40fa-94a6-1e23ceb43dbd
+    $ bin/omero logout
+
+If you want to use a custom directory for sessions exclusively, use the
 :envvar:`OMERO_SESSIONDIR` environment variable::
 
     $ export OMERO_SESSIONDIR=/tmp/my_sessions


### PR DESCRIPTION
This PR documents the feature additions in https://github.com/openmicroscopy/openmicroscopy/pull/3789

- use `OMERO_TMPDIR` rather than `OMERO_TEMPDIR` across the documentation
- mention `OMERO_USERDIR` (for alternate sessions storage directory) under `omero/cli/sessions`
- mention and describe `bin/omero help env` in the overview page
- add a table listing all the client directories and their environment variables