### PR TITLE
Update all Trac links to use HTTPS URL ending with .org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -456,7 +456,7 @@ Hibernate                   http://www.hibernate.org
 ZeroC                       https://zeroc.com
 Ice                         https://zeroc.com
 Jenkins                     http://jenkins-ci.org
-roadmap                     https://trac.openmicroscopy.org.uk/ome/roadmap
+roadmap                     https://trac.openmicroscopy.org/ome/roadmap
 Open Microscopy Environment http://www.openmicroscopy.org/site
 Glencoe Software, Inc.      http://www.glencoesoftware.com/
 =========================== ==============================================

--- a/common/conf.py
+++ b/common/conf.py
@@ -129,7 +129,7 @@ jenkins_view_root = jenkins_root + '/view'
 
 # Variables used to define other extlinks
 cvs_root = 'http://cvs.openmicroscopy.org.uk'
-trac_root = 'http://trac.openmicroscopy.org.uk/ome'
+trac_root = 'https://trac.openmicroscopy.org/ome'
 oo_root = 'http://www.openmicroscopy.org'
 oo_site_root = oo_root + '/site'
 lists_root = 'http://lists.openmicroscopy.org.uk'
@@ -185,7 +185,7 @@ rst_epilog = """
 .. _ZeroC: https://zeroc.com
 .. _Ice: https://zeroc.com
 .. _Jenkins: http://jenkins-ci.org
-.. _roadmap: https://trac.openmicroscopy.org.uk/ome/roadmap
+.. _roadmap: https://trac.openmicroscopy.org/ome/roadmap
 .. _Open Microscopy Environment: http://www.openmicroscopy.org/site
 .. _Glencoe Software, Inc.: http://www.glencoesoftware.com/
 .. _Pillow: http://pillow.readthedocs.org

--- a/contributing/conf.py
+++ b/contributing/conf.py
@@ -95,4 +95,4 @@ linkcheck_ignore += [r'http://localhost:\d+/?', 'http://localhost/',
     r'.*[.]?example\.com/.*',
     r'^https?://www\.openmicroscopy\.org/site/support/faq.*',
     r'^https://spreadsheets.google.com/.*',
-    r'^http://trac.openmicroscopy.org.uk/ome/admin/.*']
+    r'^http://trac.openmicroscopy.org/ome/admin/.*']

--- a/contributing/team-communication.txt
+++ b/contributing/team-communication.txt
@@ -53,7 +53,7 @@ developer documentation, Jenkins, and GitHub.
 Trac
 ----
 
-The Trac server is available under https://trac.openmicroscopy.org.uk/ome and
+The Trac server is available under https://trac.openmicroscopy.org/ome and
 uses your LDAP account for authentication. Trac is used to record all tickets
 and allows hierarchical groups of “tasks” in “requirements” and “stories”
 (functionality provided by a `plugin for Trac named “Agilo”

--- a/formats/developers/index.txt
+++ b/formats/developers/index.txt
@@ -35,7 +35,7 @@ Process workflow:
    we are trying to keep schema changes in step with new versions of
    OMERO so they are released simultaneous. This is why the tickets for
    OME-XML development have been moved to the main `OME
-   Trac <http://trac.openmicroscopy.org.uk/ome>`_
+   Trac <https://trac.openmicroscopy.org/ome>`_
 
 For more information about the OME team workflows, see the
 :devs_doc:`Contributing Developer <index.html>` documentation.

--- a/formats/ome-xml/index.txt
+++ b/formats/ome-xml/index.txt
@@ -110,7 +110,7 @@ Ongoing development
 -------------------
 
 The ongoing development of the OME-XML data model can be tracked on
-http://trac.openmicroscopy.org.uk/ome.
+https://trac.openmicroscopy.org/ome.
 
 Users can also add work tickets to the system detailing any changes they
 feel should be made.


### PR DESCRIPTION
With the recent switch to trac.openmicroscopy.org as the default domain, this
should avoid unnecessary redirects while checking URLs.