### PR TITLE
Updating what's new pages for point release stuff

### DIFF
--- a/omero/developers/Model/EveryObject.txt
+++ b/omero/developers/Model/EveryObject.txt
@@ -1,5 +1,5 @@
-Every OMERO model object
-========================
+Glossary of all OMERO Model Objects
+===================================
 
 Overview
 --------

--- a/omero/developers/Model/Units.txt
+++ b/omero/developers/Model/Units.txt
@@ -136,6 +136,8 @@ as defined in the SI specification, for example, use the
     Length l1 = ...; // As above
     l1.getSymbol(); // Returns "µm"
 
+.. _querying-units:
+
 Querying units
 --------------
 

--- a/omero/developers/whatsnew.txt
+++ b/omero/developers/whatsnew.txt
@@ -1,11 +1,11 @@
-What's new for OMERO 5.1
-========================
+What's new for OMERO 5.1 for developers
+=======================================
 
-- :doc:`/sysadmins/version-requirements` provides extensive details about
-  which operating systems and dependency versions we will be supporting for
-  the life of 5.1 and the likely changes to these for the next major release
-  (currently slated to be 5.2). Most notably for development purposes, we are
-  deprecating support for Java 1.6 and Python 2.6.
+- The :doc:`/sysadmins/version-requirements` section provides extensive
+  details about which operating systems and dependency versions we will be
+  supporting for the life of 5.1 and the likely changes to these for the next
+  major release (currently planned to be 5.2). Most notably for development
+  purposes, we are deprecating support for Java 1.6 and Python 2.6.
 - :doc:`Model/Units` introduces the new Units-types which are available
   for use from :doc:`Model Objects <Model/EveryObject>` (note that this
   documentation has been expanded since the release of 5.1.2 and is still a
@@ -27,8 +27,8 @@ OMERO.web
 ^^^^^^^^^
 
 There have been many updates to this client for 5.1. See the
-:ref:`web-breaking-changes` section on the :doc:`/sysadmins/whatsnew` for
-sysadmins page for further details.
+:ref:`web-breaking-changes` section on the :doc:`/sysadmins/whatsnew` page for
+further details.
 
 OMERO.web template and view writers need to use the ``@render_response()``
 decorator, see :ref:`render-response` for more details.

--- a/omero/developers/whatsnew.txt
+++ b/omero/developers/whatsnew.txt
@@ -73,3 +73,19 @@ ImportContainer
 Changes to ImportContainer will break any listeners implemented by external
 developers.
 
+Units
+^^^^^
+
+A number of Objects formerly of numerical type are now unit quantities. As a
+result, code working with these types will no longer compile and queries of
+these types will now return different values. For example, as explained in
+:ref:`querying-units`, to return the floating point number using::
+
+   select planeInfo.exposureTime from PlaneInfo planeInfo ...
+
+you now need to add ``.value`` as follows::
+
+   select planeInfo.exposureTime.value from PlaneInfo planeInfo ...
+
+and you also need the enum to go along with it.
+

--- a/omero/developers/whatsnew.txt
+++ b/omero/developers/whatsnew.txt
@@ -7,7 +7,9 @@ What's new for OMERO 5.1
   (currently slated to be 5.2). Most notably for development purposes, we are
   deprecating support for Java 1.6 and Python 2.6.
 - :doc:`Model/Units` introduces the new Units-types which are available
-  for use from all model objects.
+  for use from :doc:`Model Objects <Model/EveryObject>` (note that this
+  documentation has been expanded since the release of 5.1.2 and is still a
+  work in progress).
 - Similarly, :doc:`Model/KeyValuePairs` introduces the new concept of a
   "map" type, which consists of ordered lists of key-value pairs.
 - :doc:`Server/ObjectGraphs` explains how the new graph operations of

--- a/omero/sysadmins/index.txt
+++ b/omero/sysadmins/index.txt
@@ -59,6 +59,8 @@ performance and security.
     omero-home-prefix
     config
 
+.. _index-public-data:
+
 *************************************
 Optimizing OMERO as a Data Repository
 *************************************

--- a/omero/sysadmins/whatsnew.txt
+++ b/omero/sysadmins/whatsnew.txt
@@ -80,8 +80,8 @@ OMERO permissions system
 ------------------------
 
 Read-Write groups are now (as of OMERO version 5.1.2) supported in the
-clients. Existing groups can be promoted to this permissions level, which
-essentially allows all members to act as if they co-own the data except for
-the ability to move it between groups, via your usual OMERO admin tool. See
-:doc:`server-permissions` for more details.
+clients. This group type essentially allows all members to act as if they
+co-own the data except for the ability to move it between groups. Existing
+groups can be promoted to this permissions level via your usual OMERO admin
+tool. See :doc:`server-permissions` for more details.
 

--- a/omero/sysadmins/whatsnew.txt
+++ b/omero/sysadmins/whatsnew.txt
@@ -13,7 +13,10 @@ What's new for OMERO 5.1
   configuration property is *removed* in OMERO 5.2.
 
 - The server download policy can now be configured to restrict users' ability
-  to download the original data e.g. by user or by data type.
+  to download the original data e.g. by user or by data type. This is one of
+  the features we have introduced to help support using OMERO for data
+  publication. More information about how to configure your server for this
+  purpose is available in the updated :ref:`index-public-data` section.
 
 
 Database
@@ -72,3 +75,13 @@ OMERO.mail
 A new :doc:`additional feature <advanced-install>` has been added. :doc:`mail`
 allows you to configure the server to email users, for example to alert group
 owners to broken links in OMERO.web.
+
+OMERO permissions system
+------------------------
+
+Read-Write groups are now (as of OMERO version 5.1.2) supported in the
+clients. Existing groups can be promoted to this permissions level, which
+essentially allows all members to act as if they co-own the data except for
+the ability to move it between groups, via your usual OMERO admin tool. See
+:doc:`server-permissions` for more details.
+

--- a/omero/sysadmins/whatsnew.txt
+++ b/omero/sysadmins/whatsnew.txt
@@ -1,10 +1,10 @@
-What's new for OMERO 5.1
-========================
+What's new for OMERO 5.1 for sysadmins
+======================================
 
-- :doc:`version-requirements` provides extensive details about which operating
-  systems and dependency versions we will be supporting for the life of 5.1
-  and the likely changes to these for the next major release (currently slated
-  to be 5.2).
+- The :doc:`version-requirements` section provides extensive details about
+  which operating systems and dependency versions we will be supporting for
+  the life of 5.1 and the likely changes to these for the next major release
+  (currently slated to be 5.2).
 
 - A new configuration property :property:`omero.graphs.wrap` allows
   switching back to the old server code for moving and deleting data. If

--- a/omero/sysadmins/whatsnew.txt
+++ b/omero/sysadmins/whatsnew.txt
@@ -4,7 +4,7 @@ What's new for OMERO 5.1 for sysadmins
 - The :doc:`version-requirements` section provides extensive details about
   which operating systems and dependency versions we will be supporting for
   the life of 5.1 and the likely changes to these for the next major release
-  (currently slated to be 5.2).
+  (currently planned to be 5.2).
 
 - A new configuration property :property:`omero.graphs.wrap` allows
   switching back to the old server code for moving and deleting data. If

--- a/omero/users/whatsnew.txt
+++ b/omero/users/whatsnew.txt
@@ -1,5 +1,5 @@
-What's new for OMERO 5.1
-========================
+What's new for OMERO 5.1 for users
+==================================
 
 Updates and new features for OMERO 5.1 include:
 

--- a/omero/users/whatsnew.txt
+++ b/omero/users/whatsnew.txt
@@ -20,3 +20,6 @@ Updates and new features for OMERO 5.1 include:
 See the updated user guides for :help:`managing data <managing-data.html>`,
 :help:`viewing data <viewing-data.html>` and
 :help:`using ImageJ with OMERO <imagej.html>` for further information.
+
+OMERO 5.1.2 introduced support for Read-Write groups - see the updated
+:help:`sharing data <sharing-data.html>` guide for details.


### PR DESCRIPTION
Promoting Read-Write groups and updated Units and Publishing docs in the what's new pages.

@joshmoore if you want to submit a PR against this to add a **brief** summary of the breaking changes re: units to the developer page, go ahead. Otherwise, it can be added when you and Mark get the queries info documented.