### PR TITLE
Add permissions advice to DropBox page

### DIFF
--- a/omero/sysadmins/dropbox.txt
+++ b/omero/sysadmins/dropbox.txt
@@ -95,7 +95,7 @@ Permissions
 
 Changing the permissions of a directory within DropBox may result in duplicate
 imports as a newly readable directory appears identical to a new directory. If
-directories need to be modfied it is recommended that the DropBox system is
+directories need to be modified it is recommended that the DropBox system is
 stopped and then restarted around any changes, as below.
 ::
 

--- a/omero/sysadmins/dropbox.txt
+++ b/omero/sysadmins/dropbox.txt
@@ -90,6 +90,11 @@ a given DropBox.
         being imported depending on the operating system and how the image
         was modified.
 
+    -   Once directories are created within DropBox or files are copied or
+        moved into DropBox they should not be moved, renamed or otherwise
+        changed. Images may be imported again or already imported images may
+        become unreadable.
+
 Permissions
 -----------
 

--- a/omero/sysadmins/dropbox.txt
+++ b/omero/sysadmins/dropbox.txt
@@ -90,6 +90,31 @@ a given DropBox.
         being imported depending on the operating system and how the image
         was modified.
 
+Permissions
+-----------
+
+Changing the permissions of a directory within DropBox may result in duplicate
+imports as a newly readable directory appears identical to a new directory. If
+directories need to be modfied it is recommended that the DropBox system is
+stopped and then restarted around any changes, as below.
+::
+
+    $ bin/omero admin server disable DropBox
+    $ bin/omero admin server stop DropBox
+    $ bin/omero admin server disable MonitorServer
+    $ bin/omero admin server stop MonitorServer
+
+    # make any directory changes
+
+    $ bin/omero admin server enable DropBox
+    $ bin/omero admin server enable MonitorServer
+
+.. note::
+
+    Any new files copied into DropBox during this disabled period will not
+    be detected and thus not imported.
+
+
 Log files
 ---------
 

--- a/omero/sysadmins/dropbox.txt
+++ b/omero/sysadmins/dropbox.txt
@@ -99,15 +99,15 @@ directories need to be modfied it is recommended that the DropBox system is
 stopped and then restarted around any changes, as below.
 ::
 
-    $ bin/omero admin server disable DropBox
-    $ bin/omero admin server stop DropBox
-    $ bin/omero admin server disable MonitorServer
-    $ bin/omero admin server stop MonitorServer
+    $ bin/omero admin ice server disable DropBox
+    $ bin/omero admin ice server stop DropBox
+    $ bin/omero admin ice server disable MonitorServer
+    $ bin/omero admin ice server stop MonitorServer
 
     # make any directory changes
 
-    $ bin/omero admin server enable DropBox
-    $ bin/omero admin server enable MonitorServer
+    $ bin/omero admin ice server enable MonitorServer
+    $ bin/omero admin ice server enable DropBox
 
 .. note::
 


### PR DESCRIPTION
This PR advises sysadmins on how best to handle permissions changes of DropBox directories. The restart sequence in this PR needs testing. With DropBox running (confirm via diagnostics) disable and then stop both servers. Confirm via diagnostics. Then restart both servers in the order given. Both should be active according to diagnostics. Confirm that the MonitorServer log ends with something like,
```
...
2015-05-26 18:51:20,200 INFO  [                fsserver.fsMonitorServer] (Dummy-3   ) Monitor id = d07d34dc-03cf-11e5-8d75-3c075416fb46 created. Proxy: DropBox.default -t -e 1.1 @ DropBox.omerofs.DropBox
2015-05-26 18:51:20,201 INFO  [                fsserver.fsMonitorServer] (Dummy-5   ) Monitor id = d07d34dc-03cf-11e5-8d75-3c075416fb46 started
```

**Note**: If the log ends with just,
```
...
2015-05-26 18:50:59,357 INFO  [                  fsserver.MonitorServer] (MainThread) Started OMERO.fs MonitorServer
```
then the server has failed to start fully.

See: https://github.com/openmicroscopy/openmicroscopy/pull/3842#issuecomment-105436794

--no-rebase