### PR TITLE
do not show settings.env header comment on walkthrough page

### DIFF
--- a/omero/sysadmins/unix/server-linux-walkthrough.txt
+++ b/omero/sysadmins/unix/server-linux-walkthrough.txt
@@ -18,6 +18,7 @@ been defined as environment variables. When following this walkthrough you can
 either use your own values, or alternatively source the following file:
 
 .. literalinclude:: walkthrough/settings.env
+   :start-after: Substitute
 
 :download:`settings.env <walkthrough/settings.env>`
 

--- a/omero/sysadmins/unix/walkthrough/settings.env
+++ b/omero/sysadmins/unix/walkthrough/settings.env
@@ -1,3 +1,6 @@
+# This file is just an example that you may use as a template.
+# Substitute the variables' values with those appropriate for your server.
+
 OMERO_DB_USER=db_user
 OMERO_DB_PASS=db_password
 OMERO_DB_NAME=omero_database


### PR DESCRIPTION
Omits the header comment introduced by https://github.com/ome/omero-install/pull/35 from the literal include on http://www.openmicroscopy.org/site/support/omero5.1-staging/sysadmins/unix/server-linux-walkthrough.html.