### PR TITLE
Fixing formatting on omero.mail page

### DIFF
--- a/omero/sysadmins/mail.txt
+++ b/omero/sysadmins/mail.txt
@@ -79,13 +79,14 @@ Other key properties
 Along with :property:`omero.mail.host`, a few general connection properties may
 be needed for your particular SMTP server:
 
- * :property:`omero.mail.port`
- * :property:`omero.mail.smtp.auth`
- * :property:`omero.mail.smtp.starttls.enable`
+* :property:`omero.mail.port`
+* :property:`omero.mail.smtp.auth`
+* :property:`omero.mail.smtp.starttls.enable`
+* :property:`omero.mail.from`
 
-:property:`omero.mail.from` may not be necessary, though some servers may require
-it to match username. Regardless, it can be useful to inform users more clearly
-of who is getting in touch with them.
+.. note:: :property:`omero.mail.from` may not be necessary but some
+    servers may require it to match username. Regardless, it can be useful to
+    inform users more clearly of who is getting in touch with them.
 
 All properties can be found under the :ref:`mail_configuration` section of
 :doc:`config`.


### PR DESCRIPTION
Replaces #1241
Should get rid of the purple highlighting in plone and also clarifies the mail.from property