### PR TITLE
Document CI job changes post develop/dev_5_1 split

### DIFF
--- a/contributing/ci-bio-formats.txt
+++ b/contributing/ci-bio-formats.txt
@@ -7,131 +7,52 @@ All jobs are listed under the :jenkinsview:`Bio-Formats` view tab of Jenkins.
 	:header-rows: 1
 
 	-	* Job task
-		* 5.0.x series
 		* 5.1.x series
+		* 5.2.x series
 
 	-	* Builds the latest Bio-Formats artifacts
-		* :term:`BIOFORMATS-5.0-latest`
 		* :term:`BIOFORMATS-5.1-latest`
+		* 
 
 	-	* Publishes the latest Bio-Formats to the OME artifactory
-		* :term:`BIOFORMATS-5.0-latest-maven`
 		* :term:`BIOFORMATS-5.1-latest-maven`
+		* 
 
 	-	* Builds the latest native C++ implementation for Bio-Formats
-		*
 		* :term:`BIOFORMATS-5.1-latest-cpp`
+		* 
 
 	-	* Runs the daily Bio-Formats merge jobs
-		* :term:`BIOFORMATS-5.0-merge-daily`
 		* :term:`BIOFORMATS-5.1-merge-daily`
+		* 
 
 	-	* Merges the PRs
-		*
 		* :term:`BIOFORMATS-5.1-merge-push`
+		* 
 
 	-	* Builds the merge Bio-Formats artifacts
-		* :term:`BIOFORMATS-5.0-merge-build`
 		* :term:`BIOFORMATS-5.1-merge-build`
+		* 
 
 	-	* Builds the merge native C++ implementation for Bio-Formats
-		*
 		* :term:`BIOFORMATS-5.1-merge-cpp`
+		*
 
 	-	* Runs the MATLAB tests
-		* :term:`BIOFORMATS-5.0-merge-matlab`
 		* :term:`BIOFORMATS-5.1-merge-matlab`
+		* 
 
 	-	* Runs automated tests against the full repository on squig
-		* :term:`BIOFORMATS-5.0-merge-full-repository`
 		* :term:`BIOFORMATS-5.1-merge-full-repository`
+		* 
 
 	-	* Runs automated tests against test_images_good on squig
-		* :term:`BIOFORMATS-5.0-merge-test_images_good`
 		* :term:`BIOFORMATS-5.1-merge-test_images_good`
+		* 
 
 	-	* Runs openBytes performance test
-		* :term:`BIOFORMATS-5.0-merge-openbytes-performance`
 		* :term:`BIOFORMATS-5.1-merge-openbytes-performance`
-
-5.0.x series
-^^^^^^^^^^^^
-
-The branch for the 5.0.x series of Bio-Formats is dev_5_0.
-
-.. glossary::
-
-	:jenkinsjob:`BIOFORMATS-5.0-latest`
-
-		This job builds the latest dev_5_0 branch of Bio-Formats
-
-		#. |buildBF|
-		#. |testBF|
-
-	:jenkinsjob:`BIOFORMATS-5.0-latest-maven`
-
-		This job publishes the dev_5_0 branch of Bio-Formats to the
-		OME artifactory at http://artifacts.openmicroscopy.org/
-
-	:jenkinsjob:`BIOFORMATS-5.0-merge-daily`
-
-		This job runs the daily Bio-Formats jobs used for reviewing
-		the PRs opened against the develop branch of Bio-Formats by running
-		basic unit tests, checking for open file handles, and checking for
-		regressions across a representative subset of the data repository
-
-		#. Triggers :term:`OME-5.0-merge-push`
-		#. Triggers :term:`BIOFORMATS-5.0-merge-build`,
-		   :term:`BIOFORMATS-5.0-merge-docs`,
-		   :term:`BIOFORMATS-5.0-merge-test_images_good` and
-		   BIOFORMATS-5.0-merge-performance
-
-		See :jenkinsjob:`the build graph <BIOFORMATS-5.0-merge-daily/lastSuccessfulBuild/BuildGraph>`
-
-	:jenkinsjob:`BIOFORMATS-5.0-merge-build`
-
-		This job builds the merge artifacts of Bio-Formats
-
-		#. Checks out the merge/develop/latest branch of the
-		   snoopycrimecop fork of bioformats.git_
-		#. |buildBF|
-		#. |fulltestBF|
-		#. Triggers :term:`BIOFORMATS-5.0-merge-matlab`
-
-	:jenkinsjob:`BIOFORMATS-5.0-merge-matlab`
-
-		This job runs the MATLAB tests of Bio-Formats
-
-		#. Collects the MATLAB artifacts and unit tests from
-		   :term:`BIOFORMATS-5.0-merge-daily`
-		#. Runs the MATLAB unit tests under
-		   :file:`components/bio-formats/test/matlab` and collect the results
-
-	:jenkinsjob:`BIOFORMATS-5.0-merge-full-repository`
-
-		This job runs automated tests against the full repository on squig
-
-		#. |merge|
-		#. Runs automated tests against :file:`/ome/data_repo/from_skyking/`
-
-	:jenkinsjob:`BIOFORMATS-5.0-merge-test_images_good`
-
-		This job runs automated tests against the test_images_good subset on
-		squig
-
-		#. |merge|
-		#. Runs automated tests against
-		   :file:`/ome/data_repo/test_images_good/`
-
-	:jenkinsjob:`BIOFORMATS-5.0-merge-openbytes-performance`
-
-		This job runs openBytes performance tests against directories on squig
-
-		#. |merge|
-		#. Runs ``loci.tests.testng.OmeroOpenBytesTest`` and
-		   ``loci.tests.testng.OpenBytesPerformanceTest`` tests against
-		   directories specified by
-		   :file:`BIOFORMATS-openbytes-performance.txt`
+		* 
 
 5.1.x series
 ^^^^^^^^^^^^
@@ -246,11 +167,11 @@ Jenkins.
 .. glossary::
 
 
-	:jenkinsjob:`BIOFORMATS-5.1-merge-full-repository`
+	:jenkinsjob:`BIOFORMATS-5.1-breaking-full-repository`
 
 		This job runs automated tests against the full repository on squig
 
-		#. Checks out the merge/develop/breaking branch of the
+		#. Checks out the develop/breaking/trigger branch of the
 		   snoopycrimecop fork of bioformats.git_
 		#. Run automated tests against :file:`/ome/data_repo/from_skyking/`
 

--- a/contributing/ci-docs.txt
+++ b/contributing/ci-docs.txt
@@ -107,7 +107,7 @@ dev_5_1.
 
 	:jenkinsjob:`OMERO-5.1-latest-docs`
 
-		This job is used to build the develop branch of the OMERO
+		This job is used to build the dev_5_1 branch of the OMERO
 		documentation and publish the official documentation for the 5.1.x
 		release of OMERO
 
@@ -119,7 +119,7 @@ dev_5_1.
 
 	:jenkinsjob:`BIOFORMATS-5.1-latest-docs`
 
-		This job is used to build the develop branch of the Bio-Formats
+		This job is used to build the dev_5_1 branch of the Bio-Formats
 		documentation and publish the official documentation for the 5.1.x
 		release of Bio-Formats
 
@@ -131,7 +131,7 @@ dev_5_1.
 
 	:jenkinsjob:`OMERO-5.1-merge-docs`
 
-		This job is used to review the PRs opened against the develop branch
+		This job is used to review the PRs opened against the dev_5_1 branch
 		of the OMERO documentation
 
 		#. |merge|
@@ -142,7 +142,7 @@ dev_5_1.
 
 	:jenkinsjob:`BIOFORMATS-5.1-merge-docs`
 
-		This job is used to review the PRs opened against the develop branch
+		This job is used to review the PRs opened against the dev_5_1 branch
 		of the Bio-Formats documentation
 
 		#. |merge|
