### PR TITLE
Fixing redirecting OpenGL Apple dev link

### DIFF
--- a/omero/sysadmins/version-requirements.txt
+++ b/omero/sysadmins/version-requirements.txt
@@ -1792,7 +1792,7 @@ Distribution support
       - 
       - 
       - 
-      - `Ref <https://developer.apple.com/graphicsimaging/opengl/capabilities/index.html>`__
+      - `Ref <https://developer.apple.com/opengl/capabilities/index.html>`__
       - 
 
 \*


### PR DESCRIPTION
https://developer.apple.com/graphicsimaging/opengl/capabilities/index.html link in the doc was upsetting the Jenkins build because it is being redirected to https://developer.apple.com/opengl/capabilities/index.html