### PR TITLE
Updating Upgrade Check page

### DIFF
--- a/omero/sysadmins/UpgradeCheck.txt
+++ b/omero/sysadmins/UpgradeCheck.txt
@@ -6,7 +6,7 @@ On each startup the OMERO server checks for available upgrades via the
 <components/common/src/ome/system/UpgradeCheck.java>`.
 An HTTP GET call is made to the URL configured in
 :source:`etc/omero.properties` as ``omero.upgrades.url``, currently
-`http://upgrade.openmicroscopy.org.uk` by default (note that viewing that link
+\http://upgrade.openmicroscopy.org.uk by default (note that viewing that link
 in your browser will redirect you to this page).
 
 .. note:: If you have been redirected here by clicking on a link to 

--- a/omero/sysadmins/UpgradeCheck.txt
+++ b/omero/sysadmins/UpgradeCheck.txt
@@ -76,28 +76,6 @@ code, it is necessary to have ``common.jar`` on your classpath. Then,
 will connect to the server and check your current version against the
 latest release.
 
-Updating the registry version after a release
----------------------------------------------
-
-::
-
-    $ psql -h localhost -U postgres feedback
-
-    feedback=# select * from registry_version;
-     id |  version   
-    ----+------------
-      1 | Beta-4.2.2
-    (1 row)
-
-    feedback=# select now();
-                  now              
-    -------------------------------
-     2011-06-27 16:01:30.749654+01
-    (1 row)
-
-    feedback=# update registry_version set version = 'Beta-4.3.0' where id = 1;
-    UPDATE 1
-
 .. seealso:: 
 
 

--- a/omero/sysadmins/UpgradeCheck.txt
+++ b/omero/sysadmins/UpgradeCheck.txt
@@ -6,7 +6,7 @@ On each startup the OMERO server checks for available upgrades via the
 <components/common/src/ome/system/UpgradeCheck.java>`.
 An HTTP GET call is made to the URL configured in
 :source:`etc/omero.properties` as ``omero.upgrades.url``, currently
-http://upgrade.openmicroscopy.org.uk by default (note that viewing that link
+`http://upgrade.openmicroscopy.org.uk` by default (note that viewing that link
 in your browser will redirect you to this page).
 
 .. note:: If you have been redirected here by clicking on a link to 


### PR DESCRIPTION
Removing an internal section reported by Kenny (see https://trello.com/c/PAXHlAne/344-ome-registry-version-update-in-public-docs) and also stopping the link to the upgrade URL which redirects to version 4 docs being live after the discussion in devteam the other day (I realise the link needs updating in the qa repo and this is on the list somewhere, but there is no really no need to encourage people reading the docs to click on the link by having it live in the docs page, especially as once it is fixed, it will redirect you to the same page you are already on!).