@@ -154,7 +154,7 @@ dev_5_1.
 	:jenkinsjob:`BIOFORMATS-5.1-latest-docs-autogen`
 
 		This job is used to build the latest auto-generated formats and
-		readers pages for the develop branch of the Bio-Formats documentation
+		readers pages for the dev_5_1 branch of the Bio-Formats documentation
 
 		#. Builds Bio-Formats using ``ant clean jars``
 		#. Runs the auto-generation using ``ant gen-format-pages gen-original-meta-support gen-meta-support gen-meta-support``
@@ -167,9 +167,9 @@ dev_5_1.
 	:jenkinsjob:`BIOFORMATS-5.1-merge-docs-autogen`
 
 		This job is used to build the merge auto-generated pages for the
-		develop branch of the Bio-Formats documentation
+		dev_5_1 branch of the Bio-Formats documentation
 
-		#. Checks out the merge/develop/latest branch of the
+		#. Checks out the dev_5_1/merge/daily branch of the
 		   snoopycrimecop fork of bioformats.git_
 		#. Builds Bio-Formats using ``ant clean jars``
 		#. Runs the auto-generation using ``ant gen-format-pages gen-original-meta-support gen-meta-support gen-meta-support``
@@ -181,9 +181,9 @@ dev_5_1.
 	:jenkinsjob:`OMERO-5.1-latest-docs-autogen`
 
 		This job is used to build the latest auto-generated pages for the
-		develop branch of the OMERO documentation
+		dev_5_1 branch of the OMERO documentation
 
-		#. Checks out the develop branch of ome-documentation.git_
+		#. Checks out the dev_5_1 branch of ome-documentation.git_
 		#. Downloads the OMERO.server and OMERO.clients from
 		   :term:`OMERO-5.1-latest`
 		#. Runs the :file:`omero/autogen_docs` autogeneration script
@@ -193,9 +193,9 @@ dev_5_1.
 	:jenkinsjob:`OMERO-5.1-merge-docs-autogen`
 
 		This job is used to review the component auto-generation for the
-		develop branch of the OMERO documentation
+		dev_5_1 branch of the OMERO documentation
 
-		#. Checks out the merge/develop/latest branch of the
+		#. Checks out the dev_5_1/merge/daily branch of the
 		   snoopycrimecop fork of ome-documentation.git_
 		#. Downloads the OMERO.server and OMERO.clients from
 		   :term:`OMERO-5.1-merge-build`
@@ -250,7 +250,7 @@ develop.
 		This job is used to review the component auto-generation for the
 		develop branch of the OMERO documentation
 
-		#. Checks out the merge/develop/latest branch of the
+		#. Checks out the develop/merge/daily branch of the
 		   snoopycrimecop fork of ome-documentation.git_
 		#. Downloads the OMERO.server and OMERO.clients from
 		   :term:`OMERO-5.1-merge-build`

--- a/contributing/ci-docs.txt
+++ b/contributing/ci-docs.txt
@@ -8,41 +8,41 @@ tab of Jenkins.
 	:header-rows: 1
 
 	- 	* Job task
-		* 5.0.x series
 		* 5.1.x series
+		* 5.2.x series
 
-	- 	* Builds the OMERO documentation for publishing
-		* :term:`OMERO-5.0-release-docs`
-		* :term:`OMERO-5.1-release-docs`
+	- 	* Builds the latest OMERO documentation for publishing
+		* :term:`OMERO-5.1-latest-docs`
+		* :term:`OMERO-DEV-latest-docs`
 
-	- 	* Builds the Bio-Formats documentation for publishing
-		* :term:`BIOFORMATS-5.0-release-docs`
-		* :term:`BIOFORMATS-5.1-release-docs`
+	- 	* Builds the latest Bio-Formats documentation for publishing
+		* :term:`BIOFORMATS-5.1-latest-docs`
+		*
 
 	- 	* Builds the OMERO documentation for review
-		* :term:`OMERO-5.0-merge-docs`
 		* :term:`OMERO-5.1-merge-docs`
+		* :term:`OMERO-DEV-merge-docs`
 
 
 	- 	* Builds the Bio-Formats documentation for review
-		* :term:`BIOFORMATS-5.0-merge-docs`
 		* :term:`BIOFORMATS-5.1-merge-docs`
+		*
 
 	- 	* Builds the auto-generated OMERO documentation
-		* :term:`OMERO-5.0-latest-docs-autogen`
 		* :term:`OMERO-5.1-latest-docs-autogen`
+		* :term:`OMERO-DEV-latest-docs-autogen`
 
 	- 	* Builds the auto-generated OMERO documentation for review
-		* :term:`OMERO-5.0-merge-docs-autogen`
 		* :term:`OMERO-5.1-merge-docs-autogen`
+		* :term:`OMERO-DEV-merge-docs-autogen`
 
 	- 	* Builds the auto-generated Bio-Formats documentation
-		* :term:`BIOFORMATS-5.0-latest-docs-autogen`
 		* :term:`BIOFORMATS-5.1-latest-docs-autogen`
+		*
 
 	- 	* Builds the auto-generated OMERO documentation for review
-		* :term:`BIOFORMATS-5.0-merge-docs-autogen`
 		* :term:`BIOFORMATS-5.1-merge-docs-autogen`
+		*
 
 
 The OME Model, OME help and OME Contributing documentation sets are
@@ -55,10 +55,10 @@ independent of the current OMERO/Bio-Formats version.
 		*
 
 	- 	* Publish OME Model documentation
-		* :term:`FORMATS-release-docs`
+		* :term:`FORMATS-latest-docs`
 
 	- 	* Publish OME Contributing documentation
-		* :term:`CONTRIBUTING-release-docs`
+		* :term:`CONTRIBUTING-latest-docs`
 
 	- 	* Review OME Model documentation PRs
 		* :term:`FORMATS-merge-docs`
@@ -97,120 +97,15 @@ necromancer.openmicroscopy.org.uk under the
 :program:`scc deploy` command. The :jenkinsjob:`OME-docs-deployment-setup` job
 is used to initialize new deployment folders.
 
-5.0.x series
-^^^^^^^^^^^^
-
-The branch for the 5.0.x series of the OMERO/Bio-Formats documentation is
-dev_5_0.
-
-.. glossary::
-
-	:jenkinsjob:`OMERO-5.0-release-docs`
-
-		This job is used to build the dev_5_0 branch of the OMERO
-		documentation and publish the official documentation for the next
-		major release of OMERO
-
-		#. |sphinxbuild|
-		#. |linkcheck|
-		#. If the build is promoted,
-			#. |ssh-doc| :file:`omero-5.0-release.tmp`
-			#. |deploy-doc| http://www.openmicroscopy.org/site/support/omero5/
-
-	:jenkinsjob:`BIOFORMATS-5.0-release-docs`
-
-		This job is used to build the dev_5_0 branch of the Bio-Formats
-		documentation and publish the official documentation for the next
-		major release of Bio-Formats
-
-		#. |sphinxbuild|
-		#. |linkcheck|
-		#. If the build is promoted,
-			#. |ssh-doc| :file:`bf-5.0-release.tmp`
-			#. |deploy-doc| http://www.openmicroscopy.org/site/support/bio-formats5/
-
-	:jenkinsjob:`OMERO-5.0-merge-docs`
-
-		This job is used to review the PRs opened against the dev_5_0 branch
-		of the OMERO documentation
-
-		#. |merge|
-		#. |sphinxbuild|
-		#. |linkcheck|
-		#. |ssh-doc| :file:`omero-5.0-staging.tmp`
-		#. |deploy-doc| http://www.openmicroscopy.org/site/support/omero5-staging/
-
-	:jenkinsjob:`BIOFORMATS-5.0-merge-docs`
-
-		This job is used to review the PRs opened against the dev_5_0 branch
-		of the Bio-Formats documentation
-
-		#. |merge|
-		#. |sphinxbuild|
-		#. |linkcheck|
-		#. |ssh-doc| :file:`bf-5.0-staging.tmp`
-		#. |deploy-doc| http://www.openmicroscopy.org/site/support/bio-formats5-staging/
-
-	:jenkinsjob:`BIOFORMATS-5.0-latest-docs-autogen`
-
-		This job is used to build the latest auto-generated formats and
-		readers pages for the dev_5_0 branch of the Bio-Formats documentation
-
-		#. Builds Bio-Formats using ``ant clean jars``
-		#. Runs the auto-generation using ``ant gen-format-pages gen-original-meta-support gen-meta-support gen-meta-support``
-		   from :file:`components/autogen`
-		#. Check for file changes under :file:`docs/sphinx`
-		#. Pushes the auto-generated changes to the `dev_5_0/latest/autogen`
-		   branch of https://github.com/snoopycrimecop/bioformats
-
-	:jenkinsjob:`BIOFORMATS-5.0-merge-docs-autogen`
-
-		This job is used to build the merge auto-generated formats and
-		readers pages for the dev_5_0 branch of the Bio-Formats documentation
-
-		#. Checks out the merge/dev_5_0/latest branch of the
-		   snoopycrimecop fork of bioformats.git_
-		#. Builds Bio-Formats using ``ant clean jars``
-		#. Runs the auto-generation using ``ant gen-format-pages gen-original-meta-support gen-meta-support gen-meta-support``
-		   from :file:`components/autogen`
-		#. Check for file changes under :file:`docs/sphinx`
-		#. Pushes the auto-generated changes to the `dev_5_0/merge/autogen`
-		   branch of https://github.com/snoopycrimecop/bioformats
-
-	:jenkinsjob:`OMERO-5.0-latest-docs-autogen`
-
-		This job is used to build the latest auto-generated pages for the
-		dev_5_0 branch of the OMERO documentation
-
-		#. Checks out the dev_5_0 branch of ome-documentation.git_
-		#. Downloads the OMERO.server and OMERO.clients from
-		   :term:`OMERO-5.0-latest`
-		#. Runs the :file:`omero/autogen_docs` autogeneration script
-		#. Pushes the auto-generated changes to the `dev_5_0/latest/autogen`
-		   branch of https://github.com/snoopycrimecop/ome-documentation
-
-	:jenkinsjob:`OMERO-5.0-merge-docs-autogen`
-
-		This job is used to build the merge auto-generated pages for the
-		dev_5_0 branch of the OMERO documentation
-
-		#. Checks out the merge/dev_5_0/latest branch of the
-		   snoopycrimecop fork of ome-documentation.git_
-		#. Downloads the OMERO.server and OMERO.clients from
-		   :term:`OMERO-5.0-merge-build`
-		#. Runs the :file:`omero/autogen_docs` autogeneration script
-		#. Pushes the auto-generated changes to the `dev_5_0/merge/autogen`
-		   branch of https://github.com/snoopycrimecop/ome-documentation
-
 5.1.x series
 ^^^^^^^^^^^^
 
 The branch for the 5.1.x series of the OMERO/Bio-Formats documentation is
-develop.
+dev_5_1.
 
 .. glossary::
 
-	:jenkinsjob:`OMERO-5.1-release-docs`
+	:jenkinsjob:`OMERO-5.1-latest-docs`
 
 		This job is used to build the develop branch of the OMERO
 		documentation and publish the official documentation for the 5.1.x
@@ -222,7 +117,7 @@ develop.
 			#. |ssh-doc| :file:`omero-5.1-release.tmp`
 			#. |deploy-doc| http://www.openmicroscopy.org/site/support/omero5.1/
 
-	:jenkinsjob:`BIOFORMATS-5.1-release-docs`
+	:jenkinsjob:`BIOFORMATS-5.1-latest-docs`
 
 		This job is used to build the develop branch of the Bio-Formats
 		documentation and publish the official documentation for the 5.1.x
@@ -242,7 +137,7 @@ develop.
 		#. |merge|
 		#. |sphinxbuild|
 		#. |linkcheck|
-		#. |ssh-doc| :file:`omero-5.0-staging.tmp`
+		#. |ssh-doc| :file:`omero-5.1-staging.tmp`
 		#. |deploy-doc| http://www.openmicroscopy.org/site/support/omero5.1-staging/
 
 	:jenkinsjob:`BIOFORMATS-5.1-merge-docs`
@@ -265,7 +160,7 @@ develop.
 		#. Runs the auto-generation using ``ant gen-format-pages gen-original-meta-support gen-meta-support gen-meta-support``
 		   from :file:`components/autogen`
 		#. Check for file changes under :file:`docs/sphinx`
-		#. Pushes the auto-generated changes to the `develop/latest/autogen`
+		#. Pushes the auto-generated changes to the `dev_5_1/latest/autogen`
 		   branch of https://github.com/snoopycrimecop/bioformats
 
 
@@ -280,7 +175,7 @@ develop.
 		#. Runs the auto-generation using ``ant gen-format-pages gen-original-meta-support gen-meta-support gen-meta-support``
 		   from :file:`components/autogen`
 		#. Check for file changes under :file:`docs/sphinx`
-		#. Pushes the auto-generated changes to the `develop/merge/autogen`
+		#. Pushes the auto-generated changes to the `dev_5_1/merge/autogen`
 		   branch of https://github.com/snoopycrimecop/bioformats
 
 	:jenkinsjob:`OMERO-5.1-latest-docs-autogen`
@@ -292,7 +187,7 @@ develop.
 		#. Downloads the OMERO.server and OMERO.clients from
 		   :term:`OMERO-5.1-latest`
 		#. Runs the :file:`omero/autogen_docs` autogeneration script
-		#. Pushes the auto-generated changes to the `develop/latest/autogen`
+		#. Pushes the auto-generated changes to the `dev_5_1/latest/autogen`
 		   branch of https://github.com/snoopycrimecop/ome-documentation
 
 	:jenkinsjob:`OMERO-5.1-merge-docs-autogen`
@@ -305,9 +200,63 @@ develop.
 		#. Downloads the OMERO.server and OMERO.clients from
 		   :term:`OMERO-5.1-merge-build`
 		#. Runs the :file:`omero/autogen_docs` autogeneration script
-		#. Pushes the auto-generated changes to the `develop/merge/autogen`
+		#. Pushes the auto-generated changes to the `dev_5_1/merge/autogen`
 		   branch of https://github.com/snoopycrimecop/ome-documentation
 
+5.2.x series
+^^^^^^^^^^^^
+
+The branch for the 5.2.x series of the OMERO/Bio-Formats documentation is
+develop.
+
+.. glossary::
+
+	:jenkinsjob:`OMERO-DEV-latest-docs`
+
+		This job is used to review the PRs opened against the develop branch
+		of the OMERO documentation
+
+		#. |merge|
+		#. |sphinxbuild|
+		#. |linkcheck|
+		#. |ssh-doc| :file:`omero-5.2.tmp`
+		#. |deploy-doc| http://www.openmicroscopy.org/site/support/omero5.2/
+
+	:jenkinsjob:`OMERO-DEV-merge-docs`
+
+		This job is used to review the PRs opened against the develop branch
+		of the OMERO documentation
+
+		#. |merge|
+		#. |sphinxbuild|
+		#. |linkcheck|
+		#. |ssh-doc| :file:`omero-5.2-staging.tmp`
+		#. |deploy-doc| http://www.openmicroscopy.org/site/support/omero5.2-staging/
+
+	:jenkinsjob:`OMERO-DEV-latest-docs-autogen`
+
+		This job is used to build the latest auto-generated pages for the
+		develop branch of the OMERO documentation
+
+		#. Checks out the develop branch of ome-documentation.git_
+		#. Downloads the OMERO.server and OMERO.clients from
+		   :term:`OMERO-5.1-latest`
+		#. Runs the :file:`omero/autogen_docs` autogeneration script
+		#. Pushes the auto-generated changes to the `develop/latest/autogen`
+		   branch of https://github.com/snoopycrimecop/ome-documentation
+
+	:jenkinsjob:`OMERO-DEV-merge-docs-autogen`
+
+		This job is used to review the component auto-generation for the
+		develop branch of the OMERO documentation
+
+		#. Checks out the merge/develop/latest branch of the
+		   snoopycrimecop fork of ome-documentation.git_
+		#. Downloads the OMERO.server and OMERO.clients from
+		   :term:`OMERO-5.1-merge-build`
+		#. Runs the :file:`omero/autogen_docs` autogeneration script
+		#. Pushes the auto-generated changes to the `develop/merge/autogen`
+		   branch of https://github.com/snoopycrimecop/ome-documentation
 
 OME Model and OME Contributing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -339,7 +288,7 @@ sets is develop.
 		#. |ssh-doc| :file:`contributing-staging.tmp`
 		#. |deploy-doc| http://www.openmicroscopy.org/site/support/contributing-staging/
 
-	:jenkinsjob:`FORMATS-release-docs`
+	:jenkinsjob:`FORMATS-latest-docs`
 
 		This job is used to build the develop branch of the OME Model
 		documentation and publish the official documentation
@@ -349,7 +298,7 @@ sets is develop.
 		#. |ssh-doc| :file:`formats-release.tmp`
 		#. |deploy-doc| http://www.openmicroscopy.org/site/support/ome-model/
 
-	:jenkinsjob:`CONTRIBUTING-release-docs`
+	:jenkinsjob:`CONTRIBUTING-latest-docs`
 
 		This job is used to build the develop branch of the OME Contributing
 		documentation and publish the official documentation

--- a/contributing/ci-docs.txt
+++ b/contributing/ci-docs.txt
@@ -240,7 +240,7 @@ develop.
 
 		#. Checks out the develop branch of ome-documentation.git_
 		#. Downloads the OMERO.server and OMERO.clients from
-		   :term:`OMERO-5.1-latest`
+		   :term:`OMERO-DEV-latest`
 		#. Runs the :file:`omero/autogen_docs` autogeneration script
 		#. Pushes the auto-generated changes to the `develop/latest/autogen`
 		   branch of https://github.com/snoopycrimecop/ome-documentation
@@ -253,7 +253,7 @@ develop.
 		#. Checks out the develop/merge/daily branch of the
 		   snoopycrimecop fork of ome-documentation.git_
 		#. Downloads the OMERO.server and OMERO.clients from
-		   :term:`OMERO-5.1-merge-build`
+		   :term:`OMERO-DEV-merge-build`
 		#. Runs the :file:`omero/autogen_docs` autogeneration script
 		#. Pushes the auto-generated changes to the `develop/merge/autogen`
 		   branch of https://github.com/snoopycrimecop/ome-documentation

--- a/contributing/ci-introduction.txt
+++ b/contributing/ci-introduction.txt
@@ -30,8 +30,8 @@ bioformats.git_, scripts.git_, ome-documentation.git_. Each repository
 contains several development branches associated with development series:
 
 * The "dev_5_0" branch contains work on the 5.0.x series.
-
-* The "develop" branch contains work on the 5.1.x series.
+* The "dev_5_1" branch contains work on the 5.1.x series.
+* The "develop" branch contains work on the 5.2.x series.
 
 Note that only two branches are maintained simultaneously. With this workflow,
 it is possible to have a point release immediately, while still working on
@@ -46,7 +46,10 @@ Labels are applied to PRs on GitHub under the “Issues” tab of each repositor
 The 5.0.x series consists of PRs labeled with “dev_5_0”, which is also
 the name of the branch which they will be merged into.
 
-The 5.1.x series consists of PRs labeled with “develop”, which is also
+The 5.1.x series consists of PRs labeled with “dev_5_1”, which is also
+the name of the branch which they will be merged into.
+
+The 5.2.x series consists of PRs labeled with “develop”, which is also
 the name of the branch which they will be merged into.
 
 Multiple labels are used in the PR reviewing process:

--- a/contributing/ci-omero.txt
+++ b/contributing/ci-omero.txt
@@ -179,14 +179,14 @@ clients of the deployment jobs described above:
 5.1.x series
 ^^^^^^^^^^^^
 
-The branch for the 5.1.x series of OMERO is dv_1. All jobs are listed
+The branch for the 5.1.x series of OMERO is dev_5_1. All jobs are listed
 under the :jenkinsview:`5.1` view tab of Jenkins.
 
 .. glossary::
 
     :jenkinsjob:`OMERO-5.1-latest`
 
-        This job builds the develop branch of OMERO with Ice 3.4 or 3.5
+        This job builds the dev_5_1 branch of OMERO with Ice 3.4 or 3.5
 
         #. |buildOMERO|
         #. |archiveOMEROartifacts|
@@ -210,12 +210,12 @@ under the :jenkinsview:`5.1` view tab of Jenkins.
 
     :jenkinsjob:`OMERO-5.1-latest-submods`
 
-        This job updates the submodules on the develop branch
+        This job updates the submodules on the dev_5_1 branch
 
         #. |updatesubmodules| and pushes the merge branch to
            snoopycrimecop/dev_5_1/latest/submodules
         #. If the submodules are updated, opens a new PR or updates the
-           existing develop submodules PR
+           existing dev_5_1 submodules PR
 
     :jenkinsjob:`OMERO-5.1-merge-daily`
 
@@ -231,7 +231,7 @@ under the :jenkinsview:`5.1` view tab of Jenkins.
 
     :jenkinsjob:`OMERO-5.1-merge-push`
 
-        This job merges all the PRs opened against develop
+        This job merges all the PRs opened against dev_5_1
 
         #. |merge|
         #. Pushes the branch to snoopycrimecop/dev_5_1/merge/daily

--- a/contributing/ci-omero.txt
+++ b/contributing/ci-omero.txt
@@ -5,65 +5,65 @@ OMERO jobs
     :header-rows: 1
 
     -   * Job task
-        * 5.0.x series
         * 5.1.x series
+        * DEV series
         * Breaking series
 
     -   * Builds the latest OMERO artifacts
-        * :term:`OMERO-5.0-latest`
         * :term:`OMERO-5.1-latest`
+        * :term:`OMERO-DEV-latest`
         *
 
     -   * Deploys the latest OMERO server
-        * :term:`OMERO-5.0-latest-deploy`
         * | :term:`OMERO-5.1-latest-deploy`
           | :term:`OMERO-5.1-latest-deploy-win`
           | :term:`OMERO-5.1-latest-deploy-win2012`
+        * :term:`OMERO-DEV-latest-deploy`
         *
 
     -   * Updates submodules
-        * :term:`OMERO-5.0-latest-submods`
         * :term:`OMERO-5.1-latest-submods`
+        *
         *
 
     -   * Runs the daily OMERO merge builds
-        * :term:`OMERO-5.0-merge-daily`
         * :term:`OMERO-5.1-merge-daily`
+        * :term:`OMERO-DEV-merge-daily`
         * :term:`OMERO-5.1-breaking-trigger`
 
     -   * Merges the PRs
-        * :term:`OME-5.0-merge-push`
         * :term:`OMERO-5.1-merge-push`
+        * :term:`OMERO-DEV-merge-push`
         * :term:`OMERO-5.1-breaking-push`
 
     -   * Builds the OMERO artifacts
-        * :term:`OMERO-5.0-merge-build`
         * :term:`OMERO-5.1-merge-build`
+        * :term:`OMERO-DEV-merge-build`
         * :term:`OMERO-5.1-breaking-build`
 
     -   * Deploys the OMERO server
-        * :term:`OMERO-5.0-merge-deploy`
         * | :term:`OMERO-5.1-merge-deploy`
           | :term:`OMERO-5.1-merge-deploy-win`
           | :term:`OMERO-5.1-merge-deploy-win2012`
+        * :term:`OMERO-DEV-merge-deploy`
         * :term:`OMERO-5.1-breaking-deploy`
 
     -   * Runs the OMERO upgrade scripts
-        * :term:`OMERO-5.0-merge-upgrade`
         * :term:`OMERO-5.1-merge-upgrade`
+        *
         * :term:`OMERO-5.1-breaking-upgrade`
 
     -   * Runs the OMERO integration tests
-        * | :term:`OMERO-5.0-merge-integration`
-          | :term:`OMERO-5.0-merge-integration-broken`
-          | :term:`OMERO-5.0-merge-integration-java`
-          | :term:`OMERO-5.0-merge-integration-python`
-          | :term:`OMERO-5.0-merge-integration-web`
         * | :term:`OMERO-5.1-merge-integration`
           | :term:`OMERO-5.1-merge-integration-broken`
           | :term:`OMERO-5.1-merge-integration-java`
           | :term:`OMERO-5.1-merge-integration-python`
           | :term:`OMERO-5.1-merge-integration-web`
+        * | :term:`OMERO-DEV-merge-integration`
+          | :term:`OMERO-DEV-merge-integration-broken`
+          | :term:`OMERO-DEV-merge-integration-java`
+          | :term:`OMERO-DEV-merge-integration-python`
+          | :term:`OMERO-DEV-merge-integration-web`
         * | :term:`OMERO-5.1-breaking-integration`
           | :term:`OMERO-5.1-breaking-integration-broken`
           | :term:`OMERO-5.1-breaking-integration-java`
@@ -71,25 +71,25 @@ OMERO jobs
           | :term:`OMERO-5.1-breaking-integration-web`
 
     -   * Runs the OMERO.matlab tests
-        * :term:`OMERO-5.0-merge-matlab`
         * :term:`OMERO-5.1-merge-matlab`
+        * :term:`OMERO-DEV-merge-matlab`
         *
 
     -   * Runs the robot framework tests
-        * :term:`OMERO-5.0-merge-robotframework`
         * :term:`OMERO-5.1-merge-robotframework`
+        * :term:`OMERO-DEV-merge-robotframework`
         *
 
     -   * Installs OMERO using Homebrew
-        * :term:`OME-5.0-merge-homebrew`
         * :term:`OME-5.1-merge-homebrew`
+        *
         *
 
     -   * Push SNAPSHOTS to Maven
-        * | :term:`OMERO-5.0-latest-maven`
-          | :term:`OMERO-5.0-merge-maven`
         * | :term:`OMERO-5.1-latest-maven`
           | :term:`OMERO-5.1-merge-maven`
+        * | :term:`OMERO-DEV-latest-maven`
+          | :term:`OMERO-DEV-merge-maven`
         *
 
 .. _deployment_servers:
@@ -109,24 +109,6 @@ clients of the deployment jobs described above:
         * Hostname
         * Port
         * Webclient
-
-    -   * 5.0.x
-        * :term:`OMERO-5.0-merge-deploy`
-        * octopus.openmicroscopy.org
-        * 4064
-        * https://octopus.openmicroscopy.org/merge
-
-    -   * 5.0.x
-        * :term:`OMERO-5.0-latest-deploy`
-        * octopus.openmicroscopy.org
-        * 14064
-        * https://octopus.openmicroscopy.org/latest
-
-    -   * 5.0.x
-        * :term:`OMERO-5.0-merge-integration`
-        * octopus.openmicroscopy.org
-        * 24064
-        * https://octopus.openmicroscopy.org/integration
 
     -   * 5.1.x
         * :term:`OMERO-5.1-merge-deploy`
@@ -170,181 +152,34 @@ clients of the deployment jobs described above:
         * 24064
         * https://trout.openmicroscopy.org/integration
 
+    -   * 5.2.x
+        * :term:`OMERO-DEV-merge-deploy`
+        * eel.openmicroscopy.org
+        * 4064
+        * https://eel.openmicroscopy.org/merge
+
+    -   * 5.2.x
+        * :term:`OMERO-DEV-latest-deploy`
+        * octopus.openmicroscopy.org
+        * 14064
+        * https://eel.openmicroscopy.org/latest
+
+    -   * 5.2.x
+        * :term:`OMERO-DEV-merge-integration`
+        * octopus.openmicroscopy.org
+        * 24064
+        * https://eel.openmicroscopy.org/integration
+
     -   * Breaking
         * :term:`OMERO-5.1-breaking-deploy`
         * trout.openmicroscopy.org
         * 34064
         * https://trout.openmicroscopy.org/breaking
 
-5.0.x series
-^^^^^^^^^^^^
-
-The branch for the 5.0.x series of OMERO is dev_5_0. All jobs are listed
-under the :jenkinsview:`5.0` view tab of Jenkins.
-
-
-.. glossary::
-
-    :jenkinsjob:`OMERO-5.0-latest`
-
-
-        This job build the dev_5_0 branch of OMERO with Ice 3.3, 3.4 or 3.5
-
-        #. |buildOMERO|
-        #. |archiveOMEROartifacts|
-
-        See :jenkinsjob:`the build graph <OMERO-5.0-latest/lastSuccessfulBuild/BuildGraph>`
-
-    :jenkinsjob:`OMERO-5.0-latest-deploy`
-
-        This job deploys the latest 5.0.x server (see
-        :ref:`deployment_servers`)
-
-    :jenkinsjob:`OMERO-5.0-latest-submods`
-
-        This job updates the submodules on the dev_5_0 branch
-
-        #. |updatesubmodules| and pushes the merge branch to
-           snoopycrimecop/dev_5_0/latest/submodules
-        #. If the submodules are updated, opens a new PR or updates the
-           existing dev_5_0 submodules PR
-
-    :jenkinsjob:`OMERO-5.0-merge-daily`
-
-        This job triggers all the morning merge builds listed below
-
-        #. Triggers :term:`OME-5.0-merge-push`
-        #. Triggers :term:`OMERO-5.0-merge-build` and
-           :term:`OMERO-5.0-merge-integration`
-        #. Triggers :term:`OMERO-5.0-merge-deploy`
-        #. Triggers other downstream merge jobs
-
-        See :jenkinsjob:`the build graph <OMERO-5.0-merge-daily/lastSuccessfulBuild/BuildGraph>`
-
-    :jenkinsjob:`OME-5.0-merge-push`
-
-        This job merges all the dev_5_0 PRs
-
-        #. |merge|
-        #. Pushes the branch to snoopycrimecop/merge/dev_5_0/latest
-
-    :jenkinsjob:`OMERO-5.0-merge-build`
-
-        This matrix job builds the OMERO components with Ice 3.3, 3.4 or 3.5
-
-        #. Checks out the merge/dev_5_0/latest branch of the
-           snoopycrimecop fork of openmicroscopy.git_
-        #. |buildOMERO| for each version of Ice
-        #. |buildVM|
-        #. |archiveOMEROartifacts|
-
-    :jenkinsjob:`OMERO-5.0-merge-deploy`
-
-        This job deploys the merge 5.0.x server (see
-        :ref:`deployment_servers`)
-
-    :jenkinsjob:`OMERO-5.0-merge-integration`
-
-        This job runs the integration tests
-
-        #. Checks out the merge/dev_5_0/latest branch of the
-           snoopycrimecop fork of openmicroscopy.git_
-        #. Builds OMERO.server and starts it
-        #. Runs the OMERO.java, OMERO.py and OMERO.web integration tests
-        #. Archives the results
-        #. Triggers downstream collection jobs:
-           :term:`OMERO-5.0-merge-integration-broken`,
-           :term:`OMERO-5.0-merge-integration-java`,
-           :term:`OMERO-5.0-merge-integration-python`,
-           :term:`OMERO-5.0-merge-integration-web`
-
-    :jenkinsjob:`OMERO-5.0-merge-integration-broken`
-
-        This job collects the OMERO.java broken test results
-
-        #. Receives TestNG results under
-           :file:`components/tools/OmeroJava/target/reports/broken` from
-           :term:`OMERO-5.0-merge-integration`,
-        #. Generates TestNG report
-
-    :jenkinsjob:`OMERO-5.0-merge-integration-java`
-
-        This job collects the OMERO.java integration test results
-
-        #. Receives TestNG results under
-           :file:`components/tools/OmeroJava/target/reports/integration` from
-           :term:`OMERO-5.0-merge-integration`,
-        #. Generates TestNG report
-
-    :jenkinsjob:`OMERO-5.0-merge-integration-python`
-
-        This job collects the OMERO.py integration test results
-
-        #. Receives pytest results under
-           :file:`components/tools/OmeroPy/target/reports` from
-           :term:`OMERO-5.0-merge-integration`,
-        #. Generates pytest report
-
-    :jenkinsjob:`OMERO-5.0-merge-integration-web`
-
-        This job collects the OMERO.web integration test results
-
-        #. Receives pytest results under
-           :file:`components/tools/OmeroWeb/target/reports` from
-           :term:`OMERO-5.0-merge-integration`,
-        #. Generates pytest report
-
-    :jenkinsjob:`OMERO-5.0-merge-matlab`
-
-        This job runs the OMERO.matlab tests
-
-        #. Checks out the merge/dev_5_0/latest branch of the
-           snoopycrimecop fork of openmicroscopy.git_
-        #. Collects the MATLAB artifacts from :term:`OMERO-5.0-merge-build`
-        #. Run the MATLAB unit tests under
-           :file:`components/tools/OmeroM/test/unit` and collect the results
-
-    :jenkinsjob:`OMERO-5.0-merge-maven`
-
-        The same as :term:`OMERO-5.1-merge-maven`, but for 5.0.
-
-    :jenkinsjob:`OMERO-5.0-latest-maven`
-
-        The same as :term:`OMERO-5.1-merge-maven`, but for 5.0 and pushes to `ome.snapshots`.
-
-    :jenkinsjob:`OMERO-5.0-merge-robotframework`
-
-        This job runs the robot framework tests of OMERO
-
-        #. Checks out the merge/dev_5_0/latest branch of the
-           snoopycrimecop fork of openmicroscopy.git_
-        #. Builds OMERO.server and starts it
-        #. Runs the robot framework tests and collect the results
-
-    :jenkinsjob:`OME-5.0-merge-homebrew`
-
-        This job tests the installation of OMERO 5.0 using Homebrew
-
-        #. Cleans :file:`/usr/local`
-        #. Installs Homebrew from https://github.com/ome/omero-install
-        #. Installs OMERO via :file:`homebrew/install_omero50`
-
-    :jenkinsjob:`OMERO-5.0-merge-upgrade`
-
-        This job tests the DB upgrade script from the last released 4.4.x
-        server or the 5.0.0-beta1 server
-
-        #. Initializes a database using the script from the last released
-           4.4.x server or the 5.0.0-beta1 server
-        #. Starts the OMERO server
-        #. Stops the OMERO server
-        #. Runs the upgrade script under :file:`sql/psql/OMERO5.0_0/`
-        #. Restarts the OMERO server
-
 5.1.x series
 ^^^^^^^^^^^^
 
-The branch for the 5.1.x series of OMERO is develop. All jobs are listed
+The branch for the 5.1.x series of OMERO is dv_1. All jobs are listed
 under the :jenkinsview:`5.1` view tab of Jenkins.
 
 .. glossary::
@@ -378,7 +213,7 @@ under the :jenkinsview:`5.1` view tab of Jenkins.
         This job updates the submodules on the develop branch
 
         #. |updatesubmodules| and pushes the merge branch to
-           snoopycrimecop/develop/latest/submodules
+           snoopycrimecop/dev_5_1/latest/submodules
         #. If the submodules are updated, opens a new PR or updates the
            existing develop submodules PR
 
@@ -399,16 +234,15 @@ under the :jenkinsview:`5.1` view tab of Jenkins.
         This job merges all the PRs opened against develop
 
         #. |merge|
-        #. Pushes the branch to snoopycrimecop/merge/develop/latest
+        #. Pushes the branch to snoopycrimecop/dev_5_1/merge/daily
 
     :jenkinsjob:`OMERO-5.1-merge-build`
 
         These jobs builds the OMERO components with Ice 3.4 or 3.5
 
-        #. Checks out the merge/develop/latest branch of the
+        #. Checks out the dev_5_1/merge/daily branch of the
            snoopycrimecop fork of openmicroscopy.git_
         #. |buildOMERO| for each version of Ice
-        #. |buildVM|
         #. |archiveOMEROartifacts|
 
     :jenkinsjob:`OMERO-5.1-merge-deploy`
@@ -430,7 +264,7 @@ under the :jenkinsview:`5.1` view tab of Jenkins.
 
         This job runs the integration tests of OMERO
 
-        #. Checks out the merge/develop/latest branch of the
+        #. Checks out the dev_5_1/merge/daily branch of the
            snoopycrimecop fork of openmicroscopy.git_
         #. Builds OMERO.server and starts it
         #. Runs the OMERO.java, OMERO.py and OMERO.web integration tests
@@ -481,7 +315,7 @@ under the :jenkinsview:`5.1` view tab of Jenkins.
 
         This job runs the OMERO.matlab tests
 
-        #. Checks out the merge/develop/latest branch of the
+        #. Checks out the dev_5_1/merge/daily branch of the
            snoopycrimecop fork of openmicroscopy.git_
         #. Collects the MATLAB artifacts from :term:`OMERO-5.1-merge-build`
         #. Runs the MATLAB unit tests under
@@ -502,14 +336,14 @@ under the :jenkinsview:`5.1` view tab of Jenkins.
 
         This job runs the robot framework tests of OMERO
 
-        #. Checks out the merge/develop/latest branch of the
+        #. Checks out the dev_5_1/merge/daily branch of the
            snoopycrimecop fork of openmicroscopy.git_
         #. Builds OMERO.server and starts it
         #. Runs the robot framework tests and collect the results
 
     :jenkinsjob:`OME-5.1-merge-homebrew`
 
-        This job tests the installation of OMERO 5.0 using Homebrew
+        This job tests the installation of OMERO 5.1 using Homebrew
 
         #. Cleans :file:`/usr/local`
         #. Installs Homebrew from https://github.com/ome/omero-install
@@ -524,6 +358,161 @@ under the :jenkinsview:`5.1` view tab of Jenkins.
         #. Stops the OMERO server
         #. Runs the upgrade script under :file:`sql/psql/OMERO5.1_DEVx/`
         #. Restarts the OMERO server
+
+5.2.x series
+^^^^^^^^^^^^
+
+The branch for the 5.2.x series of OMERO is develop. All jobs are listed
+under the :jenkinsview:`DEV` view tab of Jenkins.
+
+.. glossary::
+
+    :jenkinsjob:`OMERO-DEV-latest`
+
+        This job builds the develop branch of OMERO with Ice 3.5 or 3.6
+
+        #. |buildOMERO|
+        #. |archiveOMEROartifacts|
+
+        See :jenkinsjob:`the build graph <OMERO-DEV-latest/lastSuccessfulBuild/BuildGraph>`
+
+    :jenkinsjob:`OMERO-DEV-latest-deploy`
+
+        This job deploys the latest 5.1.x server (see
+        :ref:`deployment_servers`)
+
+    :jenkinsjob:`OMERO-DEV-latest-deploy-win`
+
+        This job deploys the latest 5.1.x server on Windows (see
+        :ref:`deployment_servers`)
+
+    :jenkinsjob:`OMERO-DEV-latest-deploy-win2012`
+
+        This job deploys the latest 5.1.x server on Windows 2012
+        (see :ref:`deployment_servers`)
+
+    :jenkinsjob:`OMERO-DEV-latest-submods`
+
+        This job updates the submodules on the develop branch
+
+        #. |updatesubmodules| and pushes the merge branch to
+           snoopycrimecop/develop/latest/submodules
+        #. If the submodules are updated, opens a new PR or updates the
+           existing develop submodules PR
+
+    :jenkinsjob:`OMERO-DEV-merge-daily`
+
+        This job triggers all the morning merge builds listed below
+
+        #. Triggers :term:`OMERO-DEV-merge-push`
+        #. Triggers :term:`OMERO-DEV-merge-build` and
+           :term:`OMERO-DEV-merge-integration`
+        #. Triggers :term:`OMERO-DEV-merge-deploy`
+        #. Triggers other downstream merge jobs
+
+        See :jenkinsjob:`the build graph <OMERO-DEV-merge-daily/lastSuccessfulBuild/BuildGraph>`
+
+    :jenkinsjob:`OMERO-DEV-merge-push`
+
+        This job merges all the PRs opened against develop
+
+        #. |merge|
+        #. Pushes the branch to snoopycrimecop/develop/merge/daily
+
+    :jenkinsjob:`OMERO-DEV-merge-build`
+
+        These jobs builds the OMERO components with Ice 3.5 or 3.6
+
+        #. Checks out the develop/merge/daily branch of the
+           snoopycrimecop fork of openmicroscopy.git_
+        #. |buildOMERO| for each version of Ice
+        #. |archiveOMEROartifacts|
+
+    :jenkinsjob:`OMERO-DEV-merge-deploy`
+
+        This job deploys the merge 5.2.x server (see
+        :ref:`deployment_servers`)
+
+    :jenkinsjob:`OMERO-DEV-merge-integration`
+
+        This job runs the integration tests of OMERO
+
+        #. Checks out the develop/merge/daily branch of the
+           snoopycrimecop fork of openmicroscopy.git_
+        #. Builds OMERO.server and starts it
+        #. Runs the OMERO.java, OMERO.py and OMERO.web integration tests
+        #. Archives the results
+        #. Triggers downstream collection jobs:
+           :term:`OMERO-DEV-merge-integration-broken`,
+           :term:`OMERO-DEV-merge-integration-java`,
+           :term:`OMERO-DEV-merge-integration-python`,
+           :term:`OMERO-DEV-merge-integration-web`
+
+    :jenkinsjob:`OMERO-DEV-merge-integration-broken`
+
+        This job collects the OMERO.java broken test results
+
+        #. Receives TestNG results under
+           :file:`components/tools/OmeroJava/target/reports/broken` from
+           :term:`OMERO-DEV-merge-integration`,
+        #. Generates TestNG report
+
+    :jenkinsjob:`OMERO-DEV-merge-integration-java`
+
+        This job collects the OMERO.java integration test results
+
+        #. Receives TestNG results under
+           :file:`components/tools/OmeroJava/target/reports/integration` from
+           :term:`OMERO-DEV-merge-integration`,
+        #. Generates TestNG report
+
+    :jenkinsjob:`OMERO-DEV-merge-integration-python`
+
+        This job collects the OMERO.py integration test results
+
+        #. Receives pytest results under
+           :file:`components/tools/OmeroPy/target/reports` from
+           :term:`OMERO-DEV-merge-integration`,
+        #. Generates pytest report
+
+    :jenkinsjob:`OMERO-DEV-merge-integration-web`
+
+        This job collects the OMERO.web integration test results
+
+        #. Receives pytest results under
+           :file:`components/tools/OmeroWeb/target/reports` from
+           :term:`OMERO-DEV-merge-integration`,
+        #. Generates pytest report
+
+    :jenkinsjob:`OMERO-DEV-merge-matlab`
+
+        This job runs the OMERO.matlab tests
+
+        #. Checks out the develop/merge/daily branch of the
+           snoopycrimecop fork of openmicroscopy.git_
+        #. Collects the MATLAB artifacts from :term:`OMERO-DEV-merge-build`
+        #. Runs the MATLAB unit tests under
+           :file:`components/tools/OmeroM/test/unit` and collect the results
+
+    :jenkinsjob:`OMERO-DEV-merge-maven`
+
+        This job is used to generate SNAPSHOT jars and push them to artifactory.
+
+        #. Runs :file:`docs/hudson/OMERO.sh`
+        #. Executes the `release-hudson` target for the `ome.unstable` repository.
+
+    :jenkinsjob:`OMERO-DEV-latest-maven`
+
+        The same as :term:`OMERO-DEV-merge-maven`, but pushes to `ome.snapshots`.
+
+    :jenkinsjob:`OMERO-DEV-merge-robotframework`
+
+        This job runs the robot framework tests of OMERO
+
+        #. Checks out the develop/merge/daily branch of the
+           snoopycrimecop fork of openmicroscopy.git_
+        #. Builds OMERO.server and starts it
+        #. Runs the robot framework tests and collect the results
 
 .. _omero_breaking:
 
@@ -561,7 +550,6 @@ Jenkins.
         #. Checks out the merge/develop/breaking branch of the
            snoopycrimecop fork of openmicroscopy.git_
         #. |buildOMERO| for each version of Ice
-        #. |buildVM|
         #. |archiveOMEROartifacts|
 
     :jenkinsjob:`OMERO-5.1-breaking-deploy`

--- a/contributing/ci-omero.txt
+++ b/contributing/ci-omero.txt
@@ -381,16 +381,6 @@ under the :jenkinsview:`DEV` view tab of Jenkins.
         This job deploys the latest 5.1.x server (see
         :ref:`deployment_servers`)
 
-    :jenkinsjob:`OMERO-DEV-latest-deploy-win`
-
-        This job deploys the latest 5.1.x server on Windows (see
-        :ref:`deployment_servers`)
-
-    :jenkinsjob:`OMERO-DEV-latest-deploy-win2012`
-
-        This job deploys the latest 5.1.x server on Windows 2012
-        (see :ref:`deployment_servers`)
-
     :jenkinsjob:`OMERO-DEV-latest-submods`
 
         This job updates the submodules on the develop branch

--- a/contributing/ci-omero.txt
+++ b/contributing/ci-omero.txt
@@ -378,7 +378,7 @@ under the :jenkinsview:`DEV` view tab of Jenkins.
 
     :jenkinsjob:`OMERO-DEV-latest-deploy`
 
-        This job deploys the latest 5.1.x server (see
+        This job deploys the latest 5.2.x server (see
         :ref:`deployment_servers`)
 
     :jenkinsjob:`OMERO-DEV-latest-submods`

--- a/contributing/ci-omero.txt
+++ b/contributing/ci-omero.txt
@@ -29,29 +29,29 @@ OMERO jobs
     -   * Runs the daily OMERO merge builds
         * :term:`OMERO-5.1-merge-daily`
         * :term:`OMERO-DEV-merge-daily`
-        * :term:`OMERO-5.1-breaking-trigger`
+        * :term:`OMERO-DEV-breaking-trigger`
 
     -   * Merges the PRs
         * :term:`OMERO-5.1-merge-push`
         * :term:`OMERO-DEV-merge-push`
-        * :term:`OMERO-5.1-breaking-push`
+        * :term:`OMERO-DEV-breaking-push`
 
     -   * Builds the OMERO artifacts
         * :term:`OMERO-5.1-merge-build`
         * :term:`OMERO-DEV-merge-build`
-        * :term:`OMERO-5.1-breaking-build`
+        * :term:`OMERO-DEV-breaking-build`
 
     -   * Deploys the OMERO server
         * | :term:`OMERO-5.1-merge-deploy`
           | :term:`OMERO-5.1-merge-deploy-win`
           | :term:`OMERO-5.1-merge-deploy-win2012`
         * :term:`OMERO-DEV-merge-deploy`
-        * :term:`OMERO-5.1-breaking-deploy`
+        * :term:`OMERO-DEV-breaking-deploy`
 
     -   * Runs the OMERO upgrade scripts
         * :term:`OMERO-5.1-merge-upgrade`
         *
-        * :term:`OMERO-5.1-breaking-upgrade`
+        * :term:`OMERO-DEV-breaking-upgrade`
 
     -   * Runs the OMERO integration tests
         * | :term:`OMERO-5.1-merge-integration`
@@ -64,11 +64,11 @@ OMERO jobs
           | :term:`OMERO-DEV-merge-integration-java`
           | :term:`OMERO-DEV-merge-integration-python`
           | :term:`OMERO-DEV-merge-integration-web`
-        * | :term:`OMERO-5.1-breaking-integration`
-          | :term:`OMERO-5.1-breaking-integration-broken`
-          | :term:`OMERO-5.1-breaking-integration-java`
-          | :term:`OMERO-5.1-breaking-integration-python`
-          | :term:`OMERO-5.1-breaking-integration-web`
+        * | :term:`OMERO-DEV-breaking-integration`
+          | :term:`OMERO-DEV-breaking-integration-broken`
+          | :term:`OMERO-DEV-breaking-integration-java`
+          | :term:`OMERO-DEV-breaking-integration-python`
+          | :term:`OMERO-DEV-breaking-integration-web`
 
     -   * Runs the OMERO.matlab tests
         * :term:`OMERO-5.1-merge-matlab`
@@ -171,7 +171,7 @@ clients of the deployment jobs described above:
         * https://eel.openmicroscopy.org/integration
 
     -   * Breaking
-        * :term:`OMERO-5.1-breaking-deploy`
+        * :term:`OMERO-DEV-breaking-deploy`
         * trout.openmicroscopy.org
         * 34064
         * https://trout.openmicroscopy.org/breaking
@@ -516,95 +516,95 @@ Jenkins.
 
 .. glossary::
 
-    :jenkinsjob:`OMERO-5.1-breaking-trigger`
+    :jenkinsjob:`OMERO-DEV-breaking-trigger`
 
         This job triggers all the breaking jobs listed below
 
-        #. Triggers :term:`OMERO-5.1-breaking-push`
-        #. Triggers :term:`OMERO-5.1-breaking-build` and
-           :term:`OMERO-5.1-breaking-integration`
-        #. Triggers :term:`OMERO-5.1-breaking-deploy`
+        #. Triggers :term:`OMERO-DEV-breaking-push`
+        #. Triggers :term:`OMERO-DEV-breaking-build` and
+           :term:`OMERO-DEV-breaking-integration`
+        #. Triggers :term:`OMERO-DEV-breaking-deploy`
         #. Triggers other downstream breaking jobs
 
-    :jenkinsjob:`OMERO-5.1-breaking-push`
+    :jenkinsjob:`OMERO-DEV-breaking-push`
 
         This job merges all the breaking PRs
 
         #. |merge| including only PRs labeled as `breaking`
-        #. Push the branch to snoopycrimecop/merge/develop/breaking
+        #. Push the branch to snoopycrimecop/develop/breaking/trigger
 
-    :jenkinsjob:`OMERO-5.1-breaking-build`
+    :jenkinsjob:`OMERO-DEV-breaking-build`
 
         This matrix jobs builds the OMERO components with Ice 3.4 or 3.5
 
-        #. Checks out the merge/develop/breaking branch of the
+        #. Checks out the develop/breaking/trigger branch of the
            snoopycrimecop fork of openmicroscopy.git_
         #. |buildOMERO| for each version of Ice
         #. |archiveOMEROartifacts|
 
-    :jenkinsjob:`OMERO-5.1-breaking-deploy`
+    :jenkinsjob:`OMERO-DEV-breaking-deploy`
 
         This job deploys the breaking server (see :ref:`deployment_servers`)
 
-    :jenkinsjob:`OMERO-5.1-breaking-integration`
+    :jenkinsjob:`OMERO-DEV-breaking-integration`
 
         This job runs the integration tests of OMERO
 
-        #. Checks out the merge/develop/breaking branch of the
+        #. Checks out the develop/breaking/trigger branch of the
            snoopycrimecop fork of openmicroscopy.git_
         #. Builds OMERO.server and starts it
         #. Runs the OMERO.java, OMERO.py and OMERO.web integration tests
         #. Archives the results
         #. Triggers downstream collection jobs:
-           :term:`OMERO-5.1-breaking-integration-broken`,
-           :term:`OMERO-5.1-breaking-integration-java`,
-           :term:`OMERO-5.1-breaking-integration-python`,
-           :term:`OMERO-5.1-breaking-integration-web`
+           :term:`OMERO-DEV-breaking-integration-broken`,
+           :term:`OMERO-DEV-breaking-integration-java`,
+           :term:`OMERO-DEV-breaking-integration-python`,
+           :term:`OMERO-DEV-breaking-integration-web`
 
-    :jenkinsjob:`OMERO-5.1-breaking-integration-broken`
+    :jenkinsjob:`OMERO-DEV-breaking-integration-broken`
 
         This job collects the OMERO.java broken test results
 
         #. Receives TestNG results under
            :file:`components/tools/OmeroJava/target/reports/broken` from
-           :term:`OMERO-5.1-breaking-integration`,
+           :term:`OMERO-DEV-breaking-integration`,
         #. Generates TestNG report
 
-    :jenkinsjob:`OMERO-5.1-breaking-integration-java`
+    :jenkinsjob:`OMERO-DEV-breaking-integration-java`
 
         This job collects the OMERO.java integration test results
 
         #. Receives TestNG results under
            :file:`components/tools/OmeroJava/target/reports/integration` from
-           :term:`OMERO-5.1-breaking-integration`,
+           :term:`OMERO-DEV-breaking-integration`,
         #. Generates TestNG report
 
-    :jenkinsjob:`OMERO-5.1-breaking-integration-python`
+    :jenkinsjob:`OMERO-DEV-breaking-integration-python`
 
         This job collects the OMERO.py integration test results
 
         #. Receives pytest results under
            :file:`components/tools/OmeroPy/target/reports` from
-           :term:`OMERO-5.1-breaking-integration`,
+           :term:`OMERO-DEV-breaking-integration`,
         #. Generates pytest report
 
-    :jenkinsjob:`OMERO-5.1-breaking-integration-web`
+    :jenkinsjob:`OMERO-DEV-breaking-integration-web`
 
         This job collects the OMERO.web integration test results
 
         #. Receives pytest results under
            :file:`components/tools/OmeroWeb/target/reports` from
-           :term:`OMERO-5.1-breaking-integration`,
+           :term:`OMERO-DEV-breaking-integration`,
         #. Generates pytest report
 
-    :jenkinsjob:`OMERO-5.1-breaking-upgrade`
+    :jenkinsjob:`OMERO-DEV-breaking-upgrade`
 
-        This job tests the DB upgrade script from a 5.0.0 server and the
-        last patch number of the 5.1.x series
+        This job tests the DB upgrade script from a 5.1.0 server and the
+        last patch number of the 5.2.x series
 
-        #. Initializes a database using the script from the 5.0.0 release or
-           the last patch number of the 5.1.x series
+        #. Initializes a database using the script from the 5.1.0 release or
+           the last patch number of the 5.2.x series
         #. Starts the OMERO server
         #. Stops the OMERO server
-        #. Runs the upgrade script under :file:`sql/psql/OMERO5.1_DEVx/`
+        #. Runs the upgrade script under :file:`sql/psql/OMERO5.2_DEVx/`
         #. Restarts the OMERO server


### PR DESCRIPTION
See http://lists.openmicroscopy.org.uk/pipermail/ome-devel/2015-July/003416.html

This commit drops the information about the 5.0.x jobs and replaces them with
the new DEV jobs used for the 5.2.x development of OMERO.

--no-rebase
