### PR TITLE
Signposting CLI docs better & minor tidy

### DIFF
--- a/omero/developers/cli/index.txt
+++ b/omero/developers/cli/index.txt
@@ -1,6 +1,5 @@
-OMERO Command Line Interface
-============================
-
+Command Line Interface as an OMERO development tool
+===================================================
 
 
 .. toctree::
@@ -21,9 +20,6 @@ OMERO Command Line Interface
 
 Help for any specific CLI command can be displayed using the :option:`-h`
 argument. See :ref:`cli_help` for more information.
-
-
-
 
 General notes
 -------------

--- a/omero/index.txt
+++ b/omero/index.txt
@@ -2,12 +2,17 @@
 OMERO |release| Documentation
 #############################
 
-The OMERO |release| documentation is divided into three parts.
+The OMERO |release| documentation is divided into three parts:
+
 :doc:`users/index` introduces the user-facing client applications and how to
-get started, as well as detailing where users can access further help and
-support. System administrators wanting to install an OMERO server can find
-instructions in the :doc:`sysadmins/index`. Finally, developers can find more
-specific and technical information about OMERO in the :doc:`developers/index`.
+get started, details the CLI client, and indicates where users can access
+further help and support.
+
+System administrators wanting to install and manage an OMERO server can find
+instructions in the :doc:`sysadmins/index`.
+
+Developers can find more specific and technical information about OMERO in the
+:doc:`developers/index`.
 
 .. only:: html
 

--- a/omero/sysadmins/cli/index.txt
+++ b/omero/sysadmins/cli/index.txt
@@ -1,5 +1,5 @@
-OMERO Command Line Interface
-============================
+Command Line Interface as an OMERO admin tool
+=============================================
 
 When first beginning to work with the OMERO server, the :omerocmd:`db`,
 :omerocmd:`config`, and :omerocmd:`admin` commands will be the first you will

--- a/omero/sysadmins/version-requirements.txt
+++ b/omero/sysadmins/version-requirements.txt
@@ -170,10 +170,10 @@ Components
 
   * [5.1] 6 deprecated, 7 recommended, 8 supported
   * [5.2] 6 dropped, 7 deprecated, 8 recommended
-  * Rationale: It will be 2 years this Februrary since the last Java 6
+  * Rationale: It will be 2 years this February since the last Java 6
     security update. Java 7 is supported on all supported operating
     systems above, and in most cases is the default Java version on
-    those systems (it’s now 8 on some). This was mentioned recently,
+    those systems (it is now 8 on some). This was mentioned recently,
     and also by the Fiji developers; 5.1 would be an opportune time to
     deprecate or preferably drop Java 6. Also note that we no longer
     actively test with a Java 6 JVM; all internal testing is on Java 7

--- a/omero/users/cli/index.txt
+++ b/omero/users/cli/index.txt
@@ -1,5 +1,5 @@
-OMERO Command Line Interface
-============================
+Command Line Interface as an OMERO client
+=========================================
 
 The |CLI| is a set of Python_ based system-administration, deployment and
 advanced user tools. Most of commands work remotely so that the |CLI| can be

--- a/omero/users/index.txt
+++ b/omero/users/index.txt
@@ -35,43 +35,6 @@ nested directory structure in the server repository. For more technical
 information, please refer to the :doc:`/developers/index`. You can read about
 the development of OMERO in the :doc:`history`.
 
-*********
-Resources
-*********
-
--   :omero_plone:`About OMERO <>` introduces OMERO for new users, while
-    the :omero_plone:`Features List <feature-list>` provides an overview
-    of the platform features with those that are new for OMERO 5.1
-    highlighted.
-
--   As OMERO is an open source project with developers and users in many
-    countries, :doc:`connecting to the community <community-resources>` can
-    provide you with a wealth of experience to draw on for help and advice.
-
--   ***NEW*** Our partners within the OME consortium are working on
-    integrating additional functions and modules with OMERO. See the
-    :partner_plone:`Partner Projects <>` page for details of the latest
-    extensions which could help OMERO meet your research needs more fully.
-
--   ***NEW*** You can also extend the functionality of OMERO using
-    OMERO.scripts, our version of plugins. Guides to some of the scripts which
-    ship with OMERO releases are already provided, but you can also check out
-    our :community_plone:`Script Sharing <scripts>` page to find extra ones.
-
--   ***NEW*** Workflow-based user assistance guides are provided on our
-    :help:`help website <>`. Extended OMERO.web and guides to other OMERO
-    applications will be coming here soon.
-
-
-.. toctree::
-    :maxdepth: 1
-    :hidden:
-
-    community-resources
-    whatsnew
-    history
-
-
 *************
 OMERO clients
 *************
@@ -82,6 +45,41 @@ OMERO clients
 
     clients-overview
     cli/index
+
+********************
+Additional resources
+********************
+
+-   :omero_plone:`About OMERO <>` introduces OMERO for new users, while
+    the :omero_plone:`Features List <feature-list>` provides an overview
+    of the platform features with those that are new for OMERO 5.1
+    highlighted.
+
+-   Workflow-based user assistance guides are provided on our
+    :help:`help website <>`.
+
+-   As OMERO is an open source project with developers and users in many
+    countries, :doc:`connecting to the community <community-resources>` can
+    provide you with a wealth of experience to draw on for help and advice.
+
+-   Our partners within the OME consortium are working on
+    integrating additional functions and modules with OMERO. See the
+    :partner_plone:`Partner Projects <>` page for details of the latest
+    extensions which could help OMERO meet your research needs more fully.
+
+-   You can also extend the functionality of OMERO using
+    OMERO.scripts, our version of plugins. Guides to some of the scripts which
+    ship with OMERO releases are already provided, but you can also check out
+    our :community_plone:`Script Sharing <scripts>` page to find extra ones.
+
+
+.. toctree::
+    :maxdepth: 1
+    :hidden:
+
+    community-resources
+    whatsnew
+    history
 
 ************************
 Quickstart server access


### PR DESCRIPTION
As I commented on Colin's last CLI user docs PR, these docs are quite buried so this tries to signpost them better now that they are more extensive. I've also tried to make the page titles clearer and have them distinguish between the doc sections because as @mtbc has pointed out before, if you use the search box on the website to find CLI docs, the results only give the page title, meaning you have to follow the link or note the full URL to see whether you're in the users, sysadmins or developer section docs.