### PR TITLE
server-installation: fix Homebrew package names

### DIFF
--- a/omero/sysadmins/unix/server-installation.txt
+++ b/omero/sysadmins/unix/server-installation.txt
@@ -68,6 +68,11 @@ Fedora and Scientific Linux.
 
   where *package* is the package name to install.
 
+* For homebrew you need to enable the "python" and "science" taps::
+
+    $ brew tap homebrew/python
+    $ brew tap homebrew/science
+
 .. _server-requirements:
 
 Overview

--- a/omero/sysadmins/unix/server-installation.txt
+++ b/omero/sysadmins/unix/server-installation.txt
@@ -232,7 +232,7 @@ If possible, install the following packages:
       - python2.7 python-pil python-matplotlib python-numpy python-tables python-scipy
 
     * - Homebrew
-      - python python/pillow python/numpy python/matplotlib
+      - python pillow numpy matplotlib
 
     * - RedHat
       - python
@@ -290,7 +290,7 @@ If possible, install the following packages:
 +-----------+-------------------------------------------------------------+
 | Debian    | postgresql                                                  |
 +-----------+-------------------------------------------------------------+
-| Homebrew  | postgresql92                                                |
+| Homebrew  | postgresql                                                  |
 +-----------+-------------------------------------------------------------+
 | RedHat    | postgresql postgresql-server                                |
 +-----------+-------------------------------------------------------------+

--- a/omero/sysadmins/unix/server-installation.txt
+++ b/omero/sysadmins/unix/server-installation.txt
@@ -253,17 +253,17 @@ Ice
 
 If possible, install one of the following packages:
 
-+-----------+--------------------------+
-| System    | Package                  |
-+===========+==========================+
-| BSD Ports | devel/ice                |
-+-----------+--------------------------+
-| Debian    | zeroc-ice                |
-+-----------+--------------------------+
-| Homebrew  | ice                      |
-+-----------+--------------------------+
-| RedHat    | N/A (install ZeroC RPMs) |
-+-----------+--------------------------+
++-----------+---------------------------------+
+| System    | Package                         |
++===========+=================================+
+| BSD Ports | devel/ice                       |
++-----------+---------------------------------+
+| Debian    | zeroc-ice                       |
++-----------+---------------------------------+
+| Homebrew  | ice (with --with-python option) |
++-----------+---------------------------------+
+| RedHat    | N/A (install ZeroC RPMs)        |
++-----------+---------------------------------+
 
 The Ice version may vary, depending upon the distribution version you
 are using. The Ice versions in currently supported versions of Debian


### PR DESCRIPTION
The Python-based Homebrew package names do not have a `python/` prefix (anymore?). The `postgresql` package installs the latest, currently 9.4.