### PR TITLE
Hyperlink fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -391,7 +391,7 @@ more than once, e.g.::
     
     ...
     
-    .. _Python.org: http://python.org
+    .. _Python.org: http://www.python.org
     
 If a hyperlink appears only once, please use anonymous, "one-off" hyperlinks
 (two underscores)::
@@ -449,7 +449,7 @@ The table below lists targets for common hyperlinks.
 =========================== ==============================================
 Target name                 Link
 =========================== ==============================================
-Python                      http://python.org
+Python                      http://www.python.org
 Matplotlib                  http://matplotlib.org/
 Pillow                      http://pillow.readthedocs.org
 Hibernate                   http://www.hibernate.org

--- a/README.rst
+++ b/README.rst
@@ -453,8 +453,8 @@ Python                      http://python.org
 Matplotlib                  http://matplotlib.org/
 Pillow                      http://pillow.readthedocs.org
 Hibernate                   http://www.hibernate.org
-ZeroC                       http://www.zeroc.com
-Ice                         http://www.zeroc.com
+ZeroC                       https://zeroc.com
+Ice                         https://zeroc.com
 Jenkins                     http://jenkins-ci.org
 roadmap                     https://trac.openmicroscopy.org.uk/ome/roadmap
 Open Microscopy Environment http://www.openmicroscopy.org/site

--- a/common/conf.py
+++ b/common/conf.py
@@ -190,7 +190,7 @@ rst_epilog = """
 .. _Glencoe Software, Inc.: http://www.glencoesoftware.com/
 .. _Pillow: http://pillow.readthedocs.org
 .. _Matplotlib: http://matplotlib.org/
-.. _Python: http://python.org
+.. _Python: http://www.python.org
 .. _Libjpeg: http://libjpeg.sourceforge.net/
 
 .. |SSH| replace:: :abbr:`SSH (Secure Shell)`

--- a/common/conf.py
+++ b/common/conf.py
@@ -172,8 +172,9 @@ extlinks = {
     'help' : (help_root + '/%s', ''),
     # Miscellaneous links
     'snapshot' : (cvs_root + '/snapshots/%s', ''),
-    'zeroc' : ('http://zeroc.com/%s', ''),
-    'zerocdoc' : ('http://doc.zeroc.com/%s', ''),
+    'zeroc' : ('https://zeroc.com/%s', ''),
+    'zerocforum' : ('https://forums.zeroc.com/forum/%s', ''),
+    'zerocdoc' : ('https://doc.zeroc.com/%s', ''),
     'djangodoc' : ('https://docs.djangoproject.com/en/1.6/%s', ''),
     'doi' : ('http://dx.doi.org/%s', ''),
     'pypi': ('https://pypi.python.org/pypi/%s', '')
@@ -181,8 +182,8 @@ extlinks = {
 
 rst_epilog = """
 .. _Hibernate: http://www.hibernate.org
-.. _ZeroC: http://www.zeroc.com
-.. _Ice: http://www.zeroc.com
+.. _ZeroC: https://zeroc.com
+.. _Ice: https://zeroc.com
 .. _Jenkins: http://jenkins-ci.org
 .. _roadmap: https://trac.openmicroscopy.org.uk/ome/roadmap
 .. _Open Microscopy Environment: http://www.openmicroscopy.org/site

--- a/omero/developers/build-system.txt
+++ b/omero/developers/build-system.txt
@@ -146,7 +146,7 @@ resolves the following locations in order:
    build system in the `install` step of the lifecycle
 #. the local dependency repository under :file:`lib/repository`
 #. the local Maven cache under :file:`~/.m2/repository`
-#. the `Maven central repository <http://search.maven.org/>`_
+#. the `Maven central repository <http://central.sonatype.org>`_
 #. the `OME artifactory <http://artifacts.openmicroscopy.org>`_
 
 Bio-Formats dependencies are resolved using a specific

--- a/omero/sysadmins/troubleshooting.txt
+++ b/omero/sysadmins/troubleshooting.txt
@@ -122,7 +122,7 @@ Server fails to start
    need to specify which network interface to use.
    :omerocmd:`config set Ice.Default.Host 127.0.0.1`, for example, would
    force OMERO to only listen on localhost. See
-   http://doc.zeroc.com/display/Ice/Proxy+and+Endpoint+Syntax#ProxyandEndpointSyntax-address
+   :zerocdoc:`Proxy and Endpoint Syntax  <display/Ice/Proxy+and+Endpoint+Syntax#ProxyandEndpointSyntax-address>`
    for more information.
 
 .. _remote_clients_cannot_connect:

--- a/omero/sysadmins/version-requirements.txt
+++ b/omero/sysadmins/version-requirements.txt
@@ -1386,7 +1386,7 @@ correctness, and should be preferred where possible.
 Ice
 ---
 
-`General overview <http://www.zeroc.com/download.html>`__
+:zeroc:`General overview <download.html>`
 
 .. tabularcolumns:: |l|l|l|l|l|l|l|
 
@@ -1406,24 +1406,24 @@ Ice
       - Dropped
       - Dropped
       - Dropped
-      - `Ice 3.3 <http://www.zeroc.com/forums/announcements/3749-ice-3-3-released.html>`__
-        `Ice 3.3.1 <http://www.zeroc.com/forums/announcements/4248-ice-3-3-1-released.html>`__
+      - :zerocforum:`Ice 3.3 <announcements/3749-ice-3-3-released.html>`
+        :zerocforum:`Ice 3.3.1 <announcements/4248-ice-3-3-1-released.html>`
     * - 3.4
       - from Mar 2010
       - to Jun 2011
       - Supported
       - Deprecated
       - Dropped
-      - `Ice 3.4 <http://www.zeroc.com/forums/announcements/4821-ice-3-4-released.html>`__
-        `Ice 3.4.2 <http://www.zeroc.com/forums/announcements/5406-ice-3-4-2-released.html>`__
+      - :zerocforum:`Ice 3.4 <announcements/4821-ice-3-4-released.html>`
+        :zerocforum:`Ice 3.4.2 <announcements/5406-ice-3-4-2-released.html>`
     * - 3.5
       - from Mar 2013
       - to Oct 2013
       - Recommended
       - Recommended
       - Deprecated
-      - `Ice 3.5 <http://www.zeroc.com/forums/announcements/5943-ice-3-5-0-released.html>`__
-        `Ice 3.5.1 <http://www.zeroc.com/forums/announcements/6118-ice-3-5-1-released.html>`__
+      - :zerocforum:`Ice 3.5 <announcements/5943-ice-3-5-0-released.html>`
+        :zerocforum:`Ice 3.5.1 <announcements/6118-ice-3-5-1-released.html>`
     * - 3.6
       - TBA (in beta)
       - TBA


### PR DESCRIPTION
Should fix https://ci.openmicroscopy.org/job/OMERO-5.1-merge-docs/ which fails on search.maven.org. Also fixes the ZeroC and Python default hyperlinks/extlinks to prevent unnecessary redirects in the link checker.