### PR TITLE
update EveryObject OMERO model glossary

### DIFF
--- a/omero/developers/Model/EveryObject.txt
+++ b/omero/developers/Model/EveryObject.txt
@@ -15,307 +15,309 @@ among the objects.
 Reference
 ---------
 
-.. _Hibernate version of class omero.model.AcquisitionMode:
+.. _OMERO model class AcquisitionMode:
 
 AcquisitionMode
 """""""""""""""
 
-Used by: :ref:`LogicalChannel.mode <Hibernate version of class omero.model.LogicalChannel>`
+Used by: :ref:`LogicalChannel.mode <OMERO model class LogicalChannel>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
+  | value: ``string``, see :javadoc:`IEnum <ome/model/IEnum.html>`
 
-.. _Hibernate version of class omero.model.Annotation:
+.. _OMERO model class Annotation:
 
 Annotation
 """"""""""
 
-Subclasses: :ref:`BasicAnnotation <Hibernate version of class omero.model.BasicAnnotation>`, :ref:`ListAnnotation <Hibernate version of class omero.model.ListAnnotation>`, :ref:`MapAnnotation <Hibernate version of class omero.model.MapAnnotation>`, :ref:`TextAnnotation <Hibernate version of class omero.model.TextAnnotation>`, :ref:`TypeAnnotation <Hibernate version of class omero.model.TypeAnnotation>`
+Subclasses: :ref:`BasicAnnotation <OMERO model class BasicAnnotation>`, :ref:`ListAnnotation <OMERO model class ListAnnotation>`, :ref:`MapAnnotation <OMERO model class MapAnnotation>`, :ref:`TextAnnotation <OMERO model class TextAnnotation>`, :ref:`TypeAnnotation <OMERO model class TypeAnnotation>`
 
-Used by: :ref:`AnnotationAnnotationLink.child <Hibernate version of class omero.model.AnnotationAnnotationLink>`, :ref:`AnnotationAnnotationLink.parent <Hibernate version of class omero.model.AnnotationAnnotationLink>`, :ref:`ChannelAnnotationLink.child <Hibernate version of class omero.model.ChannelAnnotationLink>`, :ref:`DatasetAnnotationLink.child <Hibernate version of class omero.model.DatasetAnnotationLink>`, :ref:`DetectorAnnotationLink.child <Hibernate version of class omero.model.DetectorAnnotationLink>`, :ref:`DichroicAnnotationLink.child <Hibernate version of class omero.model.DichroicAnnotationLink>`, :ref:`ExperimenterAnnotationLink.child <Hibernate version of class omero.model.ExperimenterAnnotationLink>`, :ref:`ExperimenterGroupAnnotationLink.child <Hibernate version of class omero.model.ExperimenterGroupAnnotationLink>`, :ref:`FilesetAnnotationLink.child <Hibernate version of class omero.model.FilesetAnnotationLink>`, :ref:`FilterAnnotationLink.child <Hibernate version of class omero.model.FilterAnnotationLink>`, :ref:`ImageAnnotationLink.child <Hibernate version of class omero.model.ImageAnnotationLink>`, :ref:`InstrumentAnnotationLink.child <Hibernate version of class omero.model.InstrumentAnnotationLink>`, :ref:`LightPathAnnotationLink.child <Hibernate version of class omero.model.LightPathAnnotationLink>`, :ref:`LightSourceAnnotationLink.child <Hibernate version of class omero.model.LightSourceAnnotationLink>`, :ref:`NamespaceAnnotationLink.child <Hibernate version of class omero.model.NamespaceAnnotationLink>`, :ref:`NodeAnnotationLink.child <Hibernate version of class omero.model.NodeAnnotationLink>`, :ref:`ObjectiveAnnotationLink.child <Hibernate version of class omero.model.ObjectiveAnnotationLink>`, :ref:`OriginalFileAnnotationLink.child <Hibernate version of class omero.model.OriginalFileAnnotationLink>`, :ref:`PlaneInfoAnnotationLink.child <Hibernate version of class omero.model.PlaneInfoAnnotationLink>`, :ref:`PlateAcquisitionAnnotationLink.child <Hibernate version of class omero.model.PlateAcquisitionAnnotationLink>`, :ref:`PlateAnnotationLink.child <Hibernate version of class omero.model.PlateAnnotationLink>`, :ref:`ProjectAnnotationLink.child <Hibernate version of class omero.model.ProjectAnnotationLink>`, :ref:`ReagentAnnotationLink.child <Hibernate version of class omero.model.ReagentAnnotationLink>`, :ref:`RoiAnnotationLink.child <Hibernate version of class omero.model.RoiAnnotationLink>`, :ref:`ScreenAnnotationLink.child <Hibernate version of class omero.model.ScreenAnnotationLink>`, :ref:`SessionAnnotationLink.child <Hibernate version of class omero.model.SessionAnnotationLink>`, :ref:`ShapeAnnotationLink.child <Hibernate version of class omero.model.ShapeAnnotationLink>`, :ref:`WellAnnotationLink.child <Hibernate version of class omero.model.WellAnnotationLink>`
+Used by: :ref:`AnnotationAnnotationLink.child <OMERO model class AnnotationAnnotationLink>`, :ref:`AnnotationAnnotationLink.parent <OMERO model class AnnotationAnnotationLink>`, :ref:`ChannelAnnotationLink.child <OMERO model class ChannelAnnotationLink>`, :ref:`DatasetAnnotationLink.child <OMERO model class DatasetAnnotationLink>`, :ref:`DetectorAnnotationLink.child <OMERO model class DetectorAnnotationLink>`, :ref:`DichroicAnnotationLink.child <OMERO model class DichroicAnnotationLink>`, :ref:`ExperimenterAnnotationLink.child <OMERO model class ExperimenterAnnotationLink>`, :ref:`ExperimenterGroupAnnotationLink.child <OMERO model class ExperimenterGroupAnnotationLink>`, :ref:`FilesetAnnotationLink.child <OMERO model class FilesetAnnotationLink>`, :ref:`FilterAnnotationLink.child <OMERO model class FilterAnnotationLink>`, :ref:`ImageAnnotationLink.child <OMERO model class ImageAnnotationLink>`, :ref:`InstrumentAnnotationLink.child <OMERO model class InstrumentAnnotationLink>`, :ref:`LightPathAnnotationLink.child <OMERO model class LightPathAnnotationLink>`, :ref:`LightSourceAnnotationLink.child <OMERO model class LightSourceAnnotationLink>`, :ref:`NamespaceAnnotationLink.child <OMERO model class NamespaceAnnotationLink>`, :ref:`NodeAnnotationLink.child <OMERO model class NodeAnnotationLink>`, :ref:`ObjectiveAnnotationLink.child <OMERO model class ObjectiveAnnotationLink>`, :ref:`OriginalFileAnnotationLink.child <OMERO model class OriginalFileAnnotationLink>`, :ref:`PlaneInfoAnnotationLink.child <OMERO model class PlaneInfoAnnotationLink>`, :ref:`PlateAcquisitionAnnotationLink.child <OMERO model class PlateAcquisitionAnnotationLink>`, :ref:`PlateAnnotationLink.child <OMERO model class PlateAnnotationLink>`, :ref:`ProjectAnnotationLink.child <OMERO model class ProjectAnnotationLink>`, :ref:`ReagentAnnotationLink.child <OMERO model class ReagentAnnotationLink>`, :ref:`RoiAnnotationLink.child <OMERO model class RoiAnnotationLink>`, :ref:`ScreenAnnotationLink.child <OMERO model class ScreenAnnotationLink>`, :ref:`SessionAnnotationLink.child <OMERO model class SessionAnnotationLink>`, :ref:`ShapeAnnotationLink.child <OMERO model class ShapeAnnotationLink>`, :ref:`WellAnnotationLink.child <OMERO model class WellAnnotationLink>`
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`AnnotationAnnotationLink <OMERO model class AnnotationAnnotationLink>` (multiple)
   | description: ``text`` (optional)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
   | name: ``string`` (optional)
   | ns: ``string`` (optional)
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.AnnotationAnnotationLink:
+.. _OMERO model class AnnotationAnnotationLink:
 
 AnnotationAnnotationLink
 """"""""""""""""""""""""
 
-Used by: :ref:`Annotation.annotationLinks <Hibernate version of class omero.model.Annotation>`, :ref:`BasicAnnotation.annotationLinks <Hibernate version of class omero.model.BasicAnnotation>`, :ref:`BooleanAnnotation.annotationLinks <Hibernate version of class omero.model.BooleanAnnotation>`, :ref:`CommentAnnotation.annotationLinks <Hibernate version of class omero.model.CommentAnnotation>`, :ref:`DoubleAnnotation.annotationLinks <Hibernate version of class omero.model.DoubleAnnotation>`, :ref:`FileAnnotation.annotationLinks <Hibernate version of class omero.model.FileAnnotation>`, :ref:`ListAnnotation.annotationLinks <Hibernate version of class omero.model.ListAnnotation>`, :ref:`LongAnnotation.annotationLinks <Hibernate version of class omero.model.LongAnnotation>`, :ref:`MapAnnotation.annotationLinks <Hibernate version of class omero.model.MapAnnotation>`, :ref:`NumericAnnotation.annotationLinks <Hibernate version of class omero.model.NumericAnnotation>`, :ref:`TagAnnotation.annotationLinks <Hibernate version of class omero.model.TagAnnotation>`, :ref:`TermAnnotation.annotationLinks <Hibernate version of class omero.model.TermAnnotation>`, :ref:`TextAnnotation.annotationLinks <Hibernate version of class omero.model.TextAnnotation>`, :ref:`TimestampAnnotation.annotationLinks <Hibernate version of class omero.model.TimestampAnnotation>`, :ref:`TypeAnnotation.annotationLinks <Hibernate version of class omero.model.TypeAnnotation>`, :ref:`XmlAnnotation.annotationLinks <Hibernate version of class omero.model.XmlAnnotation>`
+Used by: :ref:`Annotation.annotationLinks <OMERO model class Annotation>`, :ref:`BasicAnnotation.annotationLinks <OMERO model class BasicAnnotation>`, :ref:`BooleanAnnotation.annotationLinks <OMERO model class BooleanAnnotation>`, :ref:`CommentAnnotation.annotationLinks <OMERO model class CommentAnnotation>`, :ref:`DoubleAnnotation.annotationLinks <OMERO model class DoubleAnnotation>`, :ref:`FileAnnotation.annotationLinks <OMERO model class FileAnnotation>`, :ref:`ListAnnotation.annotationLinks <OMERO model class ListAnnotation>`, :ref:`LongAnnotation.annotationLinks <OMERO model class LongAnnotation>`, :ref:`MapAnnotation.annotationLinks <OMERO model class MapAnnotation>`, :ref:`NumericAnnotation.annotationLinks <OMERO model class NumericAnnotation>`, :ref:`TagAnnotation.annotationLinks <OMERO model class TagAnnotation>`, :ref:`TermAnnotation.annotationLinks <OMERO model class TermAnnotation>`, :ref:`TextAnnotation.annotationLinks <OMERO model class TextAnnotation>`, :ref:`TimestampAnnotation.annotationLinks <OMERO model class TimestampAnnotation>`, :ref:`TypeAnnotation.annotationLinks <OMERO model class TypeAnnotation>`, :ref:`XmlAnnotation.annotationLinks <OMERO model class XmlAnnotation>`
 
 Properties:
-  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Annotation <OMERO model class Annotation>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`Annotation <OMERO model class Annotation>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.Arc:
+.. _OMERO model class Arc:
 
 Arc
 """
 
 Properties:
-  | annotationLinks: :ref:`LightSourceAnnotationLink <Hibernate version of class omero.model.LightSourceAnnotationLink>` (multiple) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | details.permissions.perm1: ``long`` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | instrument: :ref:`Instrument <Hibernate version of class omero.model.Instrument>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | lotNumber: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | manufacturer: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | model: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | power.unit: enumeration (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`, see :javadoc:`PowerI <omero/model/PowerI.html>`
-  | power.value: ``double`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`, see :javadoc:`PowerI <omero/model/PowerI.html>`
-  | serialNumber: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | type: :ref:`ArcType <Hibernate version of class omero.model.ArcType>`
-  | version: ``integer`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | annotationLinks: :ref:`LightSourceAnnotationLink <OMERO model class LightSourceAnnotationLink>` (multiple) from :ref:`LightSource <OMERO model class LightSource>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`LightSource <OMERO model class LightSource>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`LightSource <OMERO model class LightSource>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`LightSource <OMERO model class LightSource>`
+  | details.permissions.perm1: ``long`` from :ref:`LightSource <OMERO model class LightSource>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`LightSource <OMERO model class LightSource>`
+  | instrument: :ref:`Instrument <OMERO model class Instrument>` from :ref:`LightSource <OMERO model class LightSource>`
+  | lotNumber: ``string`` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | manufacturer: ``string`` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | model: ``string`` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | power.unit: enumeration of :javadoc:`Power <ome/model/units/Power.html>` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | power.value: ``double`` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | serialNumber: ``string`` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | type: :ref:`ArcType <OMERO model class ArcType>`
+  | version: ``integer`` (optional) from :ref:`LightSource <OMERO model class LightSource>`
 
-.. _Hibernate version of class omero.model.ArcType:
+.. _OMERO model class ArcType:
 
 ArcType
 """""""
 
-Used by: :ref:`Arc.type <Hibernate version of class omero.model.Arc>`
+Used by: :ref:`Arc.type <OMERO model class Arc>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
+  | value: ``string``, see :javadoc:`IEnum <ome/model/IEnum.html>`
 
-.. _Hibernate version of class omero.model.BasicAnnotation:
+.. _OMERO model class BasicAnnotation:
 
 BasicAnnotation
 """""""""""""""
 
-Subclasses: :ref:`BooleanAnnotation <Hibernate version of class omero.model.BooleanAnnotation>`, :ref:`NumericAnnotation <Hibernate version of class omero.model.NumericAnnotation>`, :ref:`TermAnnotation <Hibernate version of class omero.model.TermAnnotation>`, :ref:`TimestampAnnotation <Hibernate version of class omero.model.TimestampAnnotation>`
+Subclasses: :ref:`BooleanAnnotation <OMERO model class BooleanAnnotation>`, :ref:`NumericAnnotation <OMERO model class NumericAnnotation>`, :ref:`TermAnnotation <OMERO model class TermAnnotation>`, :ref:`TimestampAnnotation <OMERO model class TimestampAnnotation>`
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | description: ``text`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.permissions.perm1: ``long`` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | name: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | ns: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | version: ``integer`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | annotationLinks: :ref:`AnnotationAnnotationLink <OMERO model class AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <OMERO model class Annotation>`
+  | description: ``text`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.permissions.perm1: ``long`` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Annotation <OMERO model class Annotation>`
+  | name: ``string`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | ns: ``string`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | version: ``integer`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
 
-.. _Hibernate version of class omero.model.Binning:
+.. _OMERO model class Binning:
 
 Binning
 """""""
 
-Used by: :ref:`DetectorSettings.binning <Hibernate version of class omero.model.DetectorSettings>`
+Used by: :ref:`DetectorSettings.binning <OMERO model class DetectorSettings>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
+  | value: ``string``, see :javadoc:`IEnum <ome/model/IEnum.html>`
 
-.. _Hibernate version of class omero.model.BooleanAnnotation:
+.. _OMERO model class BooleanAnnotation:
 
 BooleanAnnotation
 """""""""""""""""
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | annotationLinks: :ref:`AnnotationAnnotationLink <OMERO model class AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <OMERO model class Annotation>`
   | boolValue: ``boolean`` (optional)
-  | description: ``text`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.permissions.perm1: ``long`` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | name: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | ns: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | version: ``integer`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | description: ``text`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.permissions.perm1: ``long`` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Annotation <OMERO model class Annotation>`
+  | name: ``string`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | ns: ``string`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | version: ``integer`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
 
-.. _Hibernate version of class omero.model.Channel:
+.. _OMERO model class Channel:
 
 Channel
 """""""
 
-Used by: :ref:`ChannelAnnotationLink.parent <Hibernate version of class omero.model.ChannelAnnotationLink>`, :ref:`LogicalChannel.channels <Hibernate version of class omero.model.LogicalChannel>`, :ref:`Pixels.channels <Hibernate version of class omero.model.Pixels>`
+Used by: :ref:`ChannelAnnotationLink.parent <OMERO model class ChannelAnnotationLink>`, :ref:`LogicalChannel.channels <OMERO model class LogicalChannel>`, :ref:`Pixels.channels <OMERO model class Pixels>`
 
 Properties:
   | alpha: ``integer`` (optional)
-  | annotationLinks: :ref:`ChannelAnnotationLink <Hibernate version of class omero.model.ChannelAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`ChannelAnnotationLink <OMERO model class ChannelAnnotationLink>` (multiple)
   | blue: ``integer`` (optional)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
   | green: ``integer`` (optional)
-  | logicalChannel: :ref:`LogicalChannel <Hibernate version of class omero.model.LogicalChannel>`
-  | pixels: :ref:`Pixels <Hibernate version of class omero.model.Pixels>`
+  | logicalChannel: :ref:`LogicalChannel <OMERO model class LogicalChannel>`
+  | lookupTable: ``string`` (optional)
+  | pixels: :ref:`Pixels <OMERO model class Pixels>`
   | red: ``integer`` (optional)
-  | statsInfo: :ref:`StatsInfo <Hibernate version of class omero.model.StatsInfo>` (optional)
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | statsInfo: :ref:`StatsInfo <OMERO model class StatsInfo>` (optional)
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.ChannelAnnotationLink:
+.. _OMERO model class ChannelAnnotationLink:
 
 ChannelAnnotationLink
 """""""""""""""""""""
 
-Used by: :ref:`Channel.annotationLinks <Hibernate version of class omero.model.Channel>`
+Used by: :ref:`Channel.annotationLinks <OMERO model class Channel>`
 
 Properties:
-  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Annotation <OMERO model class Annotation>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`Channel <Hibernate version of class omero.model.Channel>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`Channel <OMERO model class Channel>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.ChannelBinding:
+.. _OMERO model class ChannelBinding:
 
 ChannelBinding
 """"""""""""""
 
-Used by: :ref:`RenderingDef.waveRendering <Hibernate version of class omero.model.RenderingDef>`
+Used by: :ref:`RenderingDef.waveRendering <OMERO model class RenderingDef>`
 
 Properties:
   | active: ``boolean``
   | alpha: ``integer``
   | blue: ``integer``
   | coefficient: ``double``
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | family: :ref:`Family <Hibernate version of class omero.model.Family>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | family: :ref:`Family <OMERO model class Family>`
   | green: ``integer``
   | inputEnd: ``double``
   | inputStart: ``double``
+  | lookupTable: ``string`` (optional)
   | noiseReduction: ``boolean``
   | red: ``integer``
-  | renderingDef: :ref:`RenderingDef <Hibernate version of class omero.model.RenderingDef>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | renderingDef: :ref:`RenderingDef <OMERO model class RenderingDef>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.ChecksumAlgorithm:
+.. _OMERO model class ChecksumAlgorithm:
 
 ChecksumAlgorithm
 """""""""""""""""
 
-Used by: :ref:`OriginalFile.hasher <Hibernate version of class omero.model.OriginalFile>`
+Used by: :ref:`OriginalFile.hasher <OMERO model class OriginalFile>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
+  | value: ``string``, see :javadoc:`IEnum <ome/model/IEnum.html>`
 
-.. _Hibernate version of class omero.model.CodomainMapContext:
+.. _OMERO model class CodomainMapContext:
 
 CodomainMapContext
 """"""""""""""""""
 
-Subclasses: :ref:`ContrastStretchingContext <Hibernate version of class omero.model.ContrastStretchingContext>`, :ref:`PlaneSlicingContext <Hibernate version of class omero.model.PlaneSlicingContext>`, :ref:`ReverseIntensityContext <Hibernate version of class omero.model.ReverseIntensityContext>`
+Subclasses: :ref:`ContrastStretchingContext <OMERO model class ContrastStretchingContext>`, :ref:`PlaneSlicingContext <OMERO model class PlaneSlicingContext>`, :ref:`ReverseIntensityContext <OMERO model class ReverseIntensityContext>`
 
-Used by: :ref:`RenderingDef.spatialDomainEnhancement <Hibernate version of class omero.model.RenderingDef>`
+Used by: :ref:`RenderingDef.spatialDomainEnhancement <OMERO model class RenderingDef>`
 
 Properties:
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | renderingDef: :ref:`RenderingDef <Hibernate version of class omero.model.RenderingDef>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | renderingDef: :ref:`RenderingDef <OMERO model class RenderingDef>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.CommentAnnotation:
+.. _OMERO model class CommentAnnotation:
 
 CommentAnnotation
 """""""""""""""""
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | description: ``text`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.permissions.perm1: ``long`` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | name: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | ns: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | textValue: ``text`` (optional) from :ref:`TextAnnotation <Hibernate version of class omero.model.TextAnnotation>`
-  | version: ``integer`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | annotationLinks: :ref:`AnnotationAnnotationLink <OMERO model class AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <OMERO model class Annotation>`
+  | description: ``text`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.permissions.perm1: ``long`` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Annotation <OMERO model class Annotation>`
+  | name: ``string`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | ns: ``string`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | textValue: ``text`` (optional) from :ref:`TextAnnotation <OMERO model class TextAnnotation>`
+  | version: ``integer`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
 
-.. _Hibernate version of class omero.model.ContrastMethod:
+.. _OMERO model class ContrastMethod:
 
 ContrastMethod
 """"""""""""""
 
-Used by: :ref:`LogicalChannel.contrastMethod <Hibernate version of class omero.model.LogicalChannel>`
+Used by: :ref:`LogicalChannel.contrastMethod <OMERO model class LogicalChannel>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
+  | value: ``string``, see :javadoc:`IEnum <ome/model/IEnum.html>`
 
-.. _Hibernate version of class omero.model.ContrastStretchingContext:
+.. _OMERO model class ContrastStretchingContext:
 
 ContrastStretchingContext
 """""""""""""""""""""""""
 
 Properties:
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
-  | details.permissions.perm1: ``long`` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
-  | renderingDef: :ref:`RenderingDef <Hibernate version of class omero.model.RenderingDef>` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
-  | version: ``integer`` (optional) from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`CodomainMapContext <OMERO model class CodomainMapContext>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`CodomainMapContext <OMERO model class CodomainMapContext>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`CodomainMapContext <OMERO model class CodomainMapContext>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`CodomainMapContext <OMERO model class CodomainMapContext>`
+  | details.permissions.perm1: ``long`` from :ref:`CodomainMapContext <OMERO model class CodomainMapContext>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`CodomainMapContext <OMERO model class CodomainMapContext>`
+  | renderingDef: :ref:`RenderingDef <OMERO model class RenderingDef>` from :ref:`CodomainMapContext <OMERO model class CodomainMapContext>`
+  | version: ``integer`` (optional) from :ref:`CodomainMapContext <OMERO model class CodomainMapContext>`
   | xend: ``integer``
   | xstart: ``integer``
   | yend: ``integer``
   | ystart: ``integer``
 
-.. _Hibernate version of class omero.model.Correction:
+.. _OMERO model class Correction:
 
 Correction
 """"""""""
 
-Used by: :ref:`Objective.correction <Hibernate version of class omero.model.Objective>`
+Used by: :ref:`Objective.correction <OMERO model class Objective>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
+  | value: ``string``, see :javadoc:`IEnum <ome/model/IEnum.html>`
 
-.. _Hibernate version of class omero.model.DBPatch:
+.. _OMERO model class DBPatch:
 
 DBPatch
 """""""
@@ -323,1733 +325,1733 @@ DBPatch
 Properties:
   | currentPatch: ``integer``
   | currentVersion: ``string``
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | finished: ``timestamp`` (optional)
   | message: ``string`` (optional)
   | previousPatch: ``integer``
   | previousVersion: ``string``
 
-.. _Hibernate version of class omero.model.Dataset:
+.. _OMERO model class Dataset:
 
 Dataset
 """""""
 
-Used by: :ref:`DatasetAnnotationLink.parent <Hibernate version of class omero.model.DatasetAnnotationLink>`, :ref:`DatasetImageLink.parent <Hibernate version of class omero.model.DatasetImageLink>`, :ref:`ProjectDatasetLink.child <Hibernate version of class omero.model.ProjectDatasetLink>`
+Used by: :ref:`DatasetAnnotationLink.parent <OMERO model class DatasetAnnotationLink>`, :ref:`DatasetImageLink.parent <OMERO model class DatasetImageLink>`, :ref:`ProjectDatasetLink.child <OMERO model class ProjectDatasetLink>`
 
 Properties:
-  | annotationLinks: :ref:`DatasetAnnotationLink <Hibernate version of class omero.model.DatasetAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`DatasetAnnotationLink <OMERO model class DatasetAnnotationLink>` (multiple)
   | description: ``text`` (optional)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | imageLinks: :ref:`DatasetImageLink <Hibernate version of class omero.model.DatasetImageLink>` (multiple)
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | imageLinks: :ref:`DatasetImageLink <OMERO model class DatasetImageLink>` (multiple)
   | name: ``string``
-  | projectLinks: :ref:`ProjectDatasetLink <Hibernate version of class omero.model.ProjectDatasetLink>` (multiple)
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | projectLinks: :ref:`ProjectDatasetLink <OMERO model class ProjectDatasetLink>` (multiple)
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.DatasetAnnotationLink:
+.. _OMERO model class DatasetAnnotationLink:
 
 DatasetAnnotationLink
 """""""""""""""""""""
 
-Used by: :ref:`Dataset.annotationLinks <Hibernate version of class omero.model.Dataset>`
+Used by: :ref:`Dataset.annotationLinks <OMERO model class Dataset>`
 
 Properties:
-  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Annotation <OMERO model class Annotation>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`Dataset <Hibernate version of class omero.model.Dataset>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`Dataset <OMERO model class Dataset>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.DatasetImageLink:
+.. _OMERO model class DatasetImageLink:
 
 DatasetImageLink
 """"""""""""""""
 
-Used by: :ref:`Dataset.imageLinks <Hibernate version of class omero.model.Dataset>`, :ref:`Image.datasetLinks <Hibernate version of class omero.model.Image>`
+Used by: :ref:`Dataset.imageLinks <OMERO model class Dataset>`, :ref:`Image.datasetLinks <OMERO model class Image>`
 
 Properties:
-  | child: :ref:`Image <Hibernate version of class omero.model.Image>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Image <OMERO model class Image>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`Dataset <Hibernate version of class omero.model.Dataset>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`Dataset <OMERO model class Dataset>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.Detector:
+.. _OMERO model class Detector:
 
 Detector
 """"""""
 
-Used by: :ref:`DetectorAnnotationLink.parent <Hibernate version of class omero.model.DetectorAnnotationLink>`, :ref:`DetectorSettings.detector <Hibernate version of class omero.model.DetectorSettings>`, :ref:`Instrument.detector <Hibernate version of class omero.model.Instrument>`
+Used by: :ref:`DetectorAnnotationLink.parent <OMERO model class DetectorAnnotationLink>`, :ref:`DetectorSettings.detector <OMERO model class DetectorSettings>`, :ref:`Instrument.detector <OMERO model class Instrument>`
 
 Properties:
   | amplificationGain: ``double`` (optional)
-  | annotationLinks: :ref:`DetectorAnnotationLink <Hibernate version of class omero.model.DetectorAnnotationLink>` (multiple)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | annotationLinks: :ref:`DetectorAnnotationLink <OMERO model class DetectorAnnotationLink>` (multiple)
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
   | gain: ``double`` (optional)
-  | instrument: :ref:`Instrument <Hibernate version of class omero.model.Instrument>`
+  | instrument: :ref:`Instrument <OMERO model class Instrument>`
   | lotNumber: ``string`` (optional)
   | manufacturer: ``string`` (optional)
   | model: ``string`` (optional)
   | offsetValue: ``double`` (optional)
   | serialNumber: ``string`` (optional)
-  | type: :ref:`DetectorType <Hibernate version of class omero.model.DetectorType>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
-  | voltage.unit: enumeration (optional), see :javadoc:`ElectricPotentialI <omero/model/ElectricPotentialI.html>`
-  | voltage.value: ``double`` (optional), see :javadoc:`ElectricPotentialI <omero/model/ElectricPotentialI.html>`
+  | type: :ref:`DetectorType <OMERO model class DetectorType>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
+  | voltage.unit: enumeration of :javadoc:`ElectricPotential <ome/model/units/ElectricPotential.html>` (optional)
+  | voltage.value: ``double`` (optional)
   | zoom: ``double`` (optional)
 
-.. _Hibernate version of class omero.model.DetectorAnnotationLink:
+.. _OMERO model class DetectorAnnotationLink:
 
 DetectorAnnotationLink
 """"""""""""""""""""""
 
-Used by: :ref:`Detector.annotationLinks <Hibernate version of class omero.model.Detector>`
+Used by: :ref:`Detector.annotationLinks <OMERO model class Detector>`
 
 Properties:
-  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Annotation <OMERO model class Annotation>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`Detector <Hibernate version of class omero.model.Detector>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`Detector <OMERO model class Detector>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.DetectorSettings:
+.. _OMERO model class DetectorSettings:
 
 DetectorSettings
 """"""""""""""""
 
-Used by: :ref:`LogicalChannel.detectorSettings <Hibernate version of class omero.model.LogicalChannel>`
+Used by: :ref:`LogicalChannel.detectorSettings <OMERO model class LogicalChannel>`
 
 Properties:
-  | binning: :ref:`Binning <Hibernate version of class omero.model.Binning>` (optional)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | binning: :ref:`Binning <OMERO model class Binning>` (optional)
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | detector: :ref:`Detector <Hibernate version of class omero.model.Detector>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | detector: :ref:`Detector <OMERO model class Detector>`
   | gain: ``double`` (optional)
   | integration: ``integer`` (optional)
   | offsetValue: ``double`` (optional)
-  | readOutRate.unit: enumeration (optional), see :javadoc:`FrequencyI <omero/model/FrequencyI.html>`
-  | readOutRate.value: ``double`` (optional), see :javadoc:`FrequencyI <omero/model/FrequencyI.html>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
-  | voltage.unit: enumeration (optional), see :javadoc:`ElectricPotentialI <omero/model/ElectricPotentialI.html>`
-  | voltage.value: ``double`` (optional), see :javadoc:`ElectricPotentialI <omero/model/ElectricPotentialI.html>`
+  | readOutRate.unit: enumeration of :javadoc:`Frequency <ome/model/units/Frequency.html>` (optional)
+  | readOutRate.value: ``double`` (optional)
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
+  | voltage.unit: enumeration of :javadoc:`ElectricPotential <ome/model/units/ElectricPotential.html>` (optional)
+  | voltage.value: ``double`` (optional)
   | zoom: ``double`` (optional)
 
-.. _Hibernate version of class omero.model.DetectorType:
+.. _OMERO model class DetectorType:
 
 DetectorType
 """"""""""""
 
-Used by: :ref:`Detector.type <Hibernate version of class omero.model.Detector>`
+Used by: :ref:`Detector.type <OMERO model class Detector>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
+  | value: ``string``, see :javadoc:`IEnum <ome/model/IEnum.html>`
 
-.. _Hibernate version of class omero.model.Dichroic:
+.. _OMERO model class Dichroic:
 
 Dichroic
 """"""""
 
-Used by: :ref:`DichroicAnnotationLink.parent <Hibernate version of class omero.model.DichroicAnnotationLink>`, :ref:`FilterSet.dichroic <Hibernate version of class omero.model.FilterSet>`, :ref:`Instrument.dichroic <Hibernate version of class omero.model.Instrument>`, :ref:`LightPath.dichroic <Hibernate version of class omero.model.LightPath>`
+Used by: :ref:`DichroicAnnotationLink.parent <OMERO model class DichroicAnnotationLink>`, :ref:`FilterSet.dichroic <OMERO model class FilterSet>`, :ref:`Instrument.dichroic <OMERO model class Instrument>`, :ref:`LightPath.dichroic <OMERO model class LightPath>`
 
 Properties:
-  | annotationLinks: :ref:`DichroicAnnotationLink <Hibernate version of class omero.model.DichroicAnnotationLink>` (multiple)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | annotationLinks: :ref:`DichroicAnnotationLink <OMERO model class DichroicAnnotationLink>` (multiple)
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | instrument: :ref:`Instrument <Hibernate version of class omero.model.Instrument>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | instrument: :ref:`Instrument <OMERO model class Instrument>`
   | lotNumber: ``string`` (optional)
   | manufacturer: ``string`` (optional)
   | model: ``string`` (optional)
   | serialNumber: ``string`` (optional)
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.DichroicAnnotationLink:
+.. _OMERO model class DichroicAnnotationLink:
 
 DichroicAnnotationLink
 """"""""""""""""""""""
 
-Used by: :ref:`Dichroic.annotationLinks <Hibernate version of class omero.model.Dichroic>`
+Used by: :ref:`Dichroic.annotationLinks <OMERO model class Dichroic>`
 
 Properties:
-  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Annotation <OMERO model class Annotation>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`Dichroic <Hibernate version of class omero.model.Dichroic>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`Dichroic <OMERO model class Dichroic>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.DimensionOrder:
+.. _OMERO model class DimensionOrder:
 
 DimensionOrder
 """"""""""""""
 
-Used by: :ref:`Pixels.dimensionOrder <Hibernate version of class omero.model.Pixels>`
+Used by: :ref:`Pixels.dimensionOrder <OMERO model class Pixels>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
+  | value: ``string``, see :javadoc:`IEnum <ome/model/IEnum.html>`
 
-.. _Hibernate version of class omero.model.DoubleAnnotation:
+.. _OMERO model class DoubleAnnotation:
 
 DoubleAnnotation
 """"""""""""""""
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | description: ``text`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.permissions.perm1: ``long`` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | annotationLinks: :ref:`AnnotationAnnotationLink <OMERO model class AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <OMERO model class Annotation>`
+  | description: ``text`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.permissions.perm1: ``long`` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Annotation <OMERO model class Annotation>`
   | doubleValue: ``double`` (optional)
-  | name: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | ns: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | version: ``integer`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | name: ``string`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | ns: ``string`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | version: ``integer`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
 
-.. _Hibernate version of class omero.model.Ellipse:
+.. _OMERO model class Ellipse:
 
 Ellipse
 """""""
 
 Properties:
-  | annotationLinks: :ref:`ShapeAnnotationLink <Hibernate version of class omero.model.ShapeAnnotationLink>` (multiple) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | annotationLinks: :ref:`ShapeAnnotationLink <OMERO model class ShapeAnnotationLink>` (multiple) from :ref:`Shape <OMERO model class Shape>`
   | cx: ``double`` (optional)
   | cy: ``double`` (optional)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.permissions.perm1: ``long`` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fillColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fillRule: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontFamily: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontSize.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | fontSize.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | fontStretch: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontStyle: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontVariant: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontWeight: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | g: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | locked: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | roi: :ref:`Roi <Hibernate version of class omero.model.Roi>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Shape <OMERO model class Shape>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Shape <OMERO model class Shape>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Shape <OMERO model class Shape>`
+  | details.permissions.perm1: ``long`` from :ref:`Shape <OMERO model class Shape>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Shape <OMERO model class Shape>`
+  | fillColor: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fillRule: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontFamily: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontSize.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontSize.value: ``double`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontStretch: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontStyle: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontVariant: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontWeight: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | g: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | locked: ``boolean`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | roi: :ref:`Roi <OMERO model class Roi>` from :ref:`Shape <OMERO model class Shape>`
   | rx: ``double`` (optional)
   | ry: ``double`` (optional)
-  | strokeColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeDashArray: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeLineCap: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeWidth.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
+  | strokeColor: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeDashArray: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeLineCap: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeWidth.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <OMERO model class Shape>`
   | textValue: ``text`` (optional)
-  | theC: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | theT: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | theZ: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | transform: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | vectorEffect: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | version: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | visibility: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | theC: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | theT: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | theZ: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | transform: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | vectorEffect: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | version: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | visibility: ``boolean`` (optional) from :ref:`Shape <OMERO model class Shape>`
 
-.. _Hibernate version of class omero.model.Event:
+.. _OMERO model class Event:
 
 Event
 """""
 
-Used by: :ref:`Annotation.details.creationEvent <Hibernate version of class omero.model.Annotation>`, :ref:`Annotation.details.updateEvent <Hibernate version of class omero.model.Annotation>`, :ref:`AnnotationAnnotationLink.details.creationEvent <Hibernate version of class omero.model.AnnotationAnnotationLink>`, :ref:`AnnotationAnnotationLink.details.updateEvent <Hibernate version of class omero.model.AnnotationAnnotationLink>`, :ref:`Arc.details.creationEvent <Hibernate version of class omero.model.Arc>`, :ref:`Arc.details.updateEvent <Hibernate version of class omero.model.Arc>`, :ref:`BasicAnnotation.details.creationEvent <Hibernate version of class omero.model.BasicAnnotation>`, :ref:`BasicAnnotation.details.updateEvent <Hibernate version of class omero.model.BasicAnnotation>`, :ref:`BooleanAnnotation.details.creationEvent <Hibernate version of class omero.model.BooleanAnnotation>`, :ref:`BooleanAnnotation.details.updateEvent <Hibernate version of class omero.model.BooleanAnnotation>`, :ref:`Channel.details.creationEvent <Hibernate version of class omero.model.Channel>`, :ref:`Channel.details.updateEvent <Hibernate version of class omero.model.Channel>`, :ref:`ChannelAnnotationLink.details.creationEvent <Hibernate version of class omero.model.ChannelAnnotationLink>`, :ref:`ChannelAnnotationLink.details.updateEvent <Hibernate version of class omero.model.ChannelAnnotationLink>`, :ref:`ChannelBinding.details.creationEvent <Hibernate version of class omero.model.ChannelBinding>`, :ref:`ChannelBinding.details.updateEvent <Hibernate version of class omero.model.ChannelBinding>`, :ref:`CodomainMapContext.details.creationEvent <Hibernate version of class omero.model.CodomainMapContext>`, :ref:`CodomainMapContext.details.updateEvent <Hibernate version of class omero.model.CodomainMapContext>`, :ref:`CommentAnnotation.details.creationEvent <Hibernate version of class omero.model.CommentAnnotation>`, :ref:`CommentAnnotation.details.updateEvent <Hibernate version of class omero.model.CommentAnnotation>`, :ref:`ContrastStretchingContext.details.creationEvent <Hibernate version of class omero.model.ContrastStretchingContext>`, :ref:`ContrastStretchingContext.details.updateEvent <Hibernate version of class omero.model.ContrastStretchingContext>`, :ref:`Dataset.details.creationEvent <Hibernate version of class omero.model.Dataset>`, :ref:`Dataset.details.updateEvent <Hibernate version of class omero.model.Dataset>`, :ref:`DatasetAnnotationLink.details.creationEvent <Hibernate version of class omero.model.DatasetAnnotationLink>`, :ref:`DatasetAnnotationLink.details.updateEvent <Hibernate version of class omero.model.DatasetAnnotationLink>`, :ref:`DatasetImageLink.details.creationEvent <Hibernate version of class omero.model.DatasetImageLink>`, :ref:`DatasetImageLink.details.updateEvent <Hibernate version of class omero.model.DatasetImageLink>`, :ref:`Detector.details.creationEvent <Hibernate version of class omero.model.Detector>`, :ref:`Detector.details.updateEvent <Hibernate version of class omero.model.Detector>`, :ref:`DetectorAnnotationLink.details.creationEvent <Hibernate version of class omero.model.DetectorAnnotationLink>`, :ref:`DetectorAnnotationLink.details.updateEvent <Hibernate version of class omero.model.DetectorAnnotationLink>`, :ref:`DetectorSettings.details.creationEvent <Hibernate version of class omero.model.DetectorSettings>`, :ref:`DetectorSettings.details.updateEvent <Hibernate version of class omero.model.DetectorSettings>`, :ref:`Dichroic.details.creationEvent <Hibernate version of class omero.model.Dichroic>`, :ref:`Dichroic.details.updateEvent <Hibernate version of class omero.model.Dichroic>`, :ref:`DichroicAnnotationLink.details.creationEvent <Hibernate version of class omero.model.DichroicAnnotationLink>`, :ref:`DichroicAnnotationLink.details.updateEvent <Hibernate version of class omero.model.DichroicAnnotationLink>`, :ref:`DoubleAnnotation.details.creationEvent <Hibernate version of class omero.model.DoubleAnnotation>`, :ref:`DoubleAnnotation.details.updateEvent <Hibernate version of class omero.model.DoubleAnnotation>`, :ref:`Ellipse.details.creationEvent <Hibernate version of class omero.model.Ellipse>`, :ref:`Ellipse.details.updateEvent <Hibernate version of class omero.model.Ellipse>`, :ref:`Event.containingEvent <Hibernate version of class omero.model.Event>`, :ref:`EventLog.event <Hibernate version of class omero.model.EventLog>`, :ref:`Experiment.details.creationEvent <Hibernate version of class omero.model.Experiment>`, :ref:`Experiment.details.updateEvent <Hibernate version of class omero.model.Experiment>`, :ref:`ExperimenterAnnotationLink.details.creationEvent <Hibernate version of class omero.model.ExperimenterAnnotationLink>`, :ref:`ExperimenterAnnotationLink.details.updateEvent <Hibernate version of class omero.model.ExperimenterAnnotationLink>`, :ref:`ExperimenterGroupAnnotationLink.details.creationEvent <Hibernate version of class omero.model.ExperimenterGroupAnnotationLink>`, :ref:`ExperimenterGroupAnnotationLink.details.updateEvent <Hibernate version of class omero.model.ExperimenterGroupAnnotationLink>`, :ref:`ExternalInfo.details.creationEvent <Hibernate version of class omero.model.ExternalInfo>`, :ref:`Filament.details.creationEvent <Hibernate version of class omero.model.Filament>`, :ref:`Filament.details.updateEvent <Hibernate version of class omero.model.Filament>`, :ref:`FileAnnotation.details.creationEvent <Hibernate version of class omero.model.FileAnnotation>`, :ref:`FileAnnotation.details.updateEvent <Hibernate version of class omero.model.FileAnnotation>`, :ref:`Fileset.details.creationEvent <Hibernate version of class omero.model.Fileset>`, :ref:`Fileset.details.updateEvent <Hibernate version of class omero.model.Fileset>`, :ref:`FilesetAnnotationLink.details.creationEvent <Hibernate version of class omero.model.FilesetAnnotationLink>`, :ref:`FilesetAnnotationLink.details.updateEvent <Hibernate version of class omero.model.FilesetAnnotationLink>`, :ref:`FilesetEntry.details.creationEvent <Hibernate version of class omero.model.FilesetEntry>`, :ref:`FilesetEntry.details.updateEvent <Hibernate version of class omero.model.FilesetEntry>`, :ref:`FilesetJobLink.details.creationEvent <Hibernate version of class omero.model.FilesetJobLink>`, :ref:`FilesetJobLink.details.updateEvent <Hibernate version of class omero.model.FilesetJobLink>`, :ref:`Filter.details.creationEvent <Hibernate version of class omero.model.Filter>`, :ref:`Filter.details.updateEvent <Hibernate version of class omero.model.Filter>`, :ref:`FilterAnnotationLink.details.creationEvent <Hibernate version of class omero.model.FilterAnnotationLink>`, :ref:`FilterAnnotationLink.details.updateEvent <Hibernate version of class omero.model.FilterAnnotationLink>`, :ref:`FilterSet.details.creationEvent <Hibernate version of class omero.model.FilterSet>`, :ref:`FilterSet.details.updateEvent <Hibernate version of class omero.model.FilterSet>`, :ref:`FilterSetEmissionFilterLink.details.creationEvent <Hibernate version of class omero.model.FilterSetEmissionFilterLink>`, :ref:`FilterSetEmissionFilterLink.details.updateEvent <Hibernate version of class omero.model.FilterSetEmissionFilterLink>`, :ref:`FilterSetExcitationFilterLink.details.creationEvent <Hibernate version of class omero.model.FilterSetExcitationFilterLink>`, :ref:`FilterSetExcitationFilterLink.details.updateEvent <Hibernate version of class omero.model.FilterSetExcitationFilterLink>`, :ref:`GenericExcitationSource.details.creationEvent <Hibernate version of class omero.model.GenericExcitationSource>`, :ref:`GenericExcitationSource.details.updateEvent <Hibernate version of class omero.model.GenericExcitationSource>`, :ref:`Image.details.creationEvent <Hibernate version of class omero.model.Image>`, :ref:`Image.details.updateEvent <Hibernate version of class omero.model.Image>`, :ref:`ImageAnnotationLink.details.creationEvent <Hibernate version of class omero.model.ImageAnnotationLink>`, :ref:`ImageAnnotationLink.details.updateEvent <Hibernate version of class omero.model.ImageAnnotationLink>`, :ref:`ImagingEnvironment.details.creationEvent <Hibernate version of class omero.model.ImagingEnvironment>`, :ref:`ImagingEnvironment.details.updateEvent <Hibernate version of class omero.model.ImagingEnvironment>`, :ref:`ImportJob.details.creationEvent <Hibernate version of class omero.model.ImportJob>`, :ref:`ImportJob.details.updateEvent <Hibernate version of class omero.model.ImportJob>`, :ref:`IndexingJob.details.creationEvent <Hibernate version of class omero.model.IndexingJob>`, :ref:`IndexingJob.details.updateEvent <Hibernate version of class omero.model.IndexingJob>`, :ref:`Instrument.details.creationEvent <Hibernate version of class omero.model.Instrument>`, :ref:`Instrument.details.updateEvent <Hibernate version of class omero.model.Instrument>`, :ref:`InstrumentAnnotationLink.details.creationEvent <Hibernate version of class omero.model.InstrumentAnnotationLink>`, :ref:`InstrumentAnnotationLink.details.updateEvent <Hibernate version of class omero.model.InstrumentAnnotationLink>`, :ref:`IntegrityCheckJob.details.creationEvent <Hibernate version of class omero.model.IntegrityCheckJob>`, :ref:`IntegrityCheckJob.details.updateEvent <Hibernate version of class omero.model.IntegrityCheckJob>`, :ref:`Job.details.creationEvent <Hibernate version of class omero.model.Job>`, :ref:`Job.details.updateEvent <Hibernate version of class omero.model.Job>`, :ref:`JobOriginalFileLink.details.creationEvent <Hibernate version of class omero.model.JobOriginalFileLink>`, :ref:`JobOriginalFileLink.details.updateEvent <Hibernate version of class omero.model.JobOriginalFileLink>`, :ref:`Label.details.creationEvent <Hibernate version of class omero.model.Label>`, :ref:`Label.details.updateEvent <Hibernate version of class omero.model.Label>`, :ref:`Laser.details.creationEvent <Hibernate version of class omero.model.Laser>`, :ref:`Laser.details.updateEvent <Hibernate version of class omero.model.Laser>`, :ref:`LightEmittingDiode.details.creationEvent <Hibernate version of class omero.model.LightEmittingDiode>`, :ref:`LightEmittingDiode.details.updateEvent <Hibernate version of class omero.model.LightEmittingDiode>`, :ref:`LightPath.details.creationEvent <Hibernate version of class omero.model.LightPath>`, :ref:`LightPath.details.updateEvent <Hibernate version of class omero.model.LightPath>`, :ref:`LightPathAnnotationLink.details.creationEvent <Hibernate version of class omero.model.LightPathAnnotationLink>`, :ref:`LightPathAnnotationLink.details.updateEvent <Hibernate version of class omero.model.LightPathAnnotationLink>`, :ref:`LightPathEmissionFilterLink.details.creationEvent <Hibernate version of class omero.model.LightPathEmissionFilterLink>`, :ref:`LightPathEmissionFilterLink.details.updateEvent <Hibernate version of class omero.model.LightPathEmissionFilterLink>`, :ref:`LightPathExcitationFilterLink.details.creationEvent <Hibernate version of class omero.model.LightPathExcitationFilterLink>`, :ref:`LightPathExcitationFilterLink.details.updateEvent <Hibernate version of class omero.model.LightPathExcitationFilterLink>`, :ref:`LightSettings.details.creationEvent <Hibernate version of class omero.model.LightSettings>`, :ref:`LightSettings.details.updateEvent <Hibernate version of class omero.model.LightSettings>`, :ref:`LightSource.details.creationEvent <Hibernate version of class omero.model.LightSource>`, :ref:`LightSource.details.updateEvent <Hibernate version of class omero.model.LightSource>`, :ref:`LightSourceAnnotationLink.details.creationEvent <Hibernate version of class omero.model.LightSourceAnnotationLink>`, :ref:`LightSourceAnnotationLink.details.updateEvent <Hibernate version of class omero.model.LightSourceAnnotationLink>`, :ref:`Line.details.creationEvent <Hibernate version of class omero.model.Line>`, :ref:`Line.details.updateEvent <Hibernate version of class omero.model.Line>`, :ref:`Link.details.creationEvent <Hibernate version of class omero.model.Link>`, :ref:`Link.details.updateEvent <Hibernate version of class omero.model.Link>`, :ref:`ListAnnotation.details.creationEvent <Hibernate version of class omero.model.ListAnnotation>`, :ref:`ListAnnotation.details.updateEvent <Hibernate version of class omero.model.ListAnnotation>`, :ref:`LogicalChannel.details.creationEvent <Hibernate version of class omero.model.LogicalChannel>`, :ref:`LogicalChannel.details.updateEvent <Hibernate version of class omero.model.LogicalChannel>`, :ref:`LongAnnotation.details.creationEvent <Hibernate version of class omero.model.LongAnnotation>`, :ref:`LongAnnotation.details.updateEvent <Hibernate version of class omero.model.LongAnnotation>`, :ref:`MapAnnotation.details.creationEvent <Hibernate version of class omero.model.MapAnnotation>`, :ref:`MapAnnotation.details.updateEvent <Hibernate version of class omero.model.MapAnnotation>`, :ref:`Mask.details.creationEvent <Hibernate version of class omero.model.Mask>`, :ref:`Mask.details.updateEvent <Hibernate version of class omero.model.Mask>`, :ref:`MetadataImportJob.details.creationEvent <Hibernate version of class omero.model.MetadataImportJob>`, :ref:`MetadataImportJob.details.updateEvent <Hibernate version of class omero.model.MetadataImportJob>`, :ref:`MicrobeamManipulation.details.creationEvent <Hibernate version of class omero.model.MicrobeamManipulation>`, :ref:`MicrobeamManipulation.details.updateEvent <Hibernate version of class omero.model.MicrobeamManipulation>`, :ref:`Microscope.details.creationEvent <Hibernate version of class omero.model.Microscope>`, :ref:`Microscope.details.updateEvent <Hibernate version of class omero.model.Microscope>`, :ref:`NamespaceAnnotationLink.details.creationEvent <Hibernate version of class omero.model.NamespaceAnnotationLink>`, :ref:`NamespaceAnnotationLink.details.updateEvent <Hibernate version of class omero.model.NamespaceAnnotationLink>`, :ref:`NodeAnnotationLink.details.creationEvent <Hibernate version of class omero.model.NodeAnnotationLink>`, :ref:`NodeAnnotationLink.details.updateEvent <Hibernate version of class omero.model.NodeAnnotationLink>`, :ref:`NumericAnnotation.details.creationEvent <Hibernate version of class omero.model.NumericAnnotation>`, :ref:`NumericAnnotation.details.updateEvent <Hibernate version of class omero.model.NumericAnnotation>`, :ref:`OTF.details.creationEvent <Hibernate version of class omero.model.OTF>`, :ref:`OTF.details.updateEvent <Hibernate version of class omero.model.OTF>`, :ref:`Objective.details.creationEvent <Hibernate version of class omero.model.Objective>`, :ref:`Objective.details.updateEvent <Hibernate version of class omero.model.Objective>`, :ref:`ObjectiveAnnotationLink.details.creationEvent <Hibernate version of class omero.model.ObjectiveAnnotationLink>`, :ref:`ObjectiveAnnotationLink.details.updateEvent <Hibernate version of class omero.model.ObjectiveAnnotationLink>`, :ref:`ObjectiveSettings.details.creationEvent <Hibernate version of class omero.model.ObjectiveSettings>`, :ref:`ObjectiveSettings.details.updateEvent <Hibernate version of class omero.model.ObjectiveSettings>`, :ref:`OriginalFile.details.creationEvent <Hibernate version of class omero.model.OriginalFile>`, :ref:`OriginalFile.details.updateEvent <Hibernate version of class omero.model.OriginalFile>`, :ref:`OriginalFileAnnotationLink.details.creationEvent <Hibernate version of class omero.model.OriginalFileAnnotationLink>`, :ref:`OriginalFileAnnotationLink.details.updateEvent <Hibernate version of class omero.model.OriginalFileAnnotationLink>`, :ref:`ParseJob.details.creationEvent <Hibernate version of class omero.model.ParseJob>`, :ref:`ParseJob.details.updateEvent <Hibernate version of class omero.model.ParseJob>`, :ref:`Path.details.creationEvent <Hibernate version of class omero.model.Path>`, :ref:`Path.details.updateEvent <Hibernate version of class omero.model.Path>`, :ref:`PixelDataJob.details.creationEvent <Hibernate version of class omero.model.PixelDataJob>`, :ref:`PixelDataJob.details.updateEvent <Hibernate version of class omero.model.PixelDataJob>`, :ref:`Pixels.details.creationEvent <Hibernate version of class omero.model.Pixels>`, :ref:`Pixels.details.updateEvent <Hibernate version of class omero.model.Pixels>`, :ref:`PixelsOriginalFileMap.details.creationEvent <Hibernate version of class omero.model.PixelsOriginalFileMap>`, :ref:`PixelsOriginalFileMap.details.updateEvent <Hibernate version of class omero.model.PixelsOriginalFileMap>`, :ref:`PlaneInfo.details.creationEvent <Hibernate version of class omero.model.PlaneInfo>`, :ref:`PlaneInfo.details.updateEvent <Hibernate version of class omero.model.PlaneInfo>`, :ref:`PlaneInfoAnnotationLink.details.creationEvent <Hibernate version of class omero.model.PlaneInfoAnnotationLink>`, :ref:`PlaneInfoAnnotationLink.details.updateEvent <Hibernate version of class omero.model.PlaneInfoAnnotationLink>`, :ref:`PlaneSlicingContext.details.creationEvent <Hibernate version of class omero.model.PlaneSlicingContext>`, :ref:`PlaneSlicingContext.details.updateEvent <Hibernate version of class omero.model.PlaneSlicingContext>`, :ref:`Plate.details.creationEvent <Hibernate version of class omero.model.Plate>`, :ref:`Plate.details.updateEvent <Hibernate version of class omero.model.Plate>`, :ref:`PlateAcquisition.details.creationEvent <Hibernate version of class omero.model.PlateAcquisition>`, :ref:`PlateAcquisition.details.updateEvent <Hibernate version of class omero.model.PlateAcquisition>`, :ref:`PlateAcquisitionAnnotationLink.details.creationEvent <Hibernate version of class omero.model.PlateAcquisitionAnnotationLink>`, :ref:`PlateAcquisitionAnnotationLink.details.updateEvent <Hibernate version of class omero.model.PlateAcquisitionAnnotationLink>`, :ref:`PlateAnnotationLink.details.creationEvent <Hibernate version of class omero.model.PlateAnnotationLink>`, :ref:`PlateAnnotationLink.details.updateEvent <Hibernate version of class omero.model.PlateAnnotationLink>`, :ref:`Point.details.creationEvent <Hibernate version of class omero.model.Point>`, :ref:`Point.details.updateEvent <Hibernate version of class omero.model.Point>`, :ref:`Polygon.details.creationEvent <Hibernate version of class omero.model.Polygon>`, :ref:`Polygon.details.updateEvent <Hibernate version of class omero.model.Polygon>`, :ref:`Polyline.details.creationEvent <Hibernate version of class omero.model.Polyline>`, :ref:`Polyline.details.updateEvent <Hibernate version of class omero.model.Polyline>`, :ref:`Project.details.creationEvent <Hibernate version of class omero.model.Project>`, :ref:`Project.details.updateEvent <Hibernate version of class omero.model.Project>`, :ref:`ProjectAnnotationLink.details.creationEvent <Hibernate version of class omero.model.ProjectAnnotationLink>`, :ref:`ProjectAnnotationLink.details.updateEvent <Hibernate version of class omero.model.ProjectAnnotationLink>`, :ref:`ProjectDatasetLink.details.creationEvent <Hibernate version of class omero.model.ProjectDatasetLink>`, :ref:`ProjectDatasetLink.details.updateEvent <Hibernate version of class omero.model.ProjectDatasetLink>`, :ref:`QuantumDef.details.creationEvent <Hibernate version of class omero.model.QuantumDef>`, :ref:`QuantumDef.details.updateEvent <Hibernate version of class omero.model.QuantumDef>`, :ref:`Reagent.details.creationEvent <Hibernate version of class omero.model.Reagent>`, :ref:`Reagent.details.updateEvent <Hibernate version of class omero.model.Reagent>`, :ref:`ReagentAnnotationLink.details.creationEvent <Hibernate version of class omero.model.ReagentAnnotationLink>`, :ref:`ReagentAnnotationLink.details.updateEvent <Hibernate version of class omero.model.ReagentAnnotationLink>`, :ref:`Rect.details.creationEvent <Hibernate version of class omero.model.Rect>`, :ref:`Rect.details.updateEvent <Hibernate version of class omero.model.Rect>`, :ref:`RenderingDef.details.creationEvent <Hibernate version of class omero.model.RenderingDef>`, :ref:`RenderingDef.details.updateEvent <Hibernate version of class omero.model.RenderingDef>`, :ref:`ReverseIntensityContext.details.creationEvent <Hibernate version of class omero.model.ReverseIntensityContext>`, :ref:`ReverseIntensityContext.details.updateEvent <Hibernate version of class omero.model.ReverseIntensityContext>`, :ref:`Roi.details.creationEvent <Hibernate version of class omero.model.Roi>`, :ref:`Roi.details.updateEvent <Hibernate version of class omero.model.Roi>`, :ref:`RoiAnnotationLink.details.creationEvent <Hibernate version of class omero.model.RoiAnnotationLink>`, :ref:`RoiAnnotationLink.details.updateEvent <Hibernate version of class omero.model.RoiAnnotationLink>`, :ref:`Screen.details.creationEvent <Hibernate version of class omero.model.Screen>`, :ref:`Screen.details.updateEvent <Hibernate version of class omero.model.Screen>`, :ref:`ScreenAnnotationLink.details.creationEvent <Hibernate version of class omero.model.ScreenAnnotationLink>`, :ref:`ScreenAnnotationLink.details.updateEvent <Hibernate version of class omero.model.ScreenAnnotationLink>`, :ref:`ScreenPlateLink.details.creationEvent <Hibernate version of class omero.model.ScreenPlateLink>`, :ref:`ScreenPlateLink.details.updateEvent <Hibernate version of class omero.model.ScreenPlateLink>`, :ref:`ScriptJob.details.creationEvent <Hibernate version of class omero.model.ScriptJob>`, :ref:`ScriptJob.details.updateEvent <Hibernate version of class omero.model.ScriptJob>`, :ref:`Session.events <Hibernate version of class omero.model.Session>`, :ref:`SessionAnnotationLink.details.creationEvent <Hibernate version of class omero.model.SessionAnnotationLink>`, :ref:`SessionAnnotationLink.details.updateEvent <Hibernate version of class omero.model.SessionAnnotationLink>`, :ref:`Shape.details.creationEvent <Hibernate version of class omero.model.Shape>`, :ref:`Shape.details.updateEvent <Hibernate version of class omero.model.Shape>`, :ref:`ShapeAnnotationLink.details.creationEvent <Hibernate version of class omero.model.ShapeAnnotationLink>`, :ref:`ShapeAnnotationLink.details.updateEvent <Hibernate version of class omero.model.ShapeAnnotationLink>`, :ref:`Share.events <Hibernate version of class omero.model.Share>`, :ref:`StageLabel.details.creationEvent <Hibernate version of class omero.model.StageLabel>`, :ref:`StageLabel.details.updateEvent <Hibernate version of class omero.model.StageLabel>`, :ref:`StatsInfo.details.creationEvent <Hibernate version of class omero.model.StatsInfo>`, :ref:`StatsInfo.details.updateEvent <Hibernate version of class omero.model.StatsInfo>`, :ref:`TagAnnotation.details.creationEvent <Hibernate version of class omero.model.TagAnnotation>`, :ref:`TagAnnotation.details.updateEvent <Hibernate version of class omero.model.TagAnnotation>`, :ref:`TermAnnotation.details.creationEvent <Hibernate version of class omero.model.TermAnnotation>`, :ref:`TermAnnotation.details.updateEvent <Hibernate version of class omero.model.TermAnnotation>`, :ref:`TextAnnotation.details.creationEvent <Hibernate version of class omero.model.TextAnnotation>`, :ref:`TextAnnotation.details.updateEvent <Hibernate version of class omero.model.TextAnnotation>`, :ref:`Thumbnail.details.creationEvent <Hibernate version of class omero.model.Thumbnail>`, :ref:`Thumbnail.details.updateEvent <Hibernate version of class omero.model.Thumbnail>`, :ref:`ThumbnailGenerationJob.details.creationEvent <Hibernate version of class omero.model.ThumbnailGenerationJob>`, :ref:`ThumbnailGenerationJob.details.updateEvent <Hibernate version of class omero.model.ThumbnailGenerationJob>`, :ref:`TimestampAnnotation.details.creationEvent <Hibernate version of class omero.model.TimestampAnnotation>`, :ref:`TimestampAnnotation.details.updateEvent <Hibernate version of class omero.model.TimestampAnnotation>`, :ref:`TransmittanceRange.details.creationEvent <Hibernate version of class omero.model.TransmittanceRange>`, :ref:`TransmittanceRange.details.updateEvent <Hibernate version of class omero.model.TransmittanceRange>`, :ref:`TypeAnnotation.details.creationEvent <Hibernate version of class omero.model.TypeAnnotation>`, :ref:`TypeAnnotation.details.updateEvent <Hibernate version of class omero.model.TypeAnnotation>`, :ref:`UploadJob.details.creationEvent <Hibernate version of class omero.model.UploadJob>`, :ref:`UploadJob.details.updateEvent <Hibernate version of class omero.model.UploadJob>`, :ref:`Well.details.creationEvent <Hibernate version of class omero.model.Well>`, :ref:`Well.details.updateEvent <Hibernate version of class omero.model.Well>`, :ref:`WellAnnotationLink.details.creationEvent <Hibernate version of class omero.model.WellAnnotationLink>`, :ref:`WellAnnotationLink.details.updateEvent <Hibernate version of class omero.model.WellAnnotationLink>`, :ref:`WellReagentLink.details.creationEvent <Hibernate version of class omero.model.WellReagentLink>`, :ref:`WellReagentLink.details.updateEvent <Hibernate version of class omero.model.WellReagentLink>`, :ref:`WellSample.details.creationEvent <Hibernate version of class omero.model.WellSample>`, :ref:`WellSample.details.updateEvent <Hibernate version of class omero.model.WellSample>`, :ref:`XmlAnnotation.details.creationEvent <Hibernate version of class omero.model.XmlAnnotation>`, :ref:`XmlAnnotation.details.updateEvent <Hibernate version of class omero.model.XmlAnnotation>`
+Used by: :ref:`Annotation.details.creationEvent <OMERO model class Annotation>`, :ref:`Annotation.details.updateEvent <OMERO model class Annotation>`, :ref:`AnnotationAnnotationLink.details.creationEvent <OMERO model class AnnotationAnnotationLink>`, :ref:`AnnotationAnnotationLink.details.updateEvent <OMERO model class AnnotationAnnotationLink>`, :ref:`Arc.details.creationEvent <OMERO model class Arc>`, :ref:`Arc.details.updateEvent <OMERO model class Arc>`, :ref:`BasicAnnotation.details.creationEvent <OMERO model class BasicAnnotation>`, :ref:`BasicAnnotation.details.updateEvent <OMERO model class BasicAnnotation>`, :ref:`BooleanAnnotation.details.creationEvent <OMERO model class BooleanAnnotation>`, :ref:`BooleanAnnotation.details.updateEvent <OMERO model class BooleanAnnotation>`, :ref:`Channel.details.creationEvent <OMERO model class Channel>`, :ref:`Channel.details.updateEvent <OMERO model class Channel>`, :ref:`ChannelAnnotationLink.details.creationEvent <OMERO model class ChannelAnnotationLink>`, :ref:`ChannelAnnotationLink.details.updateEvent <OMERO model class ChannelAnnotationLink>`, :ref:`ChannelBinding.details.creationEvent <OMERO model class ChannelBinding>`, :ref:`ChannelBinding.details.updateEvent <OMERO model class ChannelBinding>`, :ref:`CodomainMapContext.details.creationEvent <OMERO model class CodomainMapContext>`, :ref:`CodomainMapContext.details.updateEvent <OMERO model class CodomainMapContext>`, :ref:`CommentAnnotation.details.creationEvent <OMERO model class CommentAnnotation>`, :ref:`CommentAnnotation.details.updateEvent <OMERO model class CommentAnnotation>`, :ref:`ContrastStretchingContext.details.creationEvent <OMERO model class ContrastStretchingContext>`, :ref:`ContrastStretchingContext.details.updateEvent <OMERO model class ContrastStretchingContext>`, :ref:`Dataset.details.creationEvent <OMERO model class Dataset>`, :ref:`Dataset.details.updateEvent <OMERO model class Dataset>`, :ref:`DatasetAnnotationLink.details.creationEvent <OMERO model class DatasetAnnotationLink>`, :ref:`DatasetAnnotationLink.details.updateEvent <OMERO model class DatasetAnnotationLink>`, :ref:`DatasetImageLink.details.creationEvent <OMERO model class DatasetImageLink>`, :ref:`DatasetImageLink.details.updateEvent <OMERO model class DatasetImageLink>`, :ref:`Detector.details.creationEvent <OMERO model class Detector>`, :ref:`Detector.details.updateEvent <OMERO model class Detector>`, :ref:`DetectorAnnotationLink.details.creationEvent <OMERO model class DetectorAnnotationLink>`, :ref:`DetectorAnnotationLink.details.updateEvent <OMERO model class DetectorAnnotationLink>`, :ref:`DetectorSettings.details.creationEvent <OMERO model class DetectorSettings>`, :ref:`DetectorSettings.details.updateEvent <OMERO model class DetectorSettings>`, :ref:`Dichroic.details.creationEvent <OMERO model class Dichroic>`, :ref:`Dichroic.details.updateEvent <OMERO model class Dichroic>`, :ref:`DichroicAnnotationLink.details.creationEvent <OMERO model class DichroicAnnotationLink>`, :ref:`DichroicAnnotationLink.details.updateEvent <OMERO model class DichroicAnnotationLink>`, :ref:`DoubleAnnotation.details.creationEvent <OMERO model class DoubleAnnotation>`, :ref:`DoubleAnnotation.details.updateEvent <OMERO model class DoubleAnnotation>`, :ref:`Ellipse.details.creationEvent <OMERO model class Ellipse>`, :ref:`Ellipse.details.updateEvent <OMERO model class Ellipse>`, :ref:`Event.containingEvent <OMERO model class Event>`, :ref:`EventLog.event <OMERO model class EventLog>`, :ref:`Experiment.details.creationEvent <OMERO model class Experiment>`, :ref:`Experiment.details.updateEvent <OMERO model class Experiment>`, :ref:`ExperimenterAnnotationLink.details.creationEvent <OMERO model class ExperimenterAnnotationLink>`, :ref:`ExperimenterAnnotationLink.details.updateEvent <OMERO model class ExperimenterAnnotationLink>`, :ref:`ExperimenterGroupAnnotationLink.details.creationEvent <OMERO model class ExperimenterGroupAnnotationLink>`, :ref:`ExperimenterGroupAnnotationLink.details.updateEvent <OMERO model class ExperimenterGroupAnnotationLink>`, :ref:`ExternalInfo.details.creationEvent <OMERO model class ExternalInfo>`, :ref:`Filament.details.creationEvent <OMERO model class Filament>`, :ref:`Filament.details.updateEvent <OMERO model class Filament>`, :ref:`FileAnnotation.details.creationEvent <OMERO model class FileAnnotation>`, :ref:`FileAnnotation.details.updateEvent <OMERO model class FileAnnotation>`, :ref:`Fileset.details.creationEvent <OMERO model class Fileset>`, :ref:`Fileset.details.updateEvent <OMERO model class Fileset>`, :ref:`FilesetAnnotationLink.details.creationEvent <OMERO model class FilesetAnnotationLink>`, :ref:`FilesetAnnotationLink.details.updateEvent <OMERO model class FilesetAnnotationLink>`, :ref:`FilesetEntry.details.creationEvent <OMERO model class FilesetEntry>`, :ref:`FilesetEntry.details.updateEvent <OMERO model class FilesetEntry>`, :ref:`FilesetJobLink.details.creationEvent <OMERO model class FilesetJobLink>`, :ref:`FilesetJobLink.details.updateEvent <OMERO model class FilesetJobLink>`, :ref:`Filter.details.creationEvent <OMERO model class Filter>`, :ref:`Filter.details.updateEvent <OMERO model class Filter>`, :ref:`FilterAnnotationLink.details.creationEvent <OMERO model class FilterAnnotationLink>`, :ref:`FilterAnnotationLink.details.updateEvent <OMERO model class FilterAnnotationLink>`, :ref:`FilterSet.details.creationEvent <OMERO model class FilterSet>`, :ref:`FilterSet.details.updateEvent <OMERO model class FilterSet>`, :ref:`FilterSetEmissionFilterLink.details.creationEvent <OMERO model class FilterSetEmissionFilterLink>`, :ref:`FilterSetEmissionFilterLink.details.updateEvent <OMERO model class FilterSetEmissionFilterLink>`, :ref:`FilterSetExcitationFilterLink.details.creationEvent <OMERO model class FilterSetExcitationFilterLink>`, :ref:`FilterSetExcitationFilterLink.details.updateEvent <OMERO model class FilterSetExcitationFilterLink>`, :ref:`GenericExcitationSource.details.creationEvent <OMERO model class GenericExcitationSource>`, :ref:`GenericExcitationSource.details.updateEvent <OMERO model class GenericExcitationSource>`, :ref:`Image.details.creationEvent <OMERO model class Image>`, :ref:`Image.details.updateEvent <OMERO model class Image>`, :ref:`ImageAnnotationLink.details.creationEvent <OMERO model class ImageAnnotationLink>`, :ref:`ImageAnnotationLink.details.updateEvent <OMERO model class ImageAnnotationLink>`, :ref:`ImagingEnvironment.details.creationEvent <OMERO model class ImagingEnvironment>`, :ref:`ImagingEnvironment.details.updateEvent <OMERO model class ImagingEnvironment>`, :ref:`ImportJob.details.creationEvent <OMERO model class ImportJob>`, :ref:`ImportJob.details.updateEvent <OMERO model class ImportJob>`, :ref:`IndexingJob.details.creationEvent <OMERO model class IndexingJob>`, :ref:`IndexingJob.details.updateEvent <OMERO model class IndexingJob>`, :ref:`Instrument.details.creationEvent <OMERO model class Instrument>`, :ref:`Instrument.details.updateEvent <OMERO model class Instrument>`, :ref:`InstrumentAnnotationLink.details.creationEvent <OMERO model class InstrumentAnnotationLink>`, :ref:`InstrumentAnnotationLink.details.updateEvent <OMERO model class InstrumentAnnotationLink>`, :ref:`IntegrityCheckJob.details.creationEvent <OMERO model class IntegrityCheckJob>`, :ref:`IntegrityCheckJob.details.updateEvent <OMERO model class IntegrityCheckJob>`, :ref:`Job.details.creationEvent <OMERO model class Job>`, :ref:`Job.details.updateEvent <OMERO model class Job>`, :ref:`JobOriginalFileLink.details.creationEvent <OMERO model class JobOriginalFileLink>`, :ref:`JobOriginalFileLink.details.updateEvent <OMERO model class JobOriginalFileLink>`, :ref:`Label.details.creationEvent <OMERO model class Label>`, :ref:`Label.details.updateEvent <OMERO model class Label>`, :ref:`Laser.details.creationEvent <OMERO model class Laser>`, :ref:`Laser.details.updateEvent <OMERO model class Laser>`, :ref:`LightEmittingDiode.details.creationEvent <OMERO model class LightEmittingDiode>`, :ref:`LightEmittingDiode.details.updateEvent <OMERO model class LightEmittingDiode>`, :ref:`LightPath.details.creationEvent <OMERO model class LightPath>`, :ref:`LightPath.details.updateEvent <OMERO model class LightPath>`, :ref:`LightPathAnnotationLink.details.creationEvent <OMERO model class LightPathAnnotationLink>`, :ref:`LightPathAnnotationLink.details.updateEvent <OMERO model class LightPathAnnotationLink>`, :ref:`LightPathEmissionFilterLink.details.creationEvent <OMERO model class LightPathEmissionFilterLink>`, :ref:`LightPathEmissionFilterLink.details.updateEvent <OMERO model class LightPathEmissionFilterLink>`, :ref:`LightPathExcitationFilterLink.details.creationEvent <OMERO model class LightPathExcitationFilterLink>`, :ref:`LightPathExcitationFilterLink.details.updateEvent <OMERO model class LightPathExcitationFilterLink>`, :ref:`LightSettings.details.creationEvent <OMERO model class LightSettings>`, :ref:`LightSettings.details.updateEvent <OMERO model class LightSettings>`, :ref:`LightSource.details.creationEvent <OMERO model class LightSource>`, :ref:`LightSource.details.updateEvent <OMERO model class LightSource>`, :ref:`LightSourceAnnotationLink.details.creationEvent <OMERO model class LightSourceAnnotationLink>`, :ref:`LightSourceAnnotationLink.details.updateEvent <OMERO model class LightSourceAnnotationLink>`, :ref:`Line.details.creationEvent <OMERO model class Line>`, :ref:`Line.details.updateEvent <OMERO model class Line>`, :ref:`Link.details.creationEvent <OMERO model class Link>`, :ref:`Link.details.updateEvent <OMERO model class Link>`, :ref:`ListAnnotation.details.creationEvent <OMERO model class ListAnnotation>`, :ref:`ListAnnotation.details.updateEvent <OMERO model class ListAnnotation>`, :ref:`LogicalChannel.details.creationEvent <OMERO model class LogicalChannel>`, :ref:`LogicalChannel.details.updateEvent <OMERO model class LogicalChannel>`, :ref:`LongAnnotation.details.creationEvent <OMERO model class LongAnnotation>`, :ref:`LongAnnotation.details.updateEvent <OMERO model class LongAnnotation>`, :ref:`MapAnnotation.details.creationEvent <OMERO model class MapAnnotation>`, :ref:`MapAnnotation.details.updateEvent <OMERO model class MapAnnotation>`, :ref:`Mask.details.creationEvent <OMERO model class Mask>`, :ref:`Mask.details.updateEvent <OMERO model class Mask>`, :ref:`MetadataImportJob.details.creationEvent <OMERO model class MetadataImportJob>`, :ref:`MetadataImportJob.details.updateEvent <OMERO model class MetadataImportJob>`, :ref:`MicrobeamManipulation.details.creationEvent <OMERO model class MicrobeamManipulation>`, :ref:`MicrobeamManipulation.details.updateEvent <OMERO model class MicrobeamManipulation>`, :ref:`Microscope.details.creationEvent <OMERO model class Microscope>`, :ref:`Microscope.details.updateEvent <OMERO model class Microscope>`, :ref:`NamespaceAnnotationLink.details.creationEvent <OMERO model class NamespaceAnnotationLink>`, :ref:`NamespaceAnnotationLink.details.updateEvent <OMERO model class NamespaceAnnotationLink>`, :ref:`NodeAnnotationLink.details.creationEvent <OMERO model class NodeAnnotationLink>`, :ref:`NodeAnnotationLink.details.updateEvent <OMERO model class NodeAnnotationLink>`, :ref:`NumericAnnotation.details.creationEvent <OMERO model class NumericAnnotation>`, :ref:`NumericAnnotation.details.updateEvent <OMERO model class NumericAnnotation>`, :ref:`OTF.details.creationEvent <OMERO model class OTF>`, :ref:`OTF.details.updateEvent <OMERO model class OTF>`, :ref:`Objective.details.creationEvent <OMERO model class Objective>`, :ref:`Objective.details.updateEvent <OMERO model class Objective>`, :ref:`ObjectiveAnnotationLink.details.creationEvent <OMERO model class ObjectiveAnnotationLink>`, :ref:`ObjectiveAnnotationLink.details.updateEvent <OMERO model class ObjectiveAnnotationLink>`, :ref:`ObjectiveSettings.details.creationEvent <OMERO model class ObjectiveSettings>`, :ref:`ObjectiveSettings.details.updateEvent <OMERO model class ObjectiveSettings>`, :ref:`OriginalFile.details.creationEvent <OMERO model class OriginalFile>`, :ref:`OriginalFile.details.updateEvent <OMERO model class OriginalFile>`, :ref:`OriginalFileAnnotationLink.details.creationEvent <OMERO model class OriginalFileAnnotationLink>`, :ref:`OriginalFileAnnotationLink.details.updateEvent <OMERO model class OriginalFileAnnotationLink>`, :ref:`ParseJob.details.creationEvent <OMERO model class ParseJob>`, :ref:`ParseJob.details.updateEvent <OMERO model class ParseJob>`, :ref:`Path.details.creationEvent <OMERO model class Path>`, :ref:`Path.details.updateEvent <OMERO model class Path>`, :ref:`PixelDataJob.details.creationEvent <OMERO model class PixelDataJob>`, :ref:`PixelDataJob.details.updateEvent <OMERO model class PixelDataJob>`, :ref:`Pixels.details.creationEvent <OMERO model class Pixels>`, :ref:`Pixels.details.updateEvent <OMERO model class Pixels>`, :ref:`PixelsOriginalFileMap.details.creationEvent <OMERO model class PixelsOriginalFileMap>`, :ref:`PixelsOriginalFileMap.details.updateEvent <OMERO model class PixelsOriginalFileMap>`, :ref:`PlaneInfo.details.creationEvent <OMERO model class PlaneInfo>`, :ref:`PlaneInfo.details.updateEvent <OMERO model class PlaneInfo>`, :ref:`PlaneInfoAnnotationLink.details.creationEvent <OMERO model class PlaneInfoAnnotationLink>`, :ref:`PlaneInfoAnnotationLink.details.updateEvent <OMERO model class PlaneInfoAnnotationLink>`, :ref:`PlaneSlicingContext.details.creationEvent <OMERO model class PlaneSlicingContext>`, :ref:`PlaneSlicingContext.details.updateEvent <OMERO model class PlaneSlicingContext>`, :ref:`Plate.details.creationEvent <OMERO model class Plate>`, :ref:`Plate.details.updateEvent <OMERO model class Plate>`, :ref:`PlateAcquisition.details.creationEvent <OMERO model class PlateAcquisition>`, :ref:`PlateAcquisition.details.updateEvent <OMERO model class PlateAcquisition>`, :ref:`PlateAcquisitionAnnotationLink.details.creationEvent <OMERO model class PlateAcquisitionAnnotationLink>`, :ref:`PlateAcquisitionAnnotationLink.details.updateEvent <OMERO model class PlateAcquisitionAnnotationLink>`, :ref:`PlateAnnotationLink.details.creationEvent <OMERO model class PlateAnnotationLink>`, :ref:`PlateAnnotationLink.details.updateEvent <OMERO model class PlateAnnotationLink>`, :ref:`Point.details.creationEvent <OMERO model class Point>`, :ref:`Point.details.updateEvent <OMERO model class Point>`, :ref:`Polygon.details.creationEvent <OMERO model class Polygon>`, :ref:`Polygon.details.updateEvent <OMERO model class Polygon>`, :ref:`Polyline.details.creationEvent <OMERO model class Polyline>`, :ref:`Polyline.details.updateEvent <OMERO model class Polyline>`, :ref:`Project.details.creationEvent <OMERO model class Project>`, :ref:`Project.details.updateEvent <OMERO model class Project>`, :ref:`ProjectAnnotationLink.details.creationEvent <OMERO model class ProjectAnnotationLink>`, :ref:`ProjectAnnotationLink.details.updateEvent <OMERO model class ProjectAnnotationLink>`, :ref:`ProjectDatasetLink.details.creationEvent <OMERO model class ProjectDatasetLink>`, :ref:`ProjectDatasetLink.details.updateEvent <OMERO model class ProjectDatasetLink>`, :ref:`QuantumDef.details.creationEvent <OMERO model class QuantumDef>`, :ref:`QuantumDef.details.updateEvent <OMERO model class QuantumDef>`, :ref:`Reagent.details.creationEvent <OMERO model class Reagent>`, :ref:`Reagent.details.updateEvent <OMERO model class Reagent>`, :ref:`ReagentAnnotationLink.details.creationEvent <OMERO model class ReagentAnnotationLink>`, :ref:`ReagentAnnotationLink.details.updateEvent <OMERO model class ReagentAnnotationLink>`, :ref:`Rect.details.creationEvent <OMERO model class Rect>`, :ref:`Rect.details.updateEvent <OMERO model class Rect>`, :ref:`RenderingDef.details.creationEvent <OMERO model class RenderingDef>`, :ref:`RenderingDef.details.updateEvent <OMERO model class RenderingDef>`, :ref:`ReverseIntensityContext.details.creationEvent <OMERO model class ReverseIntensityContext>`, :ref:`ReverseIntensityContext.details.updateEvent <OMERO model class ReverseIntensityContext>`, :ref:`Roi.details.creationEvent <OMERO model class Roi>`, :ref:`Roi.details.updateEvent <OMERO model class Roi>`, :ref:`RoiAnnotationLink.details.creationEvent <OMERO model class RoiAnnotationLink>`, :ref:`RoiAnnotationLink.details.updateEvent <OMERO model class RoiAnnotationLink>`, :ref:`Screen.details.creationEvent <OMERO model class Screen>`, :ref:`Screen.details.updateEvent <OMERO model class Screen>`, :ref:`ScreenAnnotationLink.details.creationEvent <OMERO model class ScreenAnnotationLink>`, :ref:`ScreenAnnotationLink.details.updateEvent <OMERO model class ScreenAnnotationLink>`, :ref:`ScreenPlateLink.details.creationEvent <OMERO model class ScreenPlateLink>`, :ref:`ScreenPlateLink.details.updateEvent <OMERO model class ScreenPlateLink>`, :ref:`ScriptJob.details.creationEvent <OMERO model class ScriptJob>`, :ref:`ScriptJob.details.updateEvent <OMERO model class ScriptJob>`, :ref:`Session.events <OMERO model class Session>`, :ref:`SessionAnnotationLink.details.creationEvent <OMERO model class SessionAnnotationLink>`, :ref:`SessionAnnotationLink.details.updateEvent <OMERO model class SessionAnnotationLink>`, :ref:`Shape.details.creationEvent <OMERO model class Shape>`, :ref:`Shape.details.updateEvent <OMERO model class Shape>`, :ref:`ShapeAnnotationLink.details.creationEvent <OMERO model class ShapeAnnotationLink>`, :ref:`ShapeAnnotationLink.details.updateEvent <OMERO model class ShapeAnnotationLink>`, :ref:`Share.events <OMERO model class Share>`, :ref:`StageLabel.details.creationEvent <OMERO model class StageLabel>`, :ref:`StageLabel.details.updateEvent <OMERO model class StageLabel>`, :ref:`StatsInfo.details.creationEvent <OMERO model class StatsInfo>`, :ref:`StatsInfo.details.updateEvent <OMERO model class StatsInfo>`, :ref:`TagAnnotation.details.creationEvent <OMERO model class TagAnnotation>`, :ref:`TagAnnotation.details.updateEvent <OMERO model class TagAnnotation>`, :ref:`TermAnnotation.details.creationEvent <OMERO model class TermAnnotation>`, :ref:`TermAnnotation.details.updateEvent <OMERO model class TermAnnotation>`, :ref:`TextAnnotation.details.creationEvent <OMERO model class TextAnnotation>`, :ref:`TextAnnotation.details.updateEvent <OMERO model class TextAnnotation>`, :ref:`Thumbnail.details.creationEvent <OMERO model class Thumbnail>`, :ref:`Thumbnail.details.updateEvent <OMERO model class Thumbnail>`, :ref:`ThumbnailGenerationJob.details.creationEvent <OMERO model class ThumbnailGenerationJob>`, :ref:`ThumbnailGenerationJob.details.updateEvent <OMERO model class ThumbnailGenerationJob>`, :ref:`TimestampAnnotation.details.creationEvent <OMERO model class TimestampAnnotation>`, :ref:`TimestampAnnotation.details.updateEvent <OMERO model class TimestampAnnotation>`, :ref:`TransmittanceRange.details.creationEvent <OMERO model class TransmittanceRange>`, :ref:`TransmittanceRange.details.updateEvent <OMERO model class TransmittanceRange>`, :ref:`TypeAnnotation.details.creationEvent <OMERO model class TypeAnnotation>`, :ref:`TypeAnnotation.details.updateEvent <OMERO model class TypeAnnotation>`, :ref:`UploadJob.details.creationEvent <OMERO model class UploadJob>`, :ref:`UploadJob.details.updateEvent <OMERO model class UploadJob>`, :ref:`Well.details.creationEvent <OMERO model class Well>`, :ref:`Well.details.updateEvent <OMERO model class Well>`, :ref:`WellAnnotationLink.details.creationEvent <OMERO model class WellAnnotationLink>`, :ref:`WellAnnotationLink.details.updateEvent <OMERO model class WellAnnotationLink>`, :ref:`WellReagentLink.details.creationEvent <OMERO model class WellReagentLink>`, :ref:`WellReagentLink.details.updateEvent <OMERO model class WellReagentLink>`, :ref:`WellSample.details.creationEvent <OMERO model class WellSample>`, :ref:`WellSample.details.updateEvent <OMERO model class WellSample>`, :ref:`XmlAnnotation.details.creationEvent <OMERO model class XmlAnnotation>`, :ref:`XmlAnnotation.details.updateEvent <OMERO model class XmlAnnotation>`
 
 Properties:
-  | containingEvent: :ref:`Event <Hibernate version of class omero.model.Event>` (optional)
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | containingEvent: :ref:`Event <OMERO model class Event>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | experimenter: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
-  | experimenterGroup: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | logs: :ref:`EventLog <Hibernate version of class omero.model.EventLog>` (multiple)
-  | session: :ref:`Session <Hibernate version of class omero.model.Session>`
+  | experimenter: :ref:`Experimenter <OMERO model class Experimenter>`
+  | experimenterGroup: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | logs: :ref:`EventLog <OMERO model class EventLog>` (multiple)
+  | session: :ref:`Session <OMERO model class Session>`
   | status: ``string`` (optional)
   | time: ``timestamp``
-  | type: :ref:`EventType <Hibernate version of class omero.model.EventType>`
+  | type: :ref:`EventType <OMERO model class EventType>`
 
-.. _Hibernate version of class omero.model.EventLog:
+.. _OMERO model class EventLog:
 
 EventLog
 """"""""
 
-Used by: :ref:`Event.logs <Hibernate version of class omero.model.Event>`
+Used by: :ref:`Event.logs <OMERO model class Event>`
 
 Properties:
   | action: ``string``
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | entityId: ``long``
   | entityType: ``string``
-  | event: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | event: :ref:`Event <OMERO model class Event>`
 
-.. _Hibernate version of class omero.model.EventType:
+.. _OMERO model class EventType:
 
 EventType
 """""""""
 
-Used by: :ref:`Event.type <Hibernate version of class omero.model.Event>`
+Used by: :ref:`Event.type <OMERO model class Event>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
+  | value: ``string``, see :javadoc:`IEnum <ome/model/IEnum.html>`
 
-.. _Hibernate version of class omero.model.Experiment:
+.. _OMERO model class Experiment:
 
 Experiment
 """"""""""
 
-Used by: :ref:`Image.experiment <Hibernate version of class omero.model.Image>`, :ref:`MicrobeamManipulation.experiment <Hibernate version of class omero.model.MicrobeamManipulation>`
+Used by: :ref:`Image.experiment <OMERO model class Image>`, :ref:`MicrobeamManipulation.experiment <OMERO model class MicrobeamManipulation>`
 
 Properties:
   | description: ``text`` (optional)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | microbeamManipulation: :ref:`MicrobeamManipulation <Hibernate version of class omero.model.MicrobeamManipulation>` (multiple)
-  | type: :ref:`ExperimentType <Hibernate version of class omero.model.ExperimentType>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | microbeamManipulation: :ref:`MicrobeamManipulation <OMERO model class MicrobeamManipulation>` (multiple)
+  | type: :ref:`ExperimentType <OMERO model class ExperimentType>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.ExperimentType:
+.. _OMERO model class ExperimentType:
 
 ExperimentType
 """"""""""""""
 
-Used by: :ref:`Experiment.type <Hibernate version of class omero.model.Experiment>`
+Used by: :ref:`Experiment.type <OMERO model class Experiment>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
+  | value: ``string``, see :javadoc:`IEnum <ome/model/IEnum.html>`
 
-.. _Hibernate version of class omero.model.Experimenter:
+.. _OMERO model class Experimenter:
 
 Experimenter
 """"""""""""
 
-Used by: :ref:`Annotation.details.owner <Hibernate version of class omero.model.Annotation>`, :ref:`AnnotationAnnotationLink.details.owner <Hibernate version of class omero.model.AnnotationAnnotationLink>`, :ref:`Arc.details.owner <Hibernate version of class omero.model.Arc>`, :ref:`BasicAnnotation.details.owner <Hibernate version of class omero.model.BasicAnnotation>`, :ref:`BooleanAnnotation.details.owner <Hibernate version of class omero.model.BooleanAnnotation>`, :ref:`Channel.details.owner <Hibernate version of class omero.model.Channel>`, :ref:`ChannelAnnotationLink.details.owner <Hibernate version of class omero.model.ChannelAnnotationLink>`, :ref:`ChannelBinding.details.owner <Hibernate version of class omero.model.ChannelBinding>`, :ref:`CodomainMapContext.details.owner <Hibernate version of class omero.model.CodomainMapContext>`, :ref:`CommentAnnotation.details.owner <Hibernate version of class omero.model.CommentAnnotation>`, :ref:`ContrastStretchingContext.details.owner <Hibernate version of class omero.model.ContrastStretchingContext>`, :ref:`Dataset.details.owner <Hibernate version of class omero.model.Dataset>`, :ref:`DatasetAnnotationLink.details.owner <Hibernate version of class omero.model.DatasetAnnotationLink>`, :ref:`DatasetImageLink.details.owner <Hibernate version of class omero.model.DatasetImageLink>`, :ref:`Detector.details.owner <Hibernate version of class omero.model.Detector>`, :ref:`DetectorAnnotationLink.details.owner <Hibernate version of class omero.model.DetectorAnnotationLink>`, :ref:`DetectorSettings.details.owner <Hibernate version of class omero.model.DetectorSettings>`, :ref:`Dichroic.details.owner <Hibernate version of class omero.model.Dichroic>`, :ref:`DichroicAnnotationLink.details.owner <Hibernate version of class omero.model.DichroicAnnotationLink>`, :ref:`DoubleAnnotation.details.owner <Hibernate version of class omero.model.DoubleAnnotation>`, :ref:`Ellipse.details.owner <Hibernate version of class omero.model.Ellipse>`, :ref:`Event.experimenter <Hibernate version of class omero.model.Event>`, :ref:`Experiment.details.owner <Hibernate version of class omero.model.Experiment>`, :ref:`ExperimenterAnnotationLink.details.owner <Hibernate version of class omero.model.ExperimenterAnnotationLink>`, :ref:`ExperimenterAnnotationLink.parent <Hibernate version of class omero.model.ExperimenterAnnotationLink>`, :ref:`ExperimenterGroupAnnotationLink.details.owner <Hibernate version of class omero.model.ExperimenterGroupAnnotationLink>`, :ref:`ExternalInfo.details.owner <Hibernate version of class omero.model.ExternalInfo>`, :ref:`Filament.details.owner <Hibernate version of class omero.model.Filament>`, :ref:`FileAnnotation.details.owner <Hibernate version of class omero.model.FileAnnotation>`, :ref:`Fileset.details.owner <Hibernate version of class omero.model.Fileset>`, :ref:`FilesetAnnotationLink.details.owner <Hibernate version of class omero.model.FilesetAnnotationLink>`, :ref:`FilesetEntry.details.owner <Hibernate version of class omero.model.FilesetEntry>`, :ref:`FilesetJobLink.details.owner <Hibernate version of class omero.model.FilesetJobLink>`, :ref:`Filter.details.owner <Hibernate version of class omero.model.Filter>`, :ref:`FilterAnnotationLink.details.owner <Hibernate version of class omero.model.FilterAnnotationLink>`, :ref:`FilterSet.details.owner <Hibernate version of class omero.model.FilterSet>`, :ref:`FilterSetEmissionFilterLink.details.owner <Hibernate version of class omero.model.FilterSetEmissionFilterLink>`, :ref:`FilterSetExcitationFilterLink.details.owner <Hibernate version of class omero.model.FilterSetExcitationFilterLink>`, :ref:`GenericExcitationSource.details.owner <Hibernate version of class omero.model.GenericExcitationSource>`, :ref:`GroupExperimenterMap.child <Hibernate version of class omero.model.GroupExperimenterMap>`, :ref:`Image.details.owner <Hibernate version of class omero.model.Image>`, :ref:`ImageAnnotationLink.details.owner <Hibernate version of class omero.model.ImageAnnotationLink>`, :ref:`ImagingEnvironment.details.owner <Hibernate version of class omero.model.ImagingEnvironment>`, :ref:`ImportJob.details.owner <Hibernate version of class omero.model.ImportJob>`, :ref:`IndexingJob.details.owner <Hibernate version of class omero.model.IndexingJob>`, :ref:`Instrument.details.owner <Hibernate version of class omero.model.Instrument>`, :ref:`InstrumentAnnotationLink.details.owner <Hibernate version of class omero.model.InstrumentAnnotationLink>`, :ref:`IntegrityCheckJob.details.owner <Hibernate version of class omero.model.IntegrityCheckJob>`, :ref:`Job.details.owner <Hibernate version of class omero.model.Job>`, :ref:`JobOriginalFileLink.details.owner <Hibernate version of class omero.model.JobOriginalFileLink>`, :ref:`Label.details.owner <Hibernate version of class omero.model.Label>`, :ref:`Laser.details.owner <Hibernate version of class omero.model.Laser>`, :ref:`LightEmittingDiode.details.owner <Hibernate version of class omero.model.LightEmittingDiode>`, :ref:`LightPath.details.owner <Hibernate version of class omero.model.LightPath>`, :ref:`LightPathAnnotationLink.details.owner <Hibernate version of class omero.model.LightPathAnnotationLink>`, :ref:`LightPathEmissionFilterLink.details.owner <Hibernate version of class omero.model.LightPathEmissionFilterLink>`, :ref:`LightPathExcitationFilterLink.details.owner <Hibernate version of class omero.model.LightPathExcitationFilterLink>`, :ref:`LightSettings.details.owner <Hibernate version of class omero.model.LightSettings>`, :ref:`LightSource.details.owner <Hibernate version of class omero.model.LightSource>`, :ref:`LightSourceAnnotationLink.details.owner <Hibernate version of class omero.model.LightSourceAnnotationLink>`, :ref:`Line.details.owner <Hibernate version of class omero.model.Line>`, :ref:`Link.details.owner <Hibernate version of class omero.model.Link>`, :ref:`ListAnnotation.details.owner <Hibernate version of class omero.model.ListAnnotation>`, :ref:`LogicalChannel.details.owner <Hibernate version of class omero.model.LogicalChannel>`, :ref:`LongAnnotation.details.owner <Hibernate version of class omero.model.LongAnnotation>`, :ref:`MapAnnotation.details.owner <Hibernate version of class omero.model.MapAnnotation>`, :ref:`Mask.details.owner <Hibernate version of class omero.model.Mask>`, :ref:`MetadataImportJob.details.owner <Hibernate version of class omero.model.MetadataImportJob>`, :ref:`MicrobeamManipulation.details.owner <Hibernate version of class omero.model.MicrobeamManipulation>`, :ref:`Microscope.details.owner <Hibernate version of class omero.model.Microscope>`, :ref:`NamespaceAnnotationLink.details.owner <Hibernate version of class omero.model.NamespaceAnnotationLink>`, :ref:`NodeAnnotationLink.details.owner <Hibernate version of class omero.model.NodeAnnotationLink>`, :ref:`NumericAnnotation.details.owner <Hibernate version of class omero.model.NumericAnnotation>`, :ref:`OTF.details.owner <Hibernate version of class omero.model.OTF>`, :ref:`Objective.details.owner <Hibernate version of class omero.model.Objective>`, :ref:`ObjectiveAnnotationLink.details.owner <Hibernate version of class omero.model.ObjectiveAnnotationLink>`, :ref:`ObjectiveSettings.details.owner <Hibernate version of class omero.model.ObjectiveSettings>`, :ref:`OriginalFile.details.owner <Hibernate version of class omero.model.OriginalFile>`, :ref:`OriginalFileAnnotationLink.details.owner <Hibernate version of class omero.model.OriginalFileAnnotationLink>`, :ref:`ParseJob.details.owner <Hibernate version of class omero.model.ParseJob>`, :ref:`Path.details.owner <Hibernate version of class omero.model.Path>`, :ref:`PixelDataJob.details.owner <Hibernate version of class omero.model.PixelDataJob>`, :ref:`Pixels.details.owner <Hibernate version of class omero.model.Pixels>`, :ref:`PixelsOriginalFileMap.details.owner <Hibernate version of class omero.model.PixelsOriginalFileMap>`, :ref:`PlaneInfo.details.owner <Hibernate version of class omero.model.PlaneInfo>`, :ref:`PlaneInfoAnnotationLink.details.owner <Hibernate version of class omero.model.PlaneInfoAnnotationLink>`, :ref:`PlaneSlicingContext.details.owner <Hibernate version of class omero.model.PlaneSlicingContext>`, :ref:`Plate.details.owner <Hibernate version of class omero.model.Plate>`, :ref:`PlateAcquisition.details.owner <Hibernate version of class omero.model.PlateAcquisition>`, :ref:`PlateAcquisitionAnnotationLink.details.owner <Hibernate version of class omero.model.PlateAcquisitionAnnotationLink>`, :ref:`PlateAnnotationLink.details.owner <Hibernate version of class omero.model.PlateAnnotationLink>`, :ref:`Point.details.owner <Hibernate version of class omero.model.Point>`, :ref:`Polygon.details.owner <Hibernate version of class omero.model.Polygon>`, :ref:`Polyline.details.owner <Hibernate version of class omero.model.Polyline>`, :ref:`Project.details.owner <Hibernate version of class omero.model.Project>`, :ref:`ProjectAnnotationLink.details.owner <Hibernate version of class omero.model.ProjectAnnotationLink>`, :ref:`ProjectDatasetLink.details.owner <Hibernate version of class omero.model.ProjectDatasetLink>`, :ref:`QuantumDef.details.owner <Hibernate version of class omero.model.QuantumDef>`, :ref:`Reagent.details.owner <Hibernate version of class omero.model.Reagent>`, :ref:`ReagentAnnotationLink.details.owner <Hibernate version of class omero.model.ReagentAnnotationLink>`, :ref:`Rect.details.owner <Hibernate version of class omero.model.Rect>`, :ref:`RenderingDef.details.owner <Hibernate version of class omero.model.RenderingDef>`, :ref:`ReverseIntensityContext.details.owner <Hibernate version of class omero.model.ReverseIntensityContext>`, :ref:`Roi.details.owner <Hibernate version of class omero.model.Roi>`, :ref:`RoiAnnotationLink.details.owner <Hibernate version of class omero.model.RoiAnnotationLink>`, :ref:`Screen.details.owner <Hibernate version of class omero.model.Screen>`, :ref:`ScreenAnnotationLink.details.owner <Hibernate version of class omero.model.ScreenAnnotationLink>`, :ref:`ScreenPlateLink.details.owner <Hibernate version of class omero.model.ScreenPlateLink>`, :ref:`ScriptJob.details.owner <Hibernate version of class omero.model.ScriptJob>`, :ref:`Session.owner <Hibernate version of class omero.model.Session>`, :ref:`SessionAnnotationLink.details.owner <Hibernate version of class omero.model.SessionAnnotationLink>`, :ref:`Shape.details.owner <Hibernate version of class omero.model.Shape>`, :ref:`ShapeAnnotationLink.details.owner <Hibernate version of class omero.model.ShapeAnnotationLink>`, :ref:`Share.owner <Hibernate version of class omero.model.Share>`, :ref:`ShareMember.child <Hibernate version of class omero.model.ShareMember>`, :ref:`StageLabel.details.owner <Hibernate version of class omero.model.StageLabel>`, :ref:`StatsInfo.details.owner <Hibernate version of class omero.model.StatsInfo>`, :ref:`TagAnnotation.details.owner <Hibernate version of class omero.model.TagAnnotation>`, :ref:`TermAnnotation.details.owner <Hibernate version of class omero.model.TermAnnotation>`, :ref:`TextAnnotation.details.owner <Hibernate version of class omero.model.TextAnnotation>`, :ref:`Thumbnail.details.owner <Hibernate version of class omero.model.Thumbnail>`, :ref:`ThumbnailGenerationJob.details.owner <Hibernate version of class omero.model.ThumbnailGenerationJob>`, :ref:`TimestampAnnotation.details.owner <Hibernate version of class omero.model.TimestampAnnotation>`, :ref:`TransmittanceRange.details.owner <Hibernate version of class omero.model.TransmittanceRange>`, :ref:`TypeAnnotation.details.owner <Hibernate version of class omero.model.TypeAnnotation>`, :ref:`UploadJob.details.owner <Hibernate version of class omero.model.UploadJob>`, :ref:`Well.details.owner <Hibernate version of class omero.model.Well>`, :ref:`WellAnnotationLink.details.owner <Hibernate version of class omero.model.WellAnnotationLink>`, :ref:`WellReagentLink.details.owner <Hibernate version of class omero.model.WellReagentLink>`, :ref:`WellSample.details.owner <Hibernate version of class omero.model.WellSample>`, :ref:`XmlAnnotation.details.owner <Hibernate version of class omero.model.XmlAnnotation>`
+Used by: :ref:`Annotation.details.owner <OMERO model class Annotation>`, :ref:`AnnotationAnnotationLink.details.owner <OMERO model class AnnotationAnnotationLink>`, :ref:`Arc.details.owner <OMERO model class Arc>`, :ref:`BasicAnnotation.details.owner <OMERO model class BasicAnnotation>`, :ref:`BooleanAnnotation.details.owner <OMERO model class BooleanAnnotation>`, :ref:`Channel.details.owner <OMERO model class Channel>`, :ref:`ChannelAnnotationLink.details.owner <OMERO model class ChannelAnnotationLink>`, :ref:`ChannelBinding.details.owner <OMERO model class ChannelBinding>`, :ref:`CodomainMapContext.details.owner <OMERO model class CodomainMapContext>`, :ref:`CommentAnnotation.details.owner <OMERO model class CommentAnnotation>`, :ref:`ContrastStretchingContext.details.owner <OMERO model class ContrastStretchingContext>`, :ref:`Dataset.details.owner <OMERO model class Dataset>`, :ref:`DatasetAnnotationLink.details.owner <OMERO model class DatasetAnnotationLink>`, :ref:`DatasetImageLink.details.owner <OMERO model class DatasetImageLink>`, :ref:`Detector.details.owner <OMERO model class Detector>`, :ref:`DetectorAnnotationLink.details.owner <OMERO model class DetectorAnnotationLink>`, :ref:`DetectorSettings.details.owner <OMERO model class DetectorSettings>`, :ref:`Dichroic.details.owner <OMERO model class Dichroic>`, :ref:`DichroicAnnotationLink.details.owner <OMERO model class DichroicAnnotationLink>`, :ref:`DoubleAnnotation.details.owner <OMERO model class DoubleAnnotation>`, :ref:`Ellipse.details.owner <OMERO model class Ellipse>`, :ref:`Event.experimenter <OMERO model class Event>`, :ref:`Experiment.details.owner <OMERO model class Experiment>`, :ref:`ExperimenterAnnotationLink.details.owner <OMERO model class ExperimenterAnnotationLink>`, :ref:`ExperimenterAnnotationLink.parent <OMERO model class ExperimenterAnnotationLink>`, :ref:`ExperimenterGroupAnnotationLink.details.owner <OMERO model class ExperimenterGroupAnnotationLink>`, :ref:`ExternalInfo.details.owner <OMERO model class ExternalInfo>`, :ref:`Filament.details.owner <OMERO model class Filament>`, :ref:`FileAnnotation.details.owner <OMERO model class FileAnnotation>`, :ref:`Fileset.details.owner <OMERO model class Fileset>`, :ref:`FilesetAnnotationLink.details.owner <OMERO model class FilesetAnnotationLink>`, :ref:`FilesetEntry.details.owner <OMERO model class FilesetEntry>`, :ref:`FilesetJobLink.details.owner <OMERO model class FilesetJobLink>`, :ref:`Filter.details.owner <OMERO model class Filter>`, :ref:`FilterAnnotationLink.details.owner <OMERO model class FilterAnnotationLink>`, :ref:`FilterSet.details.owner <OMERO model class FilterSet>`, :ref:`FilterSetEmissionFilterLink.details.owner <OMERO model class FilterSetEmissionFilterLink>`, :ref:`FilterSetExcitationFilterLink.details.owner <OMERO model class FilterSetExcitationFilterLink>`, :ref:`GenericExcitationSource.details.owner <OMERO model class GenericExcitationSource>`, :ref:`GroupExperimenterMap.child <OMERO model class GroupExperimenterMap>`, :ref:`Image.details.owner <OMERO model class Image>`, :ref:`ImageAnnotationLink.details.owner <OMERO model class ImageAnnotationLink>`, :ref:`ImagingEnvironment.details.owner <OMERO model class ImagingEnvironment>`, :ref:`ImportJob.details.owner <OMERO model class ImportJob>`, :ref:`IndexingJob.details.owner <OMERO model class IndexingJob>`, :ref:`Instrument.details.owner <OMERO model class Instrument>`, :ref:`InstrumentAnnotationLink.details.owner <OMERO model class InstrumentAnnotationLink>`, :ref:`IntegrityCheckJob.details.owner <OMERO model class IntegrityCheckJob>`, :ref:`Job.details.owner <OMERO model class Job>`, :ref:`JobOriginalFileLink.details.owner <OMERO model class JobOriginalFileLink>`, :ref:`Label.details.owner <OMERO model class Label>`, :ref:`Laser.details.owner <OMERO model class Laser>`, :ref:`LightEmittingDiode.details.owner <OMERO model class LightEmittingDiode>`, :ref:`LightPath.details.owner <OMERO model class LightPath>`, :ref:`LightPathAnnotationLink.details.owner <OMERO model class LightPathAnnotationLink>`, :ref:`LightPathEmissionFilterLink.details.owner <OMERO model class LightPathEmissionFilterLink>`, :ref:`LightPathExcitationFilterLink.details.owner <OMERO model class LightPathExcitationFilterLink>`, :ref:`LightSettings.details.owner <OMERO model class LightSettings>`, :ref:`LightSource.details.owner <OMERO model class LightSource>`, :ref:`LightSourceAnnotationLink.details.owner <OMERO model class LightSourceAnnotationLink>`, :ref:`Line.details.owner <OMERO model class Line>`, :ref:`Link.details.owner <OMERO model class Link>`, :ref:`ListAnnotation.details.owner <OMERO model class ListAnnotation>`, :ref:`LogicalChannel.details.owner <OMERO model class LogicalChannel>`, :ref:`LongAnnotation.details.owner <OMERO model class LongAnnotation>`, :ref:`MapAnnotation.details.owner <OMERO model class MapAnnotation>`, :ref:`Mask.details.owner <OMERO model class Mask>`, :ref:`MetadataImportJob.details.owner <OMERO model class MetadataImportJob>`, :ref:`MicrobeamManipulation.details.owner <OMERO model class MicrobeamManipulation>`, :ref:`Microscope.details.owner <OMERO model class Microscope>`, :ref:`NamespaceAnnotationLink.details.owner <OMERO model class NamespaceAnnotationLink>`, :ref:`NodeAnnotationLink.details.owner <OMERO model class NodeAnnotationLink>`, :ref:`NumericAnnotation.details.owner <OMERO model class NumericAnnotation>`, :ref:`OTF.details.owner <OMERO model class OTF>`, :ref:`Objective.details.owner <OMERO model class Objective>`, :ref:`ObjectiveAnnotationLink.details.owner <OMERO model class ObjectiveAnnotationLink>`, :ref:`ObjectiveSettings.details.owner <OMERO model class ObjectiveSettings>`, :ref:`OriginalFile.details.owner <OMERO model class OriginalFile>`, :ref:`OriginalFileAnnotationLink.details.owner <OMERO model class OriginalFileAnnotationLink>`, :ref:`ParseJob.details.owner <OMERO model class ParseJob>`, :ref:`Path.details.owner <OMERO model class Path>`, :ref:`PixelDataJob.details.owner <OMERO model class PixelDataJob>`, :ref:`Pixels.details.owner <OMERO model class Pixels>`, :ref:`PixelsOriginalFileMap.details.owner <OMERO model class PixelsOriginalFileMap>`, :ref:`PlaneInfo.details.owner <OMERO model class PlaneInfo>`, :ref:`PlaneInfoAnnotationLink.details.owner <OMERO model class PlaneInfoAnnotationLink>`, :ref:`PlaneSlicingContext.details.owner <OMERO model class PlaneSlicingContext>`, :ref:`Plate.details.owner <OMERO model class Plate>`, :ref:`PlateAcquisition.details.owner <OMERO model class PlateAcquisition>`, :ref:`PlateAcquisitionAnnotationLink.details.owner <OMERO model class PlateAcquisitionAnnotationLink>`, :ref:`PlateAnnotationLink.details.owner <OMERO model class PlateAnnotationLink>`, :ref:`Point.details.owner <OMERO model class Point>`, :ref:`Polygon.details.owner <OMERO model class Polygon>`, :ref:`Polyline.details.owner <OMERO model class Polyline>`, :ref:`Project.details.owner <OMERO model class Project>`, :ref:`ProjectAnnotationLink.details.owner <OMERO model class ProjectAnnotationLink>`, :ref:`ProjectDatasetLink.details.owner <OMERO model class ProjectDatasetLink>`, :ref:`QuantumDef.details.owner <OMERO model class QuantumDef>`, :ref:`Reagent.details.owner <OMERO model class Reagent>`, :ref:`ReagentAnnotationLink.details.owner <OMERO model class ReagentAnnotationLink>`, :ref:`Rect.details.owner <OMERO model class Rect>`, :ref:`RenderingDef.details.owner <OMERO model class RenderingDef>`, :ref:`ReverseIntensityContext.details.owner <OMERO model class ReverseIntensityContext>`, :ref:`Roi.details.owner <OMERO model class Roi>`, :ref:`RoiAnnotationLink.details.owner <OMERO model class RoiAnnotationLink>`, :ref:`Screen.details.owner <OMERO model class Screen>`, :ref:`ScreenAnnotationLink.details.owner <OMERO model class ScreenAnnotationLink>`, :ref:`ScreenPlateLink.details.owner <OMERO model class ScreenPlateLink>`, :ref:`ScriptJob.details.owner <OMERO model class ScriptJob>`, :ref:`Session.owner <OMERO model class Session>`, :ref:`SessionAnnotationLink.details.owner <OMERO model class SessionAnnotationLink>`, :ref:`Shape.details.owner <OMERO model class Shape>`, :ref:`ShapeAnnotationLink.details.owner <OMERO model class ShapeAnnotationLink>`, :ref:`Share.owner <OMERO model class Share>`, :ref:`ShareMember.child <OMERO model class ShareMember>`, :ref:`StageLabel.details.owner <OMERO model class StageLabel>`, :ref:`StatsInfo.details.owner <OMERO model class StatsInfo>`, :ref:`TagAnnotation.details.owner <OMERO model class TagAnnotation>`, :ref:`TermAnnotation.details.owner <OMERO model class TermAnnotation>`, :ref:`TextAnnotation.details.owner <OMERO model class TextAnnotation>`, :ref:`Thumbnail.details.owner <OMERO model class Thumbnail>`, :ref:`ThumbnailGenerationJob.details.owner <OMERO model class ThumbnailGenerationJob>`, :ref:`TimestampAnnotation.details.owner <OMERO model class TimestampAnnotation>`, :ref:`TransmittanceRange.details.owner <OMERO model class TransmittanceRange>`, :ref:`TypeAnnotation.details.owner <OMERO model class TypeAnnotation>`, :ref:`UploadJob.details.owner <OMERO model class UploadJob>`, :ref:`Well.details.owner <OMERO model class Well>`, :ref:`WellAnnotationLink.details.owner <OMERO model class WellAnnotationLink>`, :ref:`WellReagentLink.details.owner <OMERO model class WellReagentLink>`, :ref:`WellSample.details.owner <OMERO model class WellSample>`, :ref:`XmlAnnotation.details.owner <OMERO model class XmlAnnotation>`
 
 Properties:
-  | annotationLinks: :ref:`ExperimenterAnnotationLink <Hibernate version of class omero.model.ExperimenterAnnotationLink>` (multiple)
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | annotationLinks: :ref:`ExperimenterAnnotationLink <OMERO model class ExperimenterAnnotationLink>` (multiple)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | email: ``string`` (optional)
   | firstName: ``string``
-  | groupExperimenterMap: :ref:`GroupExperimenterMap <Hibernate version of class omero.model.GroupExperimenterMap>` (multiple)
+  | groupExperimenterMap: :ref:`GroupExperimenterMap <OMERO model class GroupExperimenterMap>` (multiple)
   | institution: ``string`` (optional)
   | lastName: ``string``
   | ldap: ``boolean``
   | middleName: ``string`` (optional)
   | omeName: ``string``
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.ExperimenterAnnotationLink:
+.. _OMERO model class ExperimenterAnnotationLink:
 
 ExperimenterAnnotationLink
 """"""""""""""""""""""""""
 
-Used by: :ref:`Experimenter.annotationLinks <Hibernate version of class omero.model.Experimenter>`
+Used by: :ref:`Experimenter.annotationLinks <OMERO model class Experimenter>`
 
 Properties:
-  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Annotation <OMERO model class Annotation>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`Experimenter <OMERO model class Experimenter>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.ExperimenterGroup:
+.. _OMERO model class ExperimenterGroup:
 
 ExperimenterGroup
 """""""""""""""""
 
-Used by: :ref:`Annotation.details.group <Hibernate version of class omero.model.Annotation>`, :ref:`AnnotationAnnotationLink.details.group <Hibernate version of class omero.model.AnnotationAnnotationLink>`, :ref:`Arc.details.group <Hibernate version of class omero.model.Arc>`, :ref:`BasicAnnotation.details.group <Hibernate version of class omero.model.BasicAnnotation>`, :ref:`BooleanAnnotation.details.group <Hibernate version of class omero.model.BooleanAnnotation>`, :ref:`Channel.details.group <Hibernate version of class omero.model.Channel>`, :ref:`ChannelAnnotationLink.details.group <Hibernate version of class omero.model.ChannelAnnotationLink>`, :ref:`ChannelBinding.details.group <Hibernate version of class omero.model.ChannelBinding>`, :ref:`CodomainMapContext.details.group <Hibernate version of class omero.model.CodomainMapContext>`, :ref:`CommentAnnotation.details.group <Hibernate version of class omero.model.CommentAnnotation>`, :ref:`ContrastStretchingContext.details.group <Hibernate version of class omero.model.ContrastStretchingContext>`, :ref:`Dataset.details.group <Hibernate version of class omero.model.Dataset>`, :ref:`DatasetAnnotationLink.details.group <Hibernate version of class omero.model.DatasetAnnotationLink>`, :ref:`DatasetImageLink.details.group <Hibernate version of class omero.model.DatasetImageLink>`, :ref:`Detector.details.group <Hibernate version of class omero.model.Detector>`, :ref:`DetectorAnnotationLink.details.group <Hibernate version of class omero.model.DetectorAnnotationLink>`, :ref:`DetectorSettings.details.group <Hibernate version of class omero.model.DetectorSettings>`, :ref:`Dichroic.details.group <Hibernate version of class omero.model.Dichroic>`, :ref:`DichroicAnnotationLink.details.group <Hibernate version of class omero.model.DichroicAnnotationLink>`, :ref:`DoubleAnnotation.details.group <Hibernate version of class omero.model.DoubleAnnotation>`, :ref:`Ellipse.details.group <Hibernate version of class omero.model.Ellipse>`, :ref:`Event.experimenterGroup <Hibernate version of class omero.model.Event>`, :ref:`Experiment.details.group <Hibernate version of class omero.model.Experiment>`, :ref:`ExperimenterAnnotationLink.details.group <Hibernate version of class omero.model.ExperimenterAnnotationLink>`, :ref:`ExperimenterGroupAnnotationLink.details.group <Hibernate version of class omero.model.ExperimenterGroupAnnotationLink>`, :ref:`ExperimenterGroupAnnotationLink.parent <Hibernate version of class omero.model.ExperimenterGroupAnnotationLink>`, :ref:`ExternalInfo.details.group <Hibernate version of class omero.model.ExternalInfo>`, :ref:`Filament.details.group <Hibernate version of class omero.model.Filament>`, :ref:`FileAnnotation.details.group <Hibernate version of class omero.model.FileAnnotation>`, :ref:`Fileset.details.group <Hibernate version of class omero.model.Fileset>`, :ref:`FilesetAnnotationLink.details.group <Hibernate version of class omero.model.FilesetAnnotationLink>`, :ref:`FilesetEntry.details.group <Hibernate version of class omero.model.FilesetEntry>`, :ref:`FilesetJobLink.details.group <Hibernate version of class omero.model.FilesetJobLink>`, :ref:`Filter.details.group <Hibernate version of class omero.model.Filter>`, :ref:`FilterAnnotationLink.details.group <Hibernate version of class omero.model.FilterAnnotationLink>`, :ref:`FilterSet.details.group <Hibernate version of class omero.model.FilterSet>`, :ref:`FilterSetEmissionFilterLink.details.group <Hibernate version of class omero.model.FilterSetEmissionFilterLink>`, :ref:`FilterSetExcitationFilterLink.details.group <Hibernate version of class omero.model.FilterSetExcitationFilterLink>`, :ref:`GenericExcitationSource.details.group <Hibernate version of class omero.model.GenericExcitationSource>`, :ref:`GroupExperimenterMap.parent <Hibernate version of class omero.model.GroupExperimenterMap>`, :ref:`Image.details.group <Hibernate version of class omero.model.Image>`, :ref:`ImageAnnotationLink.details.group <Hibernate version of class omero.model.ImageAnnotationLink>`, :ref:`ImagingEnvironment.details.group <Hibernate version of class omero.model.ImagingEnvironment>`, :ref:`ImportJob.details.group <Hibernate version of class omero.model.ImportJob>`, :ref:`IndexingJob.details.group <Hibernate version of class omero.model.IndexingJob>`, :ref:`Instrument.details.group <Hibernate version of class omero.model.Instrument>`, :ref:`InstrumentAnnotationLink.details.group <Hibernate version of class omero.model.InstrumentAnnotationLink>`, :ref:`IntegrityCheckJob.details.group <Hibernate version of class omero.model.IntegrityCheckJob>`, :ref:`Job.details.group <Hibernate version of class omero.model.Job>`, :ref:`JobOriginalFileLink.details.group <Hibernate version of class omero.model.JobOriginalFileLink>`, :ref:`Label.details.group <Hibernate version of class omero.model.Label>`, :ref:`Laser.details.group <Hibernate version of class omero.model.Laser>`, :ref:`LightEmittingDiode.details.group <Hibernate version of class omero.model.LightEmittingDiode>`, :ref:`LightPath.details.group <Hibernate version of class omero.model.LightPath>`, :ref:`LightPathAnnotationLink.details.group <Hibernate version of class omero.model.LightPathAnnotationLink>`, :ref:`LightPathEmissionFilterLink.details.group <Hibernate version of class omero.model.LightPathEmissionFilterLink>`, :ref:`LightPathExcitationFilterLink.details.group <Hibernate version of class omero.model.LightPathExcitationFilterLink>`, :ref:`LightSettings.details.group <Hibernate version of class omero.model.LightSettings>`, :ref:`LightSource.details.group <Hibernate version of class omero.model.LightSource>`, :ref:`LightSourceAnnotationLink.details.group <Hibernate version of class omero.model.LightSourceAnnotationLink>`, :ref:`Line.details.group <Hibernate version of class omero.model.Line>`, :ref:`Link.details.group <Hibernate version of class omero.model.Link>`, :ref:`ListAnnotation.details.group <Hibernate version of class omero.model.ListAnnotation>`, :ref:`LogicalChannel.details.group <Hibernate version of class omero.model.LogicalChannel>`, :ref:`LongAnnotation.details.group <Hibernate version of class omero.model.LongAnnotation>`, :ref:`MapAnnotation.details.group <Hibernate version of class omero.model.MapAnnotation>`, :ref:`Mask.details.group <Hibernate version of class omero.model.Mask>`, :ref:`MetadataImportJob.details.group <Hibernate version of class omero.model.MetadataImportJob>`, :ref:`MicrobeamManipulation.details.group <Hibernate version of class omero.model.MicrobeamManipulation>`, :ref:`Microscope.details.group <Hibernate version of class omero.model.Microscope>`, :ref:`NamespaceAnnotationLink.details.group <Hibernate version of class omero.model.NamespaceAnnotationLink>`, :ref:`NodeAnnotationLink.details.group <Hibernate version of class omero.model.NodeAnnotationLink>`, :ref:`NumericAnnotation.details.group <Hibernate version of class omero.model.NumericAnnotation>`, :ref:`OTF.details.group <Hibernate version of class omero.model.OTF>`, :ref:`Objective.details.group <Hibernate version of class omero.model.Objective>`, :ref:`ObjectiveAnnotationLink.details.group <Hibernate version of class omero.model.ObjectiveAnnotationLink>`, :ref:`ObjectiveSettings.details.group <Hibernate version of class omero.model.ObjectiveSettings>`, :ref:`OriginalFile.details.group <Hibernate version of class omero.model.OriginalFile>`, :ref:`OriginalFileAnnotationLink.details.group <Hibernate version of class omero.model.OriginalFileAnnotationLink>`, :ref:`ParseJob.details.group <Hibernate version of class omero.model.ParseJob>`, :ref:`Path.details.group <Hibernate version of class omero.model.Path>`, :ref:`PixelDataJob.details.group <Hibernate version of class omero.model.PixelDataJob>`, :ref:`Pixels.details.group <Hibernate version of class omero.model.Pixels>`, :ref:`PixelsOriginalFileMap.details.group <Hibernate version of class omero.model.PixelsOriginalFileMap>`, :ref:`PlaneInfo.details.group <Hibernate version of class omero.model.PlaneInfo>`, :ref:`PlaneInfoAnnotationLink.details.group <Hibernate version of class omero.model.PlaneInfoAnnotationLink>`, :ref:`PlaneSlicingContext.details.group <Hibernate version of class omero.model.PlaneSlicingContext>`, :ref:`Plate.details.group <Hibernate version of class omero.model.Plate>`, :ref:`PlateAcquisition.details.group <Hibernate version of class omero.model.PlateAcquisition>`, :ref:`PlateAcquisitionAnnotationLink.details.group <Hibernate version of class omero.model.PlateAcquisitionAnnotationLink>`, :ref:`PlateAnnotationLink.details.group <Hibernate version of class omero.model.PlateAnnotationLink>`, :ref:`Point.details.group <Hibernate version of class omero.model.Point>`, :ref:`Polygon.details.group <Hibernate version of class omero.model.Polygon>`, :ref:`Polyline.details.group <Hibernate version of class omero.model.Polyline>`, :ref:`Project.details.group <Hibernate version of class omero.model.Project>`, :ref:`ProjectAnnotationLink.details.group <Hibernate version of class omero.model.ProjectAnnotationLink>`, :ref:`ProjectDatasetLink.details.group <Hibernate version of class omero.model.ProjectDatasetLink>`, :ref:`QuantumDef.details.group <Hibernate version of class omero.model.QuantumDef>`, :ref:`Reagent.details.group <Hibernate version of class omero.model.Reagent>`, :ref:`ReagentAnnotationLink.details.group <Hibernate version of class omero.model.ReagentAnnotationLink>`, :ref:`Rect.details.group <Hibernate version of class omero.model.Rect>`, :ref:`RenderingDef.details.group <Hibernate version of class omero.model.RenderingDef>`, :ref:`ReverseIntensityContext.details.group <Hibernate version of class omero.model.ReverseIntensityContext>`, :ref:`Roi.details.group <Hibernate version of class omero.model.Roi>`, :ref:`RoiAnnotationLink.details.group <Hibernate version of class omero.model.RoiAnnotationLink>`, :ref:`Screen.details.group <Hibernate version of class omero.model.Screen>`, :ref:`ScreenAnnotationLink.details.group <Hibernate version of class omero.model.ScreenAnnotationLink>`, :ref:`ScreenPlateLink.details.group <Hibernate version of class omero.model.ScreenPlateLink>`, :ref:`ScriptJob.details.group <Hibernate version of class omero.model.ScriptJob>`, :ref:`SessionAnnotationLink.details.group <Hibernate version of class omero.model.SessionAnnotationLink>`, :ref:`Shape.details.group <Hibernate version of class omero.model.Shape>`, :ref:`ShapeAnnotationLink.details.group <Hibernate version of class omero.model.ShapeAnnotationLink>`, :ref:`Share.group <Hibernate version of class omero.model.Share>`, :ref:`StageLabel.details.group <Hibernate version of class omero.model.StageLabel>`, :ref:`StatsInfo.details.group <Hibernate version of class omero.model.StatsInfo>`, :ref:`TagAnnotation.details.group <Hibernate version of class omero.model.TagAnnotation>`, :ref:`TermAnnotation.details.group <Hibernate version of class omero.model.TermAnnotation>`, :ref:`TextAnnotation.details.group <Hibernate version of class omero.model.TextAnnotation>`, :ref:`Thumbnail.details.group <Hibernate version of class omero.model.Thumbnail>`, :ref:`ThumbnailGenerationJob.details.group <Hibernate version of class omero.model.ThumbnailGenerationJob>`, :ref:`TimestampAnnotation.details.group <Hibernate version of class omero.model.TimestampAnnotation>`, :ref:`TransmittanceRange.details.group <Hibernate version of class omero.model.TransmittanceRange>`, :ref:`TypeAnnotation.details.group <Hibernate version of class omero.model.TypeAnnotation>`, :ref:`UploadJob.details.group <Hibernate version of class omero.model.UploadJob>`, :ref:`Well.details.group <Hibernate version of class omero.model.Well>`, :ref:`WellAnnotationLink.details.group <Hibernate version of class omero.model.WellAnnotationLink>`, :ref:`WellReagentLink.details.group <Hibernate version of class omero.model.WellReagentLink>`, :ref:`WellSample.details.group <Hibernate version of class omero.model.WellSample>`, :ref:`XmlAnnotation.details.group <Hibernate version of class omero.model.XmlAnnotation>`
+Used by: :ref:`Annotation.details.group <OMERO model class Annotation>`, :ref:`AnnotationAnnotationLink.details.group <OMERO model class AnnotationAnnotationLink>`, :ref:`Arc.details.group <OMERO model class Arc>`, :ref:`BasicAnnotation.details.group <OMERO model class BasicAnnotation>`, :ref:`BooleanAnnotation.details.group <OMERO model class BooleanAnnotation>`, :ref:`Channel.details.group <OMERO model class Channel>`, :ref:`ChannelAnnotationLink.details.group <OMERO model class ChannelAnnotationLink>`, :ref:`ChannelBinding.details.group <OMERO model class ChannelBinding>`, :ref:`CodomainMapContext.details.group <OMERO model class CodomainMapContext>`, :ref:`CommentAnnotation.details.group <OMERO model class CommentAnnotation>`, :ref:`ContrastStretchingContext.details.group <OMERO model class ContrastStretchingContext>`, :ref:`Dataset.details.group <OMERO model class Dataset>`, :ref:`DatasetAnnotationLink.details.group <OMERO model class DatasetAnnotationLink>`, :ref:`DatasetImageLink.details.group <OMERO model class DatasetImageLink>`, :ref:`Detector.details.group <OMERO model class Detector>`, :ref:`DetectorAnnotationLink.details.group <OMERO model class DetectorAnnotationLink>`, :ref:`DetectorSettings.details.group <OMERO model class DetectorSettings>`, :ref:`Dichroic.details.group <OMERO model class Dichroic>`, :ref:`DichroicAnnotationLink.details.group <OMERO model class DichroicAnnotationLink>`, :ref:`DoubleAnnotation.details.group <OMERO model class DoubleAnnotation>`, :ref:`Ellipse.details.group <OMERO model class Ellipse>`, :ref:`Event.experimenterGroup <OMERO model class Event>`, :ref:`Experiment.details.group <OMERO model class Experiment>`, :ref:`ExperimenterAnnotationLink.details.group <OMERO model class ExperimenterAnnotationLink>`, :ref:`ExperimenterGroupAnnotationLink.details.group <OMERO model class ExperimenterGroupAnnotationLink>`, :ref:`ExperimenterGroupAnnotationLink.parent <OMERO model class ExperimenterGroupAnnotationLink>`, :ref:`ExternalInfo.details.group <OMERO model class ExternalInfo>`, :ref:`Filament.details.group <OMERO model class Filament>`, :ref:`FileAnnotation.details.group <OMERO model class FileAnnotation>`, :ref:`Fileset.details.group <OMERO model class Fileset>`, :ref:`FilesetAnnotationLink.details.group <OMERO model class FilesetAnnotationLink>`, :ref:`FilesetEntry.details.group <OMERO model class FilesetEntry>`, :ref:`FilesetJobLink.details.group <OMERO model class FilesetJobLink>`, :ref:`Filter.details.group <OMERO model class Filter>`, :ref:`FilterAnnotationLink.details.group <OMERO model class FilterAnnotationLink>`, :ref:`FilterSet.details.group <OMERO model class FilterSet>`, :ref:`FilterSetEmissionFilterLink.details.group <OMERO model class FilterSetEmissionFilterLink>`, :ref:`FilterSetExcitationFilterLink.details.group <OMERO model class FilterSetExcitationFilterLink>`, :ref:`GenericExcitationSource.details.group <OMERO model class GenericExcitationSource>`, :ref:`GroupExperimenterMap.parent <OMERO model class GroupExperimenterMap>`, :ref:`Image.details.group <OMERO model class Image>`, :ref:`ImageAnnotationLink.details.group <OMERO model class ImageAnnotationLink>`, :ref:`ImagingEnvironment.details.group <OMERO model class ImagingEnvironment>`, :ref:`ImportJob.details.group <OMERO model class ImportJob>`, :ref:`IndexingJob.details.group <OMERO model class IndexingJob>`, :ref:`Instrument.details.group <OMERO model class Instrument>`, :ref:`InstrumentAnnotationLink.details.group <OMERO model class InstrumentAnnotationLink>`, :ref:`IntegrityCheckJob.details.group <OMERO model class IntegrityCheckJob>`, :ref:`Job.details.group <OMERO model class Job>`, :ref:`JobOriginalFileLink.details.group <OMERO model class JobOriginalFileLink>`, :ref:`Label.details.group <OMERO model class Label>`, :ref:`Laser.details.group <OMERO model class Laser>`, :ref:`LightEmittingDiode.details.group <OMERO model class LightEmittingDiode>`, :ref:`LightPath.details.group <OMERO model class LightPath>`, :ref:`LightPathAnnotationLink.details.group <OMERO model class LightPathAnnotationLink>`, :ref:`LightPathEmissionFilterLink.details.group <OMERO model class LightPathEmissionFilterLink>`, :ref:`LightPathExcitationFilterLink.details.group <OMERO model class LightPathExcitationFilterLink>`, :ref:`LightSettings.details.group <OMERO model class LightSettings>`, :ref:`LightSource.details.group <OMERO model class LightSource>`, :ref:`LightSourceAnnotationLink.details.group <OMERO model class LightSourceAnnotationLink>`, :ref:`Line.details.group <OMERO model class Line>`, :ref:`Link.details.group <OMERO model class Link>`, :ref:`ListAnnotation.details.group <OMERO model class ListAnnotation>`, :ref:`LogicalChannel.details.group <OMERO model class LogicalChannel>`, :ref:`LongAnnotation.details.group <OMERO model class LongAnnotation>`, :ref:`MapAnnotation.details.group <OMERO model class MapAnnotation>`, :ref:`Mask.details.group <OMERO model class Mask>`, :ref:`MetadataImportJob.details.group <OMERO model class MetadataImportJob>`, :ref:`MicrobeamManipulation.details.group <OMERO model class MicrobeamManipulation>`, :ref:`Microscope.details.group <OMERO model class Microscope>`, :ref:`NamespaceAnnotationLink.details.group <OMERO model class NamespaceAnnotationLink>`, :ref:`NodeAnnotationLink.details.group <OMERO model class NodeAnnotationLink>`, :ref:`NumericAnnotation.details.group <OMERO model class NumericAnnotation>`, :ref:`OTF.details.group <OMERO model class OTF>`, :ref:`Objective.details.group <OMERO model class Objective>`, :ref:`ObjectiveAnnotationLink.details.group <OMERO model class ObjectiveAnnotationLink>`, :ref:`ObjectiveSettings.details.group <OMERO model class ObjectiveSettings>`, :ref:`OriginalFile.details.group <OMERO model class OriginalFile>`, :ref:`OriginalFileAnnotationLink.details.group <OMERO model class OriginalFileAnnotationLink>`, :ref:`ParseJob.details.group <OMERO model class ParseJob>`, :ref:`Path.details.group <OMERO model class Path>`, :ref:`PixelDataJob.details.group <OMERO model class PixelDataJob>`, :ref:`Pixels.details.group <OMERO model class Pixels>`, :ref:`PixelsOriginalFileMap.details.group <OMERO model class PixelsOriginalFileMap>`, :ref:`PlaneInfo.details.group <OMERO model class PlaneInfo>`, :ref:`PlaneInfoAnnotationLink.details.group <OMERO model class PlaneInfoAnnotationLink>`, :ref:`PlaneSlicingContext.details.group <OMERO model class PlaneSlicingContext>`, :ref:`Plate.details.group <OMERO model class Plate>`, :ref:`PlateAcquisition.details.group <OMERO model class PlateAcquisition>`, :ref:`PlateAcquisitionAnnotationLink.details.group <OMERO model class PlateAcquisitionAnnotationLink>`, :ref:`PlateAnnotationLink.details.group <OMERO model class PlateAnnotationLink>`, :ref:`Point.details.group <OMERO model class Point>`, :ref:`Polygon.details.group <OMERO model class Polygon>`, :ref:`Polyline.details.group <OMERO model class Polyline>`, :ref:`Project.details.group <OMERO model class Project>`, :ref:`ProjectAnnotationLink.details.group <OMERO model class ProjectAnnotationLink>`, :ref:`ProjectDatasetLink.details.group <OMERO model class ProjectDatasetLink>`, :ref:`QuantumDef.details.group <OMERO model class QuantumDef>`, :ref:`Reagent.details.group <OMERO model class Reagent>`, :ref:`ReagentAnnotationLink.details.group <OMERO model class ReagentAnnotationLink>`, :ref:`Rect.details.group <OMERO model class Rect>`, :ref:`RenderingDef.details.group <OMERO model class RenderingDef>`, :ref:`ReverseIntensityContext.details.group <OMERO model class ReverseIntensityContext>`, :ref:`Roi.details.group <OMERO model class Roi>`, :ref:`RoiAnnotationLink.details.group <OMERO model class RoiAnnotationLink>`, :ref:`Screen.details.group <OMERO model class Screen>`, :ref:`ScreenAnnotationLink.details.group <OMERO model class ScreenAnnotationLink>`, :ref:`ScreenPlateLink.details.group <OMERO model class ScreenPlateLink>`, :ref:`ScriptJob.details.group <OMERO model class ScriptJob>`, :ref:`SessionAnnotationLink.details.group <OMERO model class SessionAnnotationLink>`, :ref:`Shape.details.group <OMERO model class Shape>`, :ref:`ShapeAnnotationLink.details.group <OMERO model class ShapeAnnotationLink>`, :ref:`Share.group <OMERO model class Share>`, :ref:`StageLabel.details.group <OMERO model class StageLabel>`, :ref:`StatsInfo.details.group <OMERO model class StatsInfo>`, :ref:`TagAnnotation.details.group <OMERO model class TagAnnotation>`, :ref:`TermAnnotation.details.group <OMERO model class TermAnnotation>`, :ref:`TextAnnotation.details.group <OMERO model class TextAnnotation>`, :ref:`Thumbnail.details.group <OMERO model class Thumbnail>`, :ref:`ThumbnailGenerationJob.details.group <OMERO model class ThumbnailGenerationJob>`, :ref:`TimestampAnnotation.details.group <OMERO model class TimestampAnnotation>`, :ref:`TransmittanceRange.details.group <OMERO model class TransmittanceRange>`, :ref:`TypeAnnotation.details.group <OMERO model class TypeAnnotation>`, :ref:`UploadJob.details.group <OMERO model class UploadJob>`, :ref:`Well.details.group <OMERO model class Well>`, :ref:`WellAnnotationLink.details.group <OMERO model class WellAnnotationLink>`, :ref:`WellReagentLink.details.group <OMERO model class WellReagentLink>`, :ref:`WellSample.details.group <OMERO model class WellSample>`, :ref:`XmlAnnotation.details.group <OMERO model class XmlAnnotation>`
 
 Properties:
-  | annotationLinks: :ref:`ExperimenterGroupAnnotationLink <Hibernate version of class omero.model.ExperimenterGroupAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`ExperimenterGroupAnnotationLink <OMERO model class ExperimenterGroupAnnotationLink>` (multiple)
   | config: list (multiple)
   | description: ``text`` (optional)
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | groupExperimenterMap: :ref:`GroupExperimenterMap <Hibernate version of class omero.model.GroupExperimenterMap>` (multiple)
+  | groupExperimenterMap: :ref:`GroupExperimenterMap <OMERO model class GroupExperimenterMap>` (multiple)
   | ldap: ``boolean``
   | name: ``string``
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.ExperimenterGroupAnnotationLink:
+.. _OMERO model class ExperimenterGroupAnnotationLink:
 
 ExperimenterGroupAnnotationLink
 """""""""""""""""""""""""""""""
 
-Used by: :ref:`ExperimenterGroup.annotationLinks <Hibernate version of class omero.model.ExperimenterGroup>`
+Used by: :ref:`ExperimenterGroup.annotationLinks <OMERO model class ExperimenterGroup>`
 
 Properties:
-  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Annotation <OMERO model class Annotation>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.ExternalInfo:
+.. _OMERO model class ExternalInfo:
 
 ExternalInfo
 """"""""""""
 
-Used by: :ref:`AcquisitionMode.details.externalInfo <Hibernate version of class omero.model.AcquisitionMode>`, :ref:`Annotation.details.externalInfo <Hibernate version of class omero.model.Annotation>`, :ref:`AnnotationAnnotationLink.details.externalInfo <Hibernate version of class omero.model.AnnotationAnnotationLink>`, :ref:`Arc.details.externalInfo <Hibernate version of class omero.model.Arc>`, :ref:`ArcType.details.externalInfo <Hibernate version of class omero.model.ArcType>`, :ref:`BasicAnnotation.details.externalInfo <Hibernate version of class omero.model.BasicAnnotation>`, :ref:`Binning.details.externalInfo <Hibernate version of class omero.model.Binning>`, :ref:`BooleanAnnotation.details.externalInfo <Hibernate version of class omero.model.BooleanAnnotation>`, :ref:`Channel.details.externalInfo <Hibernate version of class omero.model.Channel>`, :ref:`ChannelAnnotationLink.details.externalInfo <Hibernate version of class omero.model.ChannelAnnotationLink>`, :ref:`ChannelBinding.details.externalInfo <Hibernate version of class omero.model.ChannelBinding>`, :ref:`ChecksumAlgorithm.details.externalInfo <Hibernate version of class omero.model.ChecksumAlgorithm>`, :ref:`CodomainMapContext.details.externalInfo <Hibernate version of class omero.model.CodomainMapContext>`, :ref:`CommentAnnotation.details.externalInfo <Hibernate version of class omero.model.CommentAnnotation>`, :ref:`ContrastMethod.details.externalInfo <Hibernate version of class omero.model.ContrastMethod>`, :ref:`ContrastStretchingContext.details.externalInfo <Hibernate version of class omero.model.ContrastStretchingContext>`, :ref:`Correction.details.externalInfo <Hibernate version of class omero.model.Correction>`, :ref:`DBPatch.details.externalInfo <Hibernate version of class omero.model.DBPatch>`, :ref:`Dataset.details.externalInfo <Hibernate version of class omero.model.Dataset>`, :ref:`DatasetAnnotationLink.details.externalInfo <Hibernate version of class omero.model.DatasetAnnotationLink>`, :ref:`DatasetImageLink.details.externalInfo <Hibernate version of class omero.model.DatasetImageLink>`, :ref:`Detector.details.externalInfo <Hibernate version of class omero.model.Detector>`, :ref:`DetectorAnnotationLink.details.externalInfo <Hibernate version of class omero.model.DetectorAnnotationLink>`, :ref:`DetectorSettings.details.externalInfo <Hibernate version of class omero.model.DetectorSettings>`, :ref:`DetectorType.details.externalInfo <Hibernate version of class omero.model.DetectorType>`, :ref:`Dichroic.details.externalInfo <Hibernate version of class omero.model.Dichroic>`, :ref:`DichroicAnnotationLink.details.externalInfo <Hibernate version of class omero.model.DichroicAnnotationLink>`, :ref:`DimensionOrder.details.externalInfo <Hibernate version of class omero.model.DimensionOrder>`, :ref:`DoubleAnnotation.details.externalInfo <Hibernate version of class omero.model.DoubleAnnotation>`, :ref:`Ellipse.details.externalInfo <Hibernate version of class omero.model.Ellipse>`, :ref:`Event.details.externalInfo <Hibernate version of class omero.model.Event>`, :ref:`EventLog.details.externalInfo <Hibernate version of class omero.model.EventLog>`, :ref:`EventType.details.externalInfo <Hibernate version of class omero.model.EventType>`, :ref:`Experiment.details.externalInfo <Hibernate version of class omero.model.Experiment>`, :ref:`ExperimentType.details.externalInfo <Hibernate version of class omero.model.ExperimentType>`, :ref:`Experimenter.details.externalInfo <Hibernate version of class omero.model.Experimenter>`, :ref:`ExperimenterAnnotationLink.details.externalInfo <Hibernate version of class omero.model.ExperimenterAnnotationLink>`, :ref:`ExperimenterGroup.details.externalInfo <Hibernate version of class omero.model.ExperimenterGroup>`, :ref:`ExperimenterGroupAnnotationLink.details.externalInfo <Hibernate version of class omero.model.ExperimenterGroupAnnotationLink>`, :ref:`ExternalInfo.details.externalInfo <Hibernate version of class omero.model.ExternalInfo>`, :ref:`Family.details.externalInfo <Hibernate version of class omero.model.Family>`, :ref:`Filament.details.externalInfo <Hibernate version of class omero.model.Filament>`, :ref:`FilamentType.details.externalInfo <Hibernate version of class omero.model.FilamentType>`, :ref:`FileAnnotation.details.externalInfo <Hibernate version of class omero.model.FileAnnotation>`, :ref:`Fileset.details.externalInfo <Hibernate version of class omero.model.Fileset>`, :ref:`FilesetAnnotationLink.details.externalInfo <Hibernate version of class omero.model.FilesetAnnotationLink>`, :ref:`FilesetEntry.details.externalInfo <Hibernate version of class omero.model.FilesetEntry>`, :ref:`FilesetJobLink.details.externalInfo <Hibernate version of class omero.model.FilesetJobLink>`, :ref:`Filter.details.externalInfo <Hibernate version of class omero.model.Filter>`, :ref:`FilterAnnotationLink.details.externalInfo <Hibernate version of class omero.model.FilterAnnotationLink>`, :ref:`FilterSet.details.externalInfo <Hibernate version of class omero.model.FilterSet>`, :ref:`FilterSetEmissionFilterLink.details.externalInfo <Hibernate version of class omero.model.FilterSetEmissionFilterLink>`, :ref:`FilterSetExcitationFilterLink.details.externalInfo <Hibernate version of class omero.model.FilterSetExcitationFilterLink>`, :ref:`FilterType.details.externalInfo <Hibernate version of class omero.model.FilterType>`, :ref:`Format.details.externalInfo <Hibernate version of class omero.model.Format>`, :ref:`GenericExcitationSource.details.externalInfo <Hibernate version of class omero.model.GenericExcitationSource>`, :ref:`GroupExperimenterMap.details.externalInfo <Hibernate version of class omero.model.GroupExperimenterMap>`, :ref:`Illumination.details.externalInfo <Hibernate version of class omero.model.Illumination>`, :ref:`Image.details.externalInfo <Hibernate version of class omero.model.Image>`, :ref:`ImageAnnotationLink.details.externalInfo <Hibernate version of class omero.model.ImageAnnotationLink>`, :ref:`ImagingEnvironment.details.externalInfo <Hibernate version of class omero.model.ImagingEnvironment>`, :ref:`Immersion.details.externalInfo <Hibernate version of class omero.model.Immersion>`, :ref:`ImportJob.details.externalInfo <Hibernate version of class omero.model.ImportJob>`, :ref:`IndexingJob.details.externalInfo <Hibernate version of class omero.model.IndexingJob>`, :ref:`Instrument.details.externalInfo <Hibernate version of class omero.model.Instrument>`, :ref:`InstrumentAnnotationLink.details.externalInfo <Hibernate version of class omero.model.InstrumentAnnotationLink>`, :ref:`IntegrityCheckJob.details.externalInfo <Hibernate version of class omero.model.IntegrityCheckJob>`, :ref:`Job.details.externalInfo <Hibernate version of class omero.model.Job>`, :ref:`JobOriginalFileLink.details.externalInfo <Hibernate version of class omero.model.JobOriginalFileLink>`, :ref:`JobStatus.details.externalInfo <Hibernate version of class omero.model.JobStatus>`, :ref:`Label.details.externalInfo <Hibernate version of class omero.model.Label>`, :ref:`Laser.details.externalInfo <Hibernate version of class omero.model.Laser>`, :ref:`LaserMedium.details.externalInfo <Hibernate version of class omero.model.LaserMedium>`, :ref:`LaserType.details.externalInfo <Hibernate version of class omero.model.LaserType>`, :ref:`LightEmittingDiode.details.externalInfo <Hibernate version of class omero.model.LightEmittingDiode>`, :ref:`LightPath.details.externalInfo <Hibernate version of class omero.model.LightPath>`, :ref:`LightPathAnnotationLink.details.externalInfo <Hibernate version of class omero.model.LightPathAnnotationLink>`, :ref:`LightPathEmissionFilterLink.details.externalInfo <Hibernate version of class omero.model.LightPathEmissionFilterLink>`, :ref:`LightPathExcitationFilterLink.details.externalInfo <Hibernate version of class omero.model.LightPathExcitationFilterLink>`, :ref:`LightSettings.details.externalInfo <Hibernate version of class omero.model.LightSettings>`, :ref:`LightSource.details.externalInfo <Hibernate version of class omero.model.LightSource>`, :ref:`LightSourceAnnotationLink.details.externalInfo <Hibernate version of class omero.model.LightSourceAnnotationLink>`, :ref:`Line.details.externalInfo <Hibernate version of class omero.model.Line>`, :ref:`Link.details.externalInfo <Hibernate version of class omero.model.Link>`, :ref:`ListAnnotation.details.externalInfo <Hibernate version of class omero.model.ListAnnotation>`, :ref:`LogicalChannel.details.externalInfo <Hibernate version of class omero.model.LogicalChannel>`, :ref:`LongAnnotation.details.externalInfo <Hibernate version of class omero.model.LongAnnotation>`, :ref:`MapAnnotation.details.externalInfo <Hibernate version of class omero.model.MapAnnotation>`, :ref:`Mask.details.externalInfo <Hibernate version of class omero.model.Mask>`, :ref:`Medium.details.externalInfo <Hibernate version of class omero.model.Medium>`, :ref:`MetadataImportJob.details.externalInfo <Hibernate version of class omero.model.MetadataImportJob>`, :ref:`MicrobeamManipulation.details.externalInfo <Hibernate version of class omero.model.MicrobeamManipulation>`, :ref:`MicrobeamManipulationType.details.externalInfo <Hibernate version of class omero.model.MicrobeamManipulationType>`, :ref:`Microscope.details.externalInfo <Hibernate version of class omero.model.Microscope>`, :ref:`MicroscopeType.details.externalInfo <Hibernate version of class omero.model.MicroscopeType>`, :ref:`Namespace.details.externalInfo <Hibernate version of class omero.model.Namespace>`, :ref:`NamespaceAnnotationLink.details.externalInfo <Hibernate version of class omero.model.NamespaceAnnotationLink>`, :ref:`Node.details.externalInfo <Hibernate version of class omero.model.Node>`, :ref:`NodeAnnotationLink.details.externalInfo <Hibernate version of class omero.model.NodeAnnotationLink>`, :ref:`NumericAnnotation.details.externalInfo <Hibernate version of class omero.model.NumericAnnotation>`, :ref:`OTF.details.externalInfo <Hibernate version of class omero.model.OTF>`, :ref:`Objective.details.externalInfo <Hibernate version of class omero.model.Objective>`, :ref:`ObjectiveAnnotationLink.details.externalInfo <Hibernate version of class omero.model.ObjectiveAnnotationLink>`, :ref:`ObjectiveSettings.details.externalInfo <Hibernate version of class omero.model.ObjectiveSettings>`, :ref:`OriginalFile.details.externalInfo <Hibernate version of class omero.model.OriginalFile>`, :ref:`OriginalFileAnnotationLink.details.externalInfo <Hibernate version of class omero.model.OriginalFileAnnotationLink>`, :ref:`ParseJob.details.externalInfo <Hibernate version of class omero.model.ParseJob>`, :ref:`Path.details.externalInfo <Hibernate version of class omero.model.Path>`, :ref:`PhotometricInterpretation.details.externalInfo <Hibernate version of class omero.model.PhotometricInterpretation>`, :ref:`PixelDataJob.details.externalInfo <Hibernate version of class omero.model.PixelDataJob>`, :ref:`Pixels.details.externalInfo <Hibernate version of class omero.model.Pixels>`, :ref:`PixelsOriginalFileMap.details.externalInfo <Hibernate version of class omero.model.PixelsOriginalFileMap>`, :ref:`PixelsType.details.externalInfo <Hibernate version of class omero.model.PixelsType>`, :ref:`PlaneInfo.details.externalInfo <Hibernate version of class omero.model.PlaneInfo>`, :ref:`PlaneInfoAnnotationLink.details.externalInfo <Hibernate version of class omero.model.PlaneInfoAnnotationLink>`, :ref:`PlaneSlicingContext.details.externalInfo <Hibernate version of class omero.model.PlaneSlicingContext>`, :ref:`Plate.details.externalInfo <Hibernate version of class omero.model.Plate>`, :ref:`PlateAcquisition.details.externalInfo <Hibernate version of class omero.model.PlateAcquisition>`, :ref:`PlateAcquisitionAnnotationLink.details.externalInfo <Hibernate version of class omero.model.PlateAcquisitionAnnotationLink>`, :ref:`PlateAnnotationLink.details.externalInfo <Hibernate version of class omero.model.PlateAnnotationLink>`, :ref:`Point.details.externalInfo <Hibernate version of class omero.model.Point>`, :ref:`Polygon.details.externalInfo <Hibernate version of class omero.model.Polygon>`, :ref:`Polyline.details.externalInfo <Hibernate version of class omero.model.Polyline>`, :ref:`Project.details.externalInfo <Hibernate version of class omero.model.Project>`, :ref:`ProjectAnnotationLink.details.externalInfo <Hibernate version of class omero.model.ProjectAnnotationLink>`, :ref:`ProjectDatasetLink.details.externalInfo <Hibernate version of class omero.model.ProjectDatasetLink>`, :ref:`Pulse.details.externalInfo <Hibernate version of class omero.model.Pulse>`, :ref:`QuantumDef.details.externalInfo <Hibernate version of class omero.model.QuantumDef>`, :ref:`Reagent.details.externalInfo <Hibernate version of class omero.model.Reagent>`, :ref:`ReagentAnnotationLink.details.externalInfo <Hibernate version of class omero.model.ReagentAnnotationLink>`, :ref:`Rect.details.externalInfo <Hibernate version of class omero.model.Rect>`, :ref:`RenderingDef.details.externalInfo <Hibernate version of class omero.model.RenderingDef>`, :ref:`RenderingModel.details.externalInfo <Hibernate version of class omero.model.RenderingModel>`, :ref:`ReverseIntensityContext.details.externalInfo <Hibernate version of class omero.model.ReverseIntensityContext>`, :ref:`Roi.details.externalInfo <Hibernate version of class omero.model.Roi>`, :ref:`RoiAnnotationLink.details.externalInfo <Hibernate version of class omero.model.RoiAnnotationLink>`, :ref:`Screen.details.externalInfo <Hibernate version of class omero.model.Screen>`, :ref:`ScreenAnnotationLink.details.externalInfo <Hibernate version of class omero.model.ScreenAnnotationLink>`, :ref:`ScreenPlateLink.details.externalInfo <Hibernate version of class omero.model.ScreenPlateLink>`, :ref:`ScriptJob.details.externalInfo <Hibernate version of class omero.model.ScriptJob>`, :ref:`Session.details.externalInfo <Hibernate version of class omero.model.Session>`, :ref:`SessionAnnotationLink.details.externalInfo <Hibernate version of class omero.model.SessionAnnotationLink>`, :ref:`Shape.details.externalInfo <Hibernate version of class omero.model.Shape>`, :ref:`ShapeAnnotationLink.details.externalInfo <Hibernate version of class omero.model.ShapeAnnotationLink>`, :ref:`Share.details.externalInfo <Hibernate version of class omero.model.Share>`, :ref:`ShareMember.details.externalInfo <Hibernate version of class omero.model.ShareMember>`, :ref:`StageLabel.details.externalInfo <Hibernate version of class omero.model.StageLabel>`, :ref:`StatsInfo.details.externalInfo <Hibernate version of class omero.model.StatsInfo>`, :ref:`TagAnnotation.details.externalInfo <Hibernate version of class omero.model.TagAnnotation>`, :ref:`TermAnnotation.details.externalInfo <Hibernate version of class omero.model.TermAnnotation>`, :ref:`TextAnnotation.details.externalInfo <Hibernate version of class omero.model.TextAnnotation>`, :ref:`Thumbnail.details.externalInfo <Hibernate version of class omero.model.Thumbnail>`, :ref:`ThumbnailGenerationJob.details.externalInfo <Hibernate version of class omero.model.ThumbnailGenerationJob>`, :ref:`TimestampAnnotation.details.externalInfo <Hibernate version of class omero.model.TimestampAnnotation>`, :ref:`TransmittanceRange.details.externalInfo <Hibernate version of class omero.model.TransmittanceRange>`, :ref:`TypeAnnotation.details.externalInfo <Hibernate version of class omero.model.TypeAnnotation>`, :ref:`UploadJob.details.externalInfo <Hibernate version of class omero.model.UploadJob>`, :ref:`Well.details.externalInfo <Hibernate version of class omero.model.Well>`, :ref:`WellAnnotationLink.details.externalInfo <Hibernate version of class omero.model.WellAnnotationLink>`, :ref:`WellReagentLink.details.externalInfo <Hibernate version of class omero.model.WellReagentLink>`, :ref:`WellSample.details.externalInfo <Hibernate version of class omero.model.WellSample>`, :ref:`XmlAnnotation.details.externalInfo <Hibernate version of class omero.model.XmlAnnotation>`
+Used by: :ref:`AcquisitionMode.details.externalInfo <OMERO model class AcquisitionMode>`, :ref:`Annotation.details.externalInfo <OMERO model class Annotation>`, :ref:`AnnotationAnnotationLink.details.externalInfo <OMERO model class AnnotationAnnotationLink>`, :ref:`Arc.details.externalInfo <OMERO model class Arc>`, :ref:`ArcType.details.externalInfo <OMERO model class ArcType>`, :ref:`BasicAnnotation.details.externalInfo <OMERO model class BasicAnnotation>`, :ref:`Binning.details.externalInfo <OMERO model class Binning>`, :ref:`BooleanAnnotation.details.externalInfo <OMERO model class BooleanAnnotation>`, :ref:`Channel.details.externalInfo <OMERO model class Channel>`, :ref:`ChannelAnnotationLink.details.externalInfo <OMERO model class ChannelAnnotationLink>`, :ref:`ChannelBinding.details.externalInfo <OMERO model class ChannelBinding>`, :ref:`ChecksumAlgorithm.details.externalInfo <OMERO model class ChecksumAlgorithm>`, :ref:`CodomainMapContext.details.externalInfo <OMERO model class CodomainMapContext>`, :ref:`CommentAnnotation.details.externalInfo <OMERO model class CommentAnnotation>`, :ref:`ContrastMethod.details.externalInfo <OMERO model class ContrastMethod>`, :ref:`ContrastStretchingContext.details.externalInfo <OMERO model class ContrastStretchingContext>`, :ref:`Correction.details.externalInfo <OMERO model class Correction>`, :ref:`DBPatch.details.externalInfo <OMERO model class DBPatch>`, :ref:`Dataset.details.externalInfo <OMERO model class Dataset>`, :ref:`DatasetAnnotationLink.details.externalInfo <OMERO model class DatasetAnnotationLink>`, :ref:`DatasetImageLink.details.externalInfo <OMERO model class DatasetImageLink>`, :ref:`Detector.details.externalInfo <OMERO model class Detector>`, :ref:`DetectorAnnotationLink.details.externalInfo <OMERO model class DetectorAnnotationLink>`, :ref:`DetectorSettings.details.externalInfo <OMERO model class DetectorSettings>`, :ref:`DetectorType.details.externalInfo <OMERO model class DetectorType>`, :ref:`Dichroic.details.externalInfo <OMERO model class Dichroic>`, :ref:`DichroicAnnotationLink.details.externalInfo <OMERO model class DichroicAnnotationLink>`, :ref:`DimensionOrder.details.externalInfo <OMERO model class DimensionOrder>`, :ref:`DoubleAnnotation.details.externalInfo <OMERO model class DoubleAnnotation>`, :ref:`Ellipse.details.externalInfo <OMERO model class Ellipse>`, :ref:`Event.details.externalInfo <OMERO model class Event>`, :ref:`EventLog.details.externalInfo <OMERO model class EventLog>`, :ref:`EventType.details.externalInfo <OMERO model class EventType>`, :ref:`Experiment.details.externalInfo <OMERO model class Experiment>`, :ref:`ExperimentType.details.externalInfo <OMERO model class ExperimentType>`, :ref:`Experimenter.details.externalInfo <OMERO model class Experimenter>`, :ref:`ExperimenterAnnotationLink.details.externalInfo <OMERO model class ExperimenterAnnotationLink>`, :ref:`ExperimenterGroup.details.externalInfo <OMERO model class ExperimenterGroup>`, :ref:`ExperimenterGroupAnnotationLink.details.externalInfo <OMERO model class ExperimenterGroupAnnotationLink>`, :ref:`ExternalInfo.details.externalInfo <OMERO model class ExternalInfo>`, :ref:`Family.details.externalInfo <OMERO model class Family>`, :ref:`Filament.details.externalInfo <OMERO model class Filament>`, :ref:`FilamentType.details.externalInfo <OMERO model class FilamentType>`, :ref:`FileAnnotation.details.externalInfo <OMERO model class FileAnnotation>`, :ref:`Fileset.details.externalInfo <OMERO model class Fileset>`, :ref:`FilesetAnnotationLink.details.externalInfo <OMERO model class FilesetAnnotationLink>`, :ref:`FilesetEntry.details.externalInfo <OMERO model class FilesetEntry>`, :ref:`FilesetJobLink.details.externalInfo <OMERO model class FilesetJobLink>`, :ref:`Filter.details.externalInfo <OMERO model class Filter>`, :ref:`FilterAnnotationLink.details.externalInfo <OMERO model class FilterAnnotationLink>`, :ref:`FilterSet.details.externalInfo <OMERO model class FilterSet>`, :ref:`FilterSetEmissionFilterLink.details.externalInfo <OMERO model class FilterSetEmissionFilterLink>`, :ref:`FilterSetExcitationFilterLink.details.externalInfo <OMERO model class FilterSetExcitationFilterLink>`, :ref:`FilterType.details.externalInfo <OMERO model class FilterType>`, :ref:`Format.details.externalInfo <OMERO model class Format>`, :ref:`GenericExcitationSource.details.externalInfo <OMERO model class GenericExcitationSource>`, :ref:`GroupExperimenterMap.details.externalInfo <OMERO model class GroupExperimenterMap>`, :ref:`Illumination.details.externalInfo <OMERO model class Illumination>`, :ref:`Image.details.externalInfo <OMERO model class Image>`, :ref:`ImageAnnotationLink.details.externalInfo <OMERO model class ImageAnnotationLink>`, :ref:`ImagingEnvironment.details.externalInfo <OMERO model class ImagingEnvironment>`, :ref:`Immersion.details.externalInfo <OMERO model class Immersion>`, :ref:`ImportJob.details.externalInfo <OMERO model class ImportJob>`, :ref:`IndexingJob.details.externalInfo <OMERO model class IndexingJob>`, :ref:`Instrument.details.externalInfo <OMERO model class Instrument>`, :ref:`InstrumentAnnotationLink.details.externalInfo <OMERO model class InstrumentAnnotationLink>`, :ref:`IntegrityCheckJob.details.externalInfo <OMERO model class IntegrityCheckJob>`, :ref:`Job.details.externalInfo <OMERO model class Job>`, :ref:`JobOriginalFileLink.details.externalInfo <OMERO model class JobOriginalFileLink>`, :ref:`JobStatus.details.externalInfo <OMERO model class JobStatus>`, :ref:`Label.details.externalInfo <OMERO model class Label>`, :ref:`Laser.details.externalInfo <OMERO model class Laser>`, :ref:`LaserMedium.details.externalInfo <OMERO model class LaserMedium>`, :ref:`LaserType.details.externalInfo <OMERO model class LaserType>`, :ref:`LightEmittingDiode.details.externalInfo <OMERO model class LightEmittingDiode>`, :ref:`LightPath.details.externalInfo <OMERO model class LightPath>`, :ref:`LightPathAnnotationLink.details.externalInfo <OMERO model class LightPathAnnotationLink>`, :ref:`LightPathEmissionFilterLink.details.externalInfo <OMERO model class LightPathEmissionFilterLink>`, :ref:`LightPathExcitationFilterLink.details.externalInfo <OMERO model class LightPathExcitationFilterLink>`, :ref:`LightSettings.details.externalInfo <OMERO model class LightSettings>`, :ref:`LightSource.details.externalInfo <OMERO model class LightSource>`, :ref:`LightSourceAnnotationLink.details.externalInfo <OMERO model class LightSourceAnnotationLink>`, :ref:`Line.details.externalInfo <OMERO model class Line>`, :ref:`Link.details.externalInfo <OMERO model class Link>`, :ref:`ListAnnotation.details.externalInfo <OMERO model class ListAnnotation>`, :ref:`LogicalChannel.details.externalInfo <OMERO model class LogicalChannel>`, :ref:`LongAnnotation.details.externalInfo <OMERO model class LongAnnotation>`, :ref:`MapAnnotation.details.externalInfo <OMERO model class MapAnnotation>`, :ref:`Mask.details.externalInfo <OMERO model class Mask>`, :ref:`Medium.details.externalInfo <OMERO model class Medium>`, :ref:`MetadataImportJob.details.externalInfo <OMERO model class MetadataImportJob>`, :ref:`MicrobeamManipulation.details.externalInfo <OMERO model class MicrobeamManipulation>`, :ref:`MicrobeamManipulationType.details.externalInfo <OMERO model class MicrobeamManipulationType>`, :ref:`Microscope.details.externalInfo <OMERO model class Microscope>`, :ref:`MicroscopeType.details.externalInfo <OMERO model class MicroscopeType>`, :ref:`Namespace.details.externalInfo <OMERO model class Namespace>`, :ref:`NamespaceAnnotationLink.details.externalInfo <OMERO model class NamespaceAnnotationLink>`, :ref:`Node.details.externalInfo <OMERO model class Node>`, :ref:`NodeAnnotationLink.details.externalInfo <OMERO model class NodeAnnotationLink>`, :ref:`NumericAnnotation.details.externalInfo <OMERO model class NumericAnnotation>`, :ref:`OTF.details.externalInfo <OMERO model class OTF>`, :ref:`Objective.details.externalInfo <OMERO model class Objective>`, :ref:`ObjectiveAnnotationLink.details.externalInfo <OMERO model class ObjectiveAnnotationLink>`, :ref:`ObjectiveSettings.details.externalInfo <OMERO model class ObjectiveSettings>`, :ref:`OriginalFile.details.externalInfo <OMERO model class OriginalFile>`, :ref:`OriginalFileAnnotationLink.details.externalInfo <OMERO model class OriginalFileAnnotationLink>`, :ref:`ParseJob.details.externalInfo <OMERO model class ParseJob>`, :ref:`Path.details.externalInfo <OMERO model class Path>`, :ref:`PhotometricInterpretation.details.externalInfo <OMERO model class PhotometricInterpretation>`, :ref:`PixelDataJob.details.externalInfo <OMERO model class PixelDataJob>`, :ref:`Pixels.details.externalInfo <OMERO model class Pixels>`, :ref:`PixelsOriginalFileMap.details.externalInfo <OMERO model class PixelsOriginalFileMap>`, :ref:`PixelsType.details.externalInfo <OMERO model class PixelsType>`, :ref:`PlaneInfo.details.externalInfo <OMERO model class PlaneInfo>`, :ref:`PlaneInfoAnnotationLink.details.externalInfo <OMERO model class PlaneInfoAnnotationLink>`, :ref:`PlaneSlicingContext.details.externalInfo <OMERO model class PlaneSlicingContext>`, :ref:`Plate.details.externalInfo <OMERO model class Plate>`, :ref:`PlateAcquisition.details.externalInfo <OMERO model class PlateAcquisition>`, :ref:`PlateAcquisitionAnnotationLink.details.externalInfo <OMERO model class PlateAcquisitionAnnotationLink>`, :ref:`PlateAnnotationLink.details.externalInfo <OMERO model class PlateAnnotationLink>`, :ref:`Point.details.externalInfo <OMERO model class Point>`, :ref:`Polygon.details.externalInfo <OMERO model class Polygon>`, :ref:`Polyline.details.externalInfo <OMERO model class Polyline>`, :ref:`Project.details.externalInfo <OMERO model class Project>`, :ref:`ProjectAnnotationLink.details.externalInfo <OMERO model class ProjectAnnotationLink>`, :ref:`ProjectDatasetLink.details.externalInfo <OMERO model class ProjectDatasetLink>`, :ref:`Pulse.details.externalInfo <OMERO model class Pulse>`, :ref:`QuantumDef.details.externalInfo <OMERO model class QuantumDef>`, :ref:`Reagent.details.externalInfo <OMERO model class Reagent>`, :ref:`ReagentAnnotationLink.details.externalInfo <OMERO model class ReagentAnnotationLink>`, :ref:`Rect.details.externalInfo <OMERO model class Rect>`, :ref:`RenderingDef.details.externalInfo <OMERO model class RenderingDef>`, :ref:`RenderingModel.details.externalInfo <OMERO model class RenderingModel>`, :ref:`ReverseIntensityContext.details.externalInfo <OMERO model class ReverseIntensityContext>`, :ref:`Roi.details.externalInfo <OMERO model class Roi>`, :ref:`RoiAnnotationLink.details.externalInfo <OMERO model class RoiAnnotationLink>`, :ref:`Screen.details.externalInfo <OMERO model class Screen>`, :ref:`ScreenAnnotationLink.details.externalInfo <OMERO model class ScreenAnnotationLink>`, :ref:`ScreenPlateLink.details.externalInfo <OMERO model class ScreenPlateLink>`, :ref:`ScriptJob.details.externalInfo <OMERO model class ScriptJob>`, :ref:`Session.details.externalInfo <OMERO model class Session>`, :ref:`SessionAnnotationLink.details.externalInfo <OMERO model class SessionAnnotationLink>`, :ref:`Shape.details.externalInfo <OMERO model class Shape>`, :ref:`ShapeAnnotationLink.details.externalInfo <OMERO model class ShapeAnnotationLink>`, :ref:`Share.details.externalInfo <OMERO model class Share>`, :ref:`ShareMember.details.externalInfo <OMERO model class ShareMember>`, :ref:`StageLabel.details.externalInfo <OMERO model class StageLabel>`, :ref:`StatsInfo.details.externalInfo <OMERO model class StatsInfo>`, :ref:`TagAnnotation.details.externalInfo <OMERO model class TagAnnotation>`, :ref:`TermAnnotation.details.externalInfo <OMERO model class TermAnnotation>`, :ref:`TextAnnotation.details.externalInfo <OMERO model class TextAnnotation>`, :ref:`Thumbnail.details.externalInfo <OMERO model class Thumbnail>`, :ref:`ThumbnailGenerationJob.details.externalInfo <OMERO model class ThumbnailGenerationJob>`, :ref:`TimestampAnnotation.details.externalInfo <OMERO model class TimestampAnnotation>`, :ref:`TransmittanceRange.details.externalInfo <OMERO model class TransmittanceRange>`, :ref:`TypeAnnotation.details.externalInfo <OMERO model class TypeAnnotation>`, :ref:`UploadJob.details.externalInfo <OMERO model class UploadJob>`, :ref:`Well.details.externalInfo <OMERO model class Well>`, :ref:`WellAnnotationLink.details.externalInfo <OMERO model class WellAnnotationLink>`, :ref:`WellReagentLink.details.externalInfo <OMERO model class WellReagentLink>`, :ref:`WellSample.details.externalInfo <OMERO model class WellSample>`, :ref:`XmlAnnotation.details.externalInfo <OMERO model class XmlAnnotation>`
 
 Properties:
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
   | entityId: ``long``
   | entityType: ``string``
   | lsid: ``string`` (optional)
   | uuid: ``string`` (optional)
 
-.. _Hibernate version of class omero.model.Family:
+.. _OMERO model class Family:
 
 Family
 """"""
 
-Used by: :ref:`ChannelBinding.family <Hibernate version of class omero.model.ChannelBinding>`
+Used by: :ref:`ChannelBinding.family <OMERO model class ChannelBinding>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
+  | value: ``string``, see :javadoc:`IEnum <ome/model/IEnum.html>`
 
-.. _Hibernate version of class omero.model.Filament:
+.. _OMERO model class Filament:
 
 Filament
 """"""""
 
 Properties:
-  | annotationLinks: :ref:`LightSourceAnnotationLink <Hibernate version of class omero.model.LightSourceAnnotationLink>` (multiple) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | details.permissions.perm1: ``long`` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | instrument: :ref:`Instrument <Hibernate version of class omero.model.Instrument>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | lotNumber: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | manufacturer: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | model: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | power.unit: enumeration (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`, see :javadoc:`PowerI <omero/model/PowerI.html>`
-  | power.value: ``double`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`, see :javadoc:`PowerI <omero/model/PowerI.html>`
-  | serialNumber: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | type: :ref:`FilamentType <Hibernate version of class omero.model.FilamentType>`
-  | version: ``integer`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | annotationLinks: :ref:`LightSourceAnnotationLink <OMERO model class LightSourceAnnotationLink>` (multiple) from :ref:`LightSource <OMERO model class LightSource>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`LightSource <OMERO model class LightSource>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`LightSource <OMERO model class LightSource>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`LightSource <OMERO model class LightSource>`
+  | details.permissions.perm1: ``long`` from :ref:`LightSource <OMERO model class LightSource>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`LightSource <OMERO model class LightSource>`
+  | instrument: :ref:`Instrument <OMERO model class Instrument>` from :ref:`LightSource <OMERO model class LightSource>`
+  | lotNumber: ``string`` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | manufacturer: ``string`` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | model: ``string`` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | power.unit: enumeration of :javadoc:`Power <ome/model/units/Power.html>` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | power.value: ``double`` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | serialNumber: ``string`` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | type: :ref:`FilamentType <OMERO model class FilamentType>`
+  | version: ``integer`` (optional) from :ref:`LightSource <OMERO model class LightSource>`
 
-.. _Hibernate version of class omero.model.FilamentType:
+.. _OMERO model class FilamentType:
 
 FilamentType
 """"""""""""
 
-Used by: :ref:`Filament.type <Hibernate version of class omero.model.Filament>`
+Used by: :ref:`Filament.type <OMERO model class Filament>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
+  | value: ``string``, see :javadoc:`IEnum <ome/model/IEnum.html>`
 
-.. _Hibernate version of class omero.model.FileAnnotation:
+.. _OMERO model class FileAnnotation:
 
 FileAnnotation
 """"""""""""""
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | description: ``text`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.permissions.perm1: ``long`` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | file: :ref:`OriginalFile <Hibernate version of class omero.model.OriginalFile>` (optional)
-  | name: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | ns: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | version: ``integer`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | annotationLinks: :ref:`AnnotationAnnotationLink <OMERO model class AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <OMERO model class Annotation>`
+  | description: ``text`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.permissions.perm1: ``long`` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Annotation <OMERO model class Annotation>`
+  | file: :ref:`OriginalFile <OMERO model class OriginalFile>` (optional)
+  | name: ``string`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | ns: ``string`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | version: ``integer`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
 
-.. _Hibernate version of class omero.model.Fileset:
+.. _OMERO model class Fileset:
 
 Fileset
 """""""
 
-Used by: :ref:`FilesetAnnotationLink.parent <Hibernate version of class omero.model.FilesetAnnotationLink>`, :ref:`FilesetEntry.fileset <Hibernate version of class omero.model.FilesetEntry>`, :ref:`FilesetJobLink.parent <Hibernate version of class omero.model.FilesetJobLink>`, :ref:`Image.fileset <Hibernate version of class omero.model.Image>`
+Used by: :ref:`FilesetAnnotationLink.parent <OMERO model class FilesetAnnotationLink>`, :ref:`FilesetEntry.fileset <OMERO model class FilesetEntry>`, :ref:`FilesetJobLink.parent <OMERO model class FilesetJobLink>`, :ref:`Image.fileset <OMERO model class Image>`
 
 Properties:
-  | annotationLinks: :ref:`FilesetAnnotationLink <Hibernate version of class omero.model.FilesetAnnotationLink>` (multiple)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | annotationLinks: :ref:`FilesetAnnotationLink <OMERO model class FilesetAnnotationLink>` (multiple)
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | images: :ref:`Image <Hibernate version of class omero.model.Image>` (multiple)
-  | jobLinks: :ref:`FilesetJobLink <Hibernate version of class omero.model.FilesetJobLink>` (multiple)
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | images: :ref:`Image <OMERO model class Image>` (multiple)
+  | jobLinks: :ref:`FilesetJobLink <OMERO model class FilesetJobLink>` (multiple)
   | templatePrefix: ``text``
-  | usedFiles: :ref:`FilesetEntry <Hibernate version of class omero.model.FilesetEntry>` (multiple)
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | usedFiles: :ref:`FilesetEntry <OMERO model class FilesetEntry>` (multiple)
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.FilesetAnnotationLink:
+.. _OMERO model class FilesetAnnotationLink:
 
 FilesetAnnotationLink
 """""""""""""""""""""
 
-Used by: :ref:`Fileset.annotationLinks <Hibernate version of class omero.model.Fileset>`
+Used by: :ref:`Fileset.annotationLinks <OMERO model class Fileset>`
 
 Properties:
-  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Annotation <OMERO model class Annotation>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`Fileset <Hibernate version of class omero.model.Fileset>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`Fileset <OMERO model class Fileset>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.FilesetEntry:
+.. _OMERO model class FilesetEntry:
 
 FilesetEntry
 """"""""""""
 
-Used by: :ref:`Fileset.usedFiles <Hibernate version of class omero.model.Fileset>`
+Used by: :ref:`Fileset.usedFiles <OMERO model class Fileset>`, :ref:`OriginalFile.filesetEntries <OMERO model class OriginalFile>`
 
 Properties:
   | clientPath: ``text``
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | fileset: :ref:`Fileset <Hibernate version of class omero.model.Fileset>`
-  | originalFile: :ref:`OriginalFile <Hibernate version of class omero.model.OriginalFile>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | fileset: :ref:`Fileset <OMERO model class Fileset>`
+  | originalFile: :ref:`OriginalFile <OMERO model class OriginalFile>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.FilesetJobLink:
+.. _OMERO model class FilesetJobLink:
 
 FilesetJobLink
 """"""""""""""
 
-Used by: :ref:`Fileset.jobLinks <Hibernate version of class omero.model.Fileset>`
+Used by: :ref:`Fileset.jobLinks <OMERO model class Fileset>`
 
 Properties:
-  | child: :ref:`Job <Hibernate version of class omero.model.Job>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Job <OMERO model class Job>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`Fileset <Hibernate version of class omero.model.Fileset>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`Fileset <OMERO model class Fileset>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.Filter:
+.. _OMERO model class Filter:
 
 Filter
 """"""
 
-Used by: :ref:`FilterAnnotationLink.parent <Hibernate version of class omero.model.FilterAnnotationLink>`, :ref:`FilterSetEmissionFilterLink.child <Hibernate version of class omero.model.FilterSetEmissionFilterLink>`, :ref:`FilterSetExcitationFilterLink.child <Hibernate version of class omero.model.FilterSetExcitationFilterLink>`, :ref:`Instrument.filter <Hibernate version of class omero.model.Instrument>`, :ref:`LightPathEmissionFilterLink.child <Hibernate version of class omero.model.LightPathEmissionFilterLink>`, :ref:`LightPathExcitationFilterLink.child <Hibernate version of class omero.model.LightPathExcitationFilterLink>`
+Used by: :ref:`FilterAnnotationLink.parent <OMERO model class FilterAnnotationLink>`, :ref:`FilterSetEmissionFilterLink.child <OMERO model class FilterSetEmissionFilterLink>`, :ref:`FilterSetExcitationFilterLink.child <OMERO model class FilterSetExcitationFilterLink>`, :ref:`Instrument.filter <OMERO model class Instrument>`, :ref:`LightPathEmissionFilterLink.child <OMERO model class LightPathEmissionFilterLink>`, :ref:`LightPathExcitationFilterLink.child <OMERO model class LightPathExcitationFilterLink>`
 
 Properties:
-  | annotationLinks: :ref:`FilterAnnotationLink <Hibernate version of class omero.model.FilterAnnotationLink>` (multiple)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | annotationLinks: :ref:`FilterAnnotationLink <OMERO model class FilterAnnotationLink>` (multiple)
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | emissionFilterLink: :ref:`FilterSetEmissionFilterLink <Hibernate version of class omero.model.FilterSetEmissionFilterLink>` (multiple)
-  | excitationFilterLink: :ref:`FilterSetExcitationFilterLink <Hibernate version of class omero.model.FilterSetExcitationFilterLink>` (multiple)
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | emissionFilterLink: :ref:`FilterSetEmissionFilterLink <OMERO model class FilterSetEmissionFilterLink>` (multiple)
+  | excitationFilterLink: :ref:`FilterSetExcitationFilterLink <OMERO model class FilterSetExcitationFilterLink>` (multiple)
   | filterWheel: ``string`` (optional)
-  | instrument: :ref:`Instrument <Hibernate version of class omero.model.Instrument>`
+  | instrument: :ref:`Instrument <OMERO model class Instrument>`
   | lotNumber: ``string`` (optional)
   | manufacturer: ``string`` (optional)
   | model: ``string`` (optional)
   | serialNumber: ``string`` (optional)
-  | transmittanceRange: :ref:`TransmittanceRange <Hibernate version of class omero.model.TransmittanceRange>` (optional)
-  | type: :ref:`FilterType <Hibernate version of class omero.model.FilterType>` (optional)
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | transmittanceRange: :ref:`TransmittanceRange <OMERO model class TransmittanceRange>` (optional)
+  | type: :ref:`FilterType <OMERO model class FilterType>` (optional)
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.FilterAnnotationLink:
+.. _OMERO model class FilterAnnotationLink:
 
 FilterAnnotationLink
 """"""""""""""""""""
 
-Used by: :ref:`Filter.annotationLinks <Hibernate version of class omero.model.Filter>`
+Used by: :ref:`Filter.annotationLinks <OMERO model class Filter>`
 
 Properties:
-  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Annotation <OMERO model class Annotation>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`Filter <Hibernate version of class omero.model.Filter>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`Filter <OMERO model class Filter>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.FilterSet:
+.. _OMERO model class FilterSet:
 
 FilterSet
 """""""""
 
-Used by: :ref:`FilterSetEmissionFilterLink.parent <Hibernate version of class omero.model.FilterSetEmissionFilterLink>`, :ref:`FilterSetExcitationFilterLink.parent <Hibernate version of class omero.model.FilterSetExcitationFilterLink>`, :ref:`Instrument.filterSet <Hibernate version of class omero.model.Instrument>`, :ref:`LogicalChannel.filterSet <Hibernate version of class omero.model.LogicalChannel>`, :ref:`OTF.filterSet <Hibernate version of class omero.model.OTF>`
+Used by: :ref:`FilterSetEmissionFilterLink.parent <OMERO model class FilterSetEmissionFilterLink>`, :ref:`FilterSetExcitationFilterLink.parent <OMERO model class FilterSetExcitationFilterLink>`, :ref:`Instrument.filterSet <OMERO model class Instrument>`, :ref:`LogicalChannel.filterSet <OMERO model class LogicalChannel>`, :ref:`OTF.filterSet <OMERO model class OTF>`
 
 Properties:
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | dichroic: :ref:`Dichroic <Hibernate version of class omero.model.Dichroic>` (optional)
-  | emissionFilterLink: :ref:`FilterSetEmissionFilterLink <Hibernate version of class omero.model.FilterSetEmissionFilterLink>` (multiple)
-  | excitationFilterLink: :ref:`FilterSetExcitationFilterLink <Hibernate version of class omero.model.FilterSetExcitationFilterLink>` (multiple)
-  | instrument: :ref:`Instrument <Hibernate version of class omero.model.Instrument>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | dichroic: :ref:`Dichroic <OMERO model class Dichroic>` (optional)
+  | emissionFilterLink: :ref:`FilterSetEmissionFilterLink <OMERO model class FilterSetEmissionFilterLink>` (multiple)
+  | excitationFilterLink: :ref:`FilterSetExcitationFilterLink <OMERO model class FilterSetExcitationFilterLink>` (multiple)
+  | instrument: :ref:`Instrument <OMERO model class Instrument>`
   | lotNumber: ``string`` (optional)
   | manufacturer: ``string`` (optional)
   | model: ``string`` (optional)
   | serialNumber: ``string`` (optional)
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.FilterSetEmissionFilterLink:
+.. _OMERO model class FilterSetEmissionFilterLink:
 
 FilterSetEmissionFilterLink
 """""""""""""""""""""""""""
 
-Used by: :ref:`Filter.emissionFilterLink <Hibernate version of class omero.model.Filter>`, :ref:`FilterSet.emissionFilterLink <Hibernate version of class omero.model.FilterSet>`
+Used by: :ref:`Filter.emissionFilterLink <OMERO model class Filter>`, :ref:`FilterSet.emissionFilterLink <OMERO model class FilterSet>`
 
 Properties:
-  | child: :ref:`Filter <Hibernate version of class omero.model.Filter>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Filter <OMERO model class Filter>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`FilterSet <Hibernate version of class omero.model.FilterSet>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`FilterSet <OMERO model class FilterSet>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.FilterSetExcitationFilterLink:
+.. _OMERO model class FilterSetExcitationFilterLink:
 
 FilterSetExcitationFilterLink
 """""""""""""""""""""""""""""
 
-Used by: :ref:`Filter.excitationFilterLink <Hibernate version of class omero.model.Filter>`, :ref:`FilterSet.excitationFilterLink <Hibernate version of class omero.model.FilterSet>`
+Used by: :ref:`Filter.excitationFilterLink <OMERO model class Filter>`, :ref:`FilterSet.excitationFilterLink <OMERO model class FilterSet>`
 
 Properties:
-  | child: :ref:`Filter <Hibernate version of class omero.model.Filter>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Filter <OMERO model class Filter>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`FilterSet <Hibernate version of class omero.model.FilterSet>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`FilterSet <OMERO model class FilterSet>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.FilterType:
+.. _OMERO model class FilterType:
 
 FilterType
 """"""""""
 
-Used by: :ref:`Filter.type <Hibernate version of class omero.model.Filter>`
+Used by: :ref:`Filter.type <OMERO model class Filter>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
+  | value: ``string``, see :javadoc:`IEnum <ome/model/IEnum.html>`
 
-.. _Hibernate version of class omero.model.Format:
+.. _OMERO model class Format:
 
 Format
 """"""
 
-Used by: :ref:`Image.format <Hibernate version of class omero.model.Image>`
+Used by: :ref:`Image.format <OMERO model class Image>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
+  | value: ``string``, see :javadoc:`IEnum <ome/model/IEnum.html>`
 
-.. _Hibernate version of class omero.model.GenericExcitationSource:
+.. _OMERO model class GenericExcitationSource:
 
 GenericExcitationSource
 """""""""""""""""""""""
 
 Properties:
-  | annotationLinks: :ref:`LightSourceAnnotationLink <Hibernate version of class omero.model.LightSourceAnnotationLink>` (multiple) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | details.permissions.perm1: ``long`` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | instrument: :ref:`Instrument <Hibernate version of class omero.model.Instrument>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | lotNumber: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | manufacturer: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | annotationLinks: :ref:`LightSourceAnnotationLink <OMERO model class LightSourceAnnotationLink>` (multiple) from :ref:`LightSource <OMERO model class LightSource>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`LightSource <OMERO model class LightSource>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`LightSource <OMERO model class LightSource>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`LightSource <OMERO model class LightSource>`
+  | details.permissions.perm1: ``long`` from :ref:`LightSource <OMERO model class LightSource>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`LightSource <OMERO model class LightSource>`
+  | instrument: :ref:`Instrument <OMERO model class Instrument>` from :ref:`LightSource <OMERO model class LightSource>`
+  | lotNumber: ``string`` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | manufacturer: ``string`` (optional) from :ref:`LightSource <OMERO model class LightSource>`
   | map: list (multiple)
-  | model: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | power.unit: enumeration (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | power.value: ``double`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | serialNumber: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | version: ``integer`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | model: ``string`` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | power.unit: enumeration of :javadoc:`Power <ome/model/units/Power.html>` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | power.value: ``double`` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | serialNumber: ``string`` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | version: ``integer`` (optional) from :ref:`LightSource <OMERO model class LightSource>`
 
-.. _Hibernate version of class omero.model.GroupExperimenterMap:
+.. _OMERO model class GroupExperimenterMap:
 
 GroupExperimenterMap
 """"""""""""""""""""
 
-Used by: :ref:`Experimenter.groupExperimenterMap <Hibernate version of class omero.model.Experimenter>`, :ref:`ExperimenterGroup.groupExperimenterMap <Hibernate version of class omero.model.ExperimenterGroup>`
+Used by: :ref:`Experimenter.groupExperimenterMap <OMERO model class Experimenter>`, :ref:`ExperimenterGroup.groupExperimenterMap <OMERO model class ExperimenterGroup>`
 
 Properties:
-  | child: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | child: :ref:`Experimenter <OMERO model class Experimenter>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | owner: ``boolean``
-  | parent: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | parent: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.Illumination:
+.. _OMERO model class Illumination:
 
 Illumination
 """"""""""""
 
-Used by: :ref:`LogicalChannel.illumination <Hibernate version of class omero.model.LogicalChannel>`
+Used by: :ref:`LogicalChannel.illumination <OMERO model class LogicalChannel>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
+  | value: ``string``, see :javadoc:`IEnum <ome/model/IEnum.html>`
 
-.. _Hibernate version of class omero.model.Image:
+.. _OMERO model class Image:
 
 Image
 """""
 
-Used by: :ref:`DatasetImageLink.child <Hibernate version of class omero.model.DatasetImageLink>`, :ref:`Fileset.images <Hibernate version of class omero.model.Fileset>`, :ref:`ImageAnnotationLink.parent <Hibernate version of class omero.model.ImageAnnotationLink>`, :ref:`Pixels.image <Hibernate version of class omero.model.Pixels>`, :ref:`Roi.image <Hibernate version of class omero.model.Roi>`, :ref:`WellSample.image <Hibernate version of class omero.model.WellSample>`
+Used by: :ref:`DatasetImageLink.child <OMERO model class DatasetImageLink>`, :ref:`Fileset.images <OMERO model class Fileset>`, :ref:`ImageAnnotationLink.parent <OMERO model class ImageAnnotationLink>`, :ref:`Pixels.image <OMERO model class Pixels>`, :ref:`Roi.image <OMERO model class Roi>`, :ref:`WellSample.image <OMERO model class WellSample>`
 
 Properties:
   | acquisitionDate: ``timestamp`` (optional)
-  | annotationLinks: :ref:`ImageAnnotationLink <Hibernate version of class omero.model.ImageAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`ImageAnnotationLink <OMERO model class ImageAnnotationLink>` (multiple)
   | archived: ``boolean`` (optional)
-  | datasetLinks: :ref:`DatasetImageLink <Hibernate version of class omero.model.DatasetImageLink>` (multiple)
+  | datasetLinks: :ref:`DatasetImageLink <OMERO model class DatasetImageLink>` (multiple)
   | description: ``text`` (optional)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | experiment: :ref:`Experiment <Hibernate version of class omero.model.Experiment>` (optional)
-  | fileset: :ref:`Fileset <Hibernate version of class omero.model.Fileset>` (optional)
-  | format: :ref:`Format <Hibernate version of class omero.model.Format>` (optional)
-  | imagingEnvironment: :ref:`ImagingEnvironment <Hibernate version of class omero.model.ImagingEnvironment>` (optional)
-  | instrument: :ref:`Instrument <Hibernate version of class omero.model.Instrument>` (optional)
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | experiment: :ref:`Experiment <OMERO model class Experiment>` (optional)
+  | fileset: :ref:`Fileset <OMERO model class Fileset>` (optional)
+  | format: :ref:`Format <OMERO model class Format>` (optional)
+  | imagingEnvironment: :ref:`ImagingEnvironment <OMERO model class ImagingEnvironment>` (optional)
+  | instrument: :ref:`Instrument <OMERO model class Instrument>` (optional)
   | name: ``string``
-  | objectiveSettings: :ref:`ObjectiveSettings <Hibernate version of class omero.model.ObjectiveSettings>` (optional)
+  | objectiveSettings: :ref:`ObjectiveSettings <OMERO model class ObjectiveSettings>` (optional)
   | partial: ``boolean`` (optional)
-  | pixels: :ref:`Pixels <Hibernate version of class omero.model.Pixels>` (multiple)
-  | rois: :ref:`Roi <Hibernate version of class omero.model.Roi>` (multiple)
+  | pixels: :ref:`Pixels <OMERO model class Pixels>` (multiple)
+  | rois: :ref:`Roi <OMERO model class Roi>` (multiple)
   | series: ``integer`` (optional)
-  | stageLabel: :ref:`StageLabel <Hibernate version of class omero.model.StageLabel>` (optional)
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
-  | wellSamples: :ref:`WellSample <Hibernate version of class omero.model.WellSample>` (multiple)
+  | stageLabel: :ref:`StageLabel <OMERO model class StageLabel>` (optional)
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
+  | wellSamples: :ref:`WellSample <OMERO model class WellSample>` (multiple)
 
-.. _Hibernate version of class omero.model.ImageAnnotationLink:
+.. _OMERO model class ImageAnnotationLink:
 
 ImageAnnotationLink
 """""""""""""""""""
 
-Used by: :ref:`Image.annotationLinks <Hibernate version of class omero.model.Image>`
+Used by: :ref:`Image.annotationLinks <OMERO model class Image>`
 
 Properties:
-  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Annotation <OMERO model class Annotation>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`Image <Hibernate version of class omero.model.Image>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`Image <OMERO model class Image>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.ImagingEnvironment:
+.. _OMERO model class ImagingEnvironment:
 
 ImagingEnvironment
 """"""""""""""""""
 
-Used by: :ref:`Image.imagingEnvironment <Hibernate version of class omero.model.Image>`
+Used by: :ref:`Image.imagingEnvironment <OMERO model class Image>`
 
 Properties:
-  | airPressure.unit: enumeration (optional), see :javadoc:`PressureI <omero/model/PressureI.html>`
-  | airPressure.value: ``double`` (optional), see :javadoc:`PressureI <omero/model/PressureI.html>`
+  | airPressure.unit: enumeration of :javadoc:`Pressure <ome/model/units/Pressure.html>` (optional)
+  | airPressure.value: ``double`` (optional)
   | co2percent: ``double`` (optional)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
   | humidity: ``double`` (optional)
   | map: list (multiple)
-  | temperature.unit: enumeration (optional), see :javadoc:`TemperatureI <omero/model/TemperatureI.html>`
-  | temperature.value: ``double`` (optional), see :javadoc:`TemperatureI <omero/model/TemperatureI.html>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | temperature.unit: enumeration of :javadoc:`Temperature <ome/model/units/Temperature.html>` (optional)
+  | temperature.value: ``double`` (optional)
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.Immersion:
+.. _OMERO model class Immersion:
 
 Immersion
 """""""""
 
-Used by: :ref:`Objective.immersion <Hibernate version of class omero.model.Objective>`
+Used by: :ref:`Objective.immersion <OMERO model class Objective>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
+  | value: ``string``, see :javadoc:`IEnum <ome/model/IEnum.html>`
 
-.. _Hibernate version of class omero.model.ImportJob:
+.. _OMERO model class ImportJob:
 
 ImportJob
 """""""""
 
 Properties:
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.permissions.perm1: ``long`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | finished: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | groupname: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Job <OMERO model class Job>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Job <OMERO model class Job>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Job <OMERO model class Job>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Job <OMERO model class Job>`
+  | details.permissions.perm1: ``long`` from :ref:`Job <OMERO model class Job>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Job <OMERO model class Job>`
+  | finished: ``timestamp`` (optional) from :ref:`Job <OMERO model class Job>`
+  | groupname: ``string`` from :ref:`Job <OMERO model class Job>`
   | imageDescription: ``string``
   | imageName: ``string``
-  | message: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | originalFileLinks: :ref:`JobOriginalFileLink <Hibernate version of class omero.model.JobOriginalFileLink>` (multiple) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | scheduledFor: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | started: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | status: :ref:`JobStatus <Hibernate version of class omero.model.JobStatus>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | submitted: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | type: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | username: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | version: ``integer`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | message: ``string`` from :ref:`Job <OMERO model class Job>`
+  | originalFileLinks: :ref:`JobOriginalFileLink <OMERO model class JobOriginalFileLink>` (multiple) from :ref:`Job <OMERO model class Job>`
+  | scheduledFor: ``timestamp`` from :ref:`Job <OMERO model class Job>`
+  | started: ``timestamp`` (optional) from :ref:`Job <OMERO model class Job>`
+  | status: :ref:`JobStatus <OMERO model class JobStatus>` from :ref:`Job <OMERO model class Job>`
+  | submitted: ``timestamp`` from :ref:`Job <OMERO model class Job>`
+  | type: ``string`` from :ref:`Job <OMERO model class Job>`
+  | username: ``string`` from :ref:`Job <OMERO model class Job>`
+  | version: ``integer`` (optional) from :ref:`Job <OMERO model class Job>`
 
-.. _Hibernate version of class omero.model.IndexingJob:
+.. _OMERO model class IndexingJob:
 
 IndexingJob
 """""""""""
 
 Properties:
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.permissions.perm1: ``long`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | finished: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | groupname: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | message: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | originalFileLinks: :ref:`JobOriginalFileLink <Hibernate version of class omero.model.JobOriginalFileLink>` (multiple) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | scheduledFor: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | started: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | status: :ref:`JobStatus <Hibernate version of class omero.model.JobStatus>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | submitted: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | type: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | username: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | version: ``integer`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Job <OMERO model class Job>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Job <OMERO model class Job>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Job <OMERO model class Job>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Job <OMERO model class Job>`
+  | details.permissions.perm1: ``long`` from :ref:`Job <OMERO model class Job>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Job <OMERO model class Job>`
+  | finished: ``timestamp`` (optional) from :ref:`Job <OMERO model class Job>`
+  | groupname: ``string`` from :ref:`Job <OMERO model class Job>`
+  | message: ``string`` from :ref:`Job <OMERO model class Job>`
+  | originalFileLinks: :ref:`JobOriginalFileLink <OMERO model class JobOriginalFileLink>` (multiple) from :ref:`Job <OMERO model class Job>`
+  | scheduledFor: ``timestamp`` from :ref:`Job <OMERO model class Job>`
+  | started: ``timestamp`` (optional) from :ref:`Job <OMERO model class Job>`
+  | status: :ref:`JobStatus <OMERO model class JobStatus>` from :ref:`Job <OMERO model class Job>`
+  | submitted: ``timestamp`` from :ref:`Job <OMERO model class Job>`
+  | type: ``string`` from :ref:`Job <OMERO model class Job>`
+  | username: ``string`` from :ref:`Job <OMERO model class Job>`
+  | version: ``integer`` (optional) from :ref:`Job <OMERO model class Job>`
 
-.. _Hibernate version of class omero.model.Instrument:
+.. _OMERO model class Instrument:
 
 Instrument
 """"""""""
 
-Used by: :ref:`Arc.instrument <Hibernate version of class omero.model.Arc>`, :ref:`Detector.instrument <Hibernate version of class omero.model.Detector>`, :ref:`Dichroic.instrument <Hibernate version of class omero.model.Dichroic>`, :ref:`Filament.instrument <Hibernate version of class omero.model.Filament>`, :ref:`Filter.instrument <Hibernate version of class omero.model.Filter>`, :ref:`FilterSet.instrument <Hibernate version of class omero.model.FilterSet>`, :ref:`GenericExcitationSource.instrument <Hibernate version of class omero.model.GenericExcitationSource>`, :ref:`Image.instrument <Hibernate version of class omero.model.Image>`, :ref:`InstrumentAnnotationLink.parent <Hibernate version of class omero.model.InstrumentAnnotationLink>`, :ref:`Laser.instrument <Hibernate version of class omero.model.Laser>`, :ref:`LightEmittingDiode.instrument <Hibernate version of class omero.model.LightEmittingDiode>`, :ref:`LightSource.instrument <Hibernate version of class omero.model.LightSource>`, :ref:`OTF.instrument <Hibernate version of class omero.model.OTF>`, :ref:`Objective.instrument <Hibernate version of class omero.model.Objective>`
+Used by: :ref:`Arc.instrument <OMERO model class Arc>`, :ref:`Detector.instrument <OMERO model class Detector>`, :ref:`Dichroic.instrument <OMERO model class Dichroic>`, :ref:`Filament.instrument <OMERO model class Filament>`, :ref:`Filter.instrument <OMERO model class Filter>`, :ref:`FilterSet.instrument <OMERO model class FilterSet>`, :ref:`GenericExcitationSource.instrument <OMERO model class GenericExcitationSource>`, :ref:`Image.instrument <OMERO model class Image>`, :ref:`InstrumentAnnotationLink.parent <OMERO model class InstrumentAnnotationLink>`, :ref:`Laser.instrument <OMERO model class Laser>`, :ref:`LightEmittingDiode.instrument <OMERO model class LightEmittingDiode>`, :ref:`LightSource.instrument <OMERO model class LightSource>`, :ref:`OTF.instrument <OMERO model class OTF>`, :ref:`Objective.instrument <OMERO model class Objective>`
 
 Properties:
-  | annotationLinks: :ref:`InstrumentAnnotationLink <Hibernate version of class omero.model.InstrumentAnnotationLink>` (multiple)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | annotationLinks: :ref:`InstrumentAnnotationLink <OMERO model class InstrumentAnnotationLink>` (multiple)
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | detector: :ref:`Detector <Hibernate version of class omero.model.Detector>` (multiple)
-  | dichroic: :ref:`Dichroic <Hibernate version of class omero.model.Dichroic>` (multiple)
-  | filter: :ref:`Filter <Hibernate version of class omero.model.Filter>` (multiple)
-  | filterSet: :ref:`FilterSet <Hibernate version of class omero.model.FilterSet>` (multiple)
-  | lightSource: :ref:`LightSource <Hibernate version of class omero.model.LightSource>` (multiple)
-  | microscope: :ref:`Microscope <Hibernate version of class omero.model.Microscope>` (optional)
-  | objective: :ref:`Objective <Hibernate version of class omero.model.Objective>` (multiple)
-  | otf: :ref:`OTF <Hibernate version of class omero.model.OTF>` (multiple)
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | detector: :ref:`Detector <OMERO model class Detector>` (multiple)
+  | dichroic: :ref:`Dichroic <OMERO model class Dichroic>` (multiple)
+  | filter: :ref:`Filter <OMERO model class Filter>` (multiple)
+  | filterSet: :ref:`FilterSet <OMERO model class FilterSet>` (multiple)
+  | lightSource: :ref:`LightSource <OMERO model class LightSource>` (multiple)
+  | microscope: :ref:`Microscope <OMERO model class Microscope>` (optional)
+  | objective: :ref:`Objective <OMERO model class Objective>` (multiple)
+  | otf: :ref:`OTF <OMERO model class OTF>` (multiple)
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.InstrumentAnnotationLink:
+.. _OMERO model class InstrumentAnnotationLink:
 
 InstrumentAnnotationLink
 """"""""""""""""""""""""
 
-Used by: :ref:`Instrument.annotationLinks <Hibernate version of class omero.model.Instrument>`
+Used by: :ref:`Instrument.annotationLinks <OMERO model class Instrument>`
 
 Properties:
-  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Annotation <OMERO model class Annotation>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`Instrument <Hibernate version of class omero.model.Instrument>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`Instrument <OMERO model class Instrument>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.IntegrityCheckJob:
+.. _OMERO model class IntegrityCheckJob:
 
 IntegrityCheckJob
 """""""""""""""""
 
 Properties:
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.permissions.perm1: ``long`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | finished: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | groupname: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | message: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | originalFileLinks: :ref:`JobOriginalFileLink <Hibernate version of class omero.model.JobOriginalFileLink>` (multiple) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | scheduledFor: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | started: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | status: :ref:`JobStatus <Hibernate version of class omero.model.JobStatus>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | submitted: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | type: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | username: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | version: ``integer`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Job <OMERO model class Job>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Job <OMERO model class Job>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Job <OMERO model class Job>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Job <OMERO model class Job>`
+  | details.permissions.perm1: ``long`` from :ref:`Job <OMERO model class Job>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Job <OMERO model class Job>`
+  | finished: ``timestamp`` (optional) from :ref:`Job <OMERO model class Job>`
+  | groupname: ``string`` from :ref:`Job <OMERO model class Job>`
+  | message: ``string`` from :ref:`Job <OMERO model class Job>`
+  | originalFileLinks: :ref:`JobOriginalFileLink <OMERO model class JobOriginalFileLink>` (multiple) from :ref:`Job <OMERO model class Job>`
+  | scheduledFor: ``timestamp`` from :ref:`Job <OMERO model class Job>`
+  | started: ``timestamp`` (optional) from :ref:`Job <OMERO model class Job>`
+  | status: :ref:`JobStatus <OMERO model class JobStatus>` from :ref:`Job <OMERO model class Job>`
+  | submitted: ``timestamp`` from :ref:`Job <OMERO model class Job>`
+  | type: ``string`` from :ref:`Job <OMERO model class Job>`
+  | username: ``string`` from :ref:`Job <OMERO model class Job>`
+  | version: ``integer`` (optional) from :ref:`Job <OMERO model class Job>`
 
-.. _Hibernate version of class omero.model.Job:
+.. _OMERO model class Job:
 
 Job
 """
 
-Subclasses: :ref:`ImportJob <Hibernate version of class omero.model.ImportJob>`, :ref:`IndexingJob <Hibernate version of class omero.model.IndexingJob>`, :ref:`IntegrityCheckJob <Hibernate version of class omero.model.IntegrityCheckJob>`, :ref:`MetadataImportJob <Hibernate version of class omero.model.MetadataImportJob>`, :ref:`ParseJob <Hibernate version of class omero.model.ParseJob>`, :ref:`PixelDataJob <Hibernate version of class omero.model.PixelDataJob>`, :ref:`ScriptJob <Hibernate version of class omero.model.ScriptJob>`, :ref:`ThumbnailGenerationJob <Hibernate version of class omero.model.ThumbnailGenerationJob>`, :ref:`UploadJob <Hibernate version of class omero.model.UploadJob>`
+Subclasses: :ref:`ImportJob <OMERO model class ImportJob>`, :ref:`IndexingJob <OMERO model class IndexingJob>`, :ref:`IntegrityCheckJob <OMERO model class IntegrityCheckJob>`, :ref:`MetadataImportJob <OMERO model class MetadataImportJob>`, :ref:`ParseJob <OMERO model class ParseJob>`, :ref:`PixelDataJob <OMERO model class PixelDataJob>`, :ref:`ScriptJob <OMERO model class ScriptJob>`, :ref:`ThumbnailGenerationJob <OMERO model class ThumbnailGenerationJob>`, :ref:`UploadJob <OMERO model class UploadJob>`
 
-Used by: :ref:`FilesetJobLink.child <Hibernate version of class omero.model.FilesetJobLink>`, :ref:`JobOriginalFileLink.parent <Hibernate version of class omero.model.JobOriginalFileLink>`
+Used by: :ref:`FilesetJobLink.child <OMERO model class FilesetJobLink>`, :ref:`JobOriginalFileLink.parent <OMERO model class JobOriginalFileLink>`
 
 Properties:
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
   | finished: ``timestamp`` (optional)
   | groupname: ``string``
   | message: ``string``
-  | originalFileLinks: :ref:`JobOriginalFileLink <Hibernate version of class omero.model.JobOriginalFileLink>` (multiple)
+  | originalFileLinks: :ref:`JobOriginalFileLink <OMERO model class JobOriginalFileLink>` (multiple)
   | scheduledFor: ``timestamp``
   | started: ``timestamp`` (optional)
-  | status: :ref:`JobStatus <Hibernate version of class omero.model.JobStatus>`
+  | status: :ref:`JobStatus <OMERO model class JobStatus>`
   | submitted: ``timestamp``
   | type: ``string``
   | username: ``string``
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.JobOriginalFileLink:
+.. _OMERO model class JobOriginalFileLink:
 
 JobOriginalFileLink
 """""""""""""""""""
 
-Used by: :ref:`ImportJob.originalFileLinks <Hibernate version of class omero.model.ImportJob>`, :ref:`IndexingJob.originalFileLinks <Hibernate version of class omero.model.IndexingJob>`, :ref:`IntegrityCheckJob.originalFileLinks <Hibernate version of class omero.model.IntegrityCheckJob>`, :ref:`Job.originalFileLinks <Hibernate version of class omero.model.Job>`, :ref:`MetadataImportJob.originalFileLinks <Hibernate version of class omero.model.MetadataImportJob>`, :ref:`ParseJob.originalFileLinks <Hibernate version of class omero.model.ParseJob>`, :ref:`PixelDataJob.originalFileLinks <Hibernate version of class omero.model.PixelDataJob>`, :ref:`ScriptJob.originalFileLinks <Hibernate version of class omero.model.ScriptJob>`, :ref:`ThumbnailGenerationJob.originalFileLinks <Hibernate version of class omero.model.ThumbnailGenerationJob>`, :ref:`UploadJob.originalFileLinks <Hibernate version of class omero.model.UploadJob>`
+Used by: :ref:`ImportJob.originalFileLinks <OMERO model class ImportJob>`, :ref:`IndexingJob.originalFileLinks <OMERO model class IndexingJob>`, :ref:`IntegrityCheckJob.originalFileLinks <OMERO model class IntegrityCheckJob>`, :ref:`Job.originalFileLinks <OMERO model class Job>`, :ref:`MetadataImportJob.originalFileLinks <OMERO model class MetadataImportJob>`, :ref:`ParseJob.originalFileLinks <OMERO model class ParseJob>`, :ref:`PixelDataJob.originalFileLinks <OMERO model class PixelDataJob>`, :ref:`ScriptJob.originalFileLinks <OMERO model class ScriptJob>`, :ref:`ThumbnailGenerationJob.originalFileLinks <OMERO model class ThumbnailGenerationJob>`, :ref:`UploadJob.originalFileLinks <OMERO model class UploadJob>`
 
 Properties:
-  | child: :ref:`OriginalFile <Hibernate version of class omero.model.OriginalFile>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`OriginalFile <OMERO model class OriginalFile>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`Job <Hibernate version of class omero.model.Job>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`Job <OMERO model class Job>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.JobStatus:
+.. _OMERO model class JobStatus:
 
 JobStatus
 """""""""
 
-Used by: :ref:`ImportJob.status <Hibernate version of class omero.model.ImportJob>`, :ref:`IndexingJob.status <Hibernate version of class omero.model.IndexingJob>`, :ref:`IntegrityCheckJob.status <Hibernate version of class omero.model.IntegrityCheckJob>`, :ref:`Job.status <Hibernate version of class omero.model.Job>`, :ref:`MetadataImportJob.status <Hibernate version of class omero.model.MetadataImportJob>`, :ref:`ParseJob.status <Hibernate version of class omero.model.ParseJob>`, :ref:`PixelDataJob.status <Hibernate version of class omero.model.PixelDataJob>`, :ref:`ScriptJob.status <Hibernate version of class omero.model.ScriptJob>`, :ref:`ThumbnailGenerationJob.status <Hibernate version of class omero.model.ThumbnailGenerationJob>`, :ref:`UploadJob.status <Hibernate version of class omero.model.UploadJob>`
+Used by: :ref:`ImportJob.status <OMERO model class ImportJob>`, :ref:`IndexingJob.status <OMERO model class IndexingJob>`, :ref:`IntegrityCheckJob.status <OMERO model class IntegrityCheckJob>`, :ref:`Job.status <OMERO model class Job>`, :ref:`MetadataImportJob.status <OMERO model class MetadataImportJob>`, :ref:`ParseJob.status <OMERO model class ParseJob>`, :ref:`PixelDataJob.status <OMERO model class PixelDataJob>`, :ref:`ScriptJob.status <OMERO model class ScriptJob>`, :ref:`ThumbnailGenerationJob.status <OMERO model class ThumbnailGenerationJob>`, :ref:`UploadJob.status <OMERO model class UploadJob>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
+  | value: ``string``, see :javadoc:`IEnum <ome/model/IEnum.html>`
 
-.. _Hibernate version of class omero.model.Label:
+.. _OMERO model class Label:
 
 Label
 """""
 
 Properties:
   | anchor: ``string`` (optional)
-  | annotationLinks: :ref:`ShapeAnnotationLink <Hibernate version of class omero.model.ShapeAnnotationLink>` (multiple) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | annotationLinks: :ref:`ShapeAnnotationLink <OMERO model class ShapeAnnotationLink>` (multiple) from :ref:`Shape <OMERO model class Shape>`
   | baselineShift: ``string`` (optional)
   | decoration: ``string`` (optional)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.permissions.perm1: ``long`` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Shape <OMERO model class Shape>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Shape <OMERO model class Shape>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Shape <OMERO model class Shape>`
+  | details.permissions.perm1: ``long`` from :ref:`Shape <OMERO model class Shape>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Shape <OMERO model class Shape>`
   | direction: ``string`` (optional)
-  | fillColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fillRule: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontFamily: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontSize.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | fontSize.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | fontStretch: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontStyle: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontVariant: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontWeight: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | g: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | fillColor: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fillRule: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontFamily: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontSize.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontSize.value: ``double`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontStretch: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontStyle: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontVariant: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontWeight: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | g: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
   | glyphOrientationVertical: ``integer`` (optional)
-  | locked: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | roi: :ref:`Roi <Hibernate version of class omero.model.Roi>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeDashArray: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeLineCap: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeWidth.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
+  | locked: ``boolean`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | roi: :ref:`Roi <OMERO model class Roi>` from :ref:`Shape <OMERO model class Shape>`
+  | strokeColor: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeDashArray: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeLineCap: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeWidth.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <OMERO model class Shape>`
   | textValue: ``text`` (optional)
-  | theC: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | theT: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | theZ: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | transform: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | vectorEffect: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | version: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | visibility: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | theC: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | theT: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | theZ: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | transform: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | vectorEffect: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | version: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | visibility: ``boolean`` (optional) from :ref:`Shape <OMERO model class Shape>`
   | writingMode: ``string`` (optional)
   | x: ``double`` (optional)
   | y: ``double`` (optional)
 
-.. _Hibernate version of class omero.model.Laser:
+.. _OMERO model class Laser:
 
 Laser
 """""
 
 Properties:
-  | annotationLinks: :ref:`LightSourceAnnotationLink <Hibernate version of class omero.model.LightSourceAnnotationLink>` (multiple) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | details.permissions.perm1: ``long`` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | annotationLinks: :ref:`LightSourceAnnotationLink <OMERO model class LightSourceAnnotationLink>` (multiple) from :ref:`LightSource <OMERO model class LightSource>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`LightSource <OMERO model class LightSource>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`LightSource <OMERO model class LightSource>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`LightSource <OMERO model class LightSource>`
+  | details.permissions.perm1: ``long`` from :ref:`LightSource <OMERO model class LightSource>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`LightSource <OMERO model class LightSource>`
   | frequencyMultiplication: ``integer`` (optional)
-  | instrument: :ref:`Instrument <Hibernate version of class omero.model.Instrument>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | laserMedium: :ref:`LaserMedium <Hibernate version of class omero.model.LaserMedium>`
-  | lotNumber: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | manufacturer: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | model: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | instrument: :ref:`Instrument <OMERO model class Instrument>` from :ref:`LightSource <OMERO model class LightSource>`
+  | laserMedium: :ref:`LaserMedium <OMERO model class LaserMedium>`
+  | lotNumber: ``string`` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | manufacturer: ``string`` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | model: ``string`` (optional) from :ref:`LightSource <OMERO model class LightSource>`
   | pockelCell: ``boolean`` (optional)
-  | power.unit: enumeration (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`, see :javadoc:`PowerI <omero/model/PowerI.html>`
-  | power.value: ``double`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`, see :javadoc:`PowerI <omero/model/PowerI.html>`
-  | pulse: :ref:`Pulse <Hibernate version of class omero.model.Pulse>` (optional)
-  | pump: :ref:`LightSource <Hibernate version of class omero.model.LightSource>` (optional)
-  | repetitionRate.unit: enumeration (optional), see :javadoc:`FrequencyI <omero/model/FrequencyI.html>`
-  | repetitionRate.value: ``double`` (optional), see :javadoc:`FrequencyI <omero/model/FrequencyI.html>`
-  | serialNumber: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | power.unit: enumeration of :javadoc:`Power <ome/model/units/Power.html>` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | power.value: ``double`` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | pulse: :ref:`Pulse <OMERO model class Pulse>` (optional)
+  | pump: :ref:`LightSource <OMERO model class LightSource>` (optional)
+  | repetitionRate.unit: enumeration of :javadoc:`Frequency <ome/model/units/Frequency.html>` (optional)
+  | repetitionRate.value: ``double`` (optional)
+  | serialNumber: ``string`` (optional) from :ref:`LightSource <OMERO model class LightSource>`
   | tuneable: ``boolean`` (optional)
-  | type: :ref:`LaserType <Hibernate version of class omero.model.LaserType>`
-  | version: ``integer`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | wavelength.unit: enumeration (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | wavelength.value: ``double`` (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
+  | type: :ref:`LaserType <OMERO model class LaserType>`
+  | version: ``integer`` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | wavelength.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional)
+  | wavelength.value: ``double`` (optional)
 
-.. _Hibernate version of class omero.model.LaserMedium:
+.. _OMERO model class LaserMedium:
 
 LaserMedium
 """""""""""
 
-Used by: :ref:`Laser.laserMedium <Hibernate version of class omero.model.Laser>`
+Used by: :ref:`Laser.laserMedium <OMERO model class Laser>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
+  | value: ``string``, see :javadoc:`IEnum <ome/model/IEnum.html>`
 
-.. _Hibernate version of class omero.model.LaserType:
+.. _OMERO model class LaserType:
 
 LaserType
 """""""""
 
-Used by: :ref:`Laser.type <Hibernate version of class omero.model.Laser>`
+Used by: :ref:`Laser.type <OMERO model class Laser>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
+  | value: ``string``, see :javadoc:`IEnum <ome/model/IEnum.html>`
 
-.. _Hibernate version of class omero.model.LightEmittingDiode:
+.. _OMERO model class LightEmittingDiode:
 
 LightEmittingDiode
 """"""""""""""""""
 
 Properties:
-  | annotationLinks: :ref:`LightSourceAnnotationLink <Hibernate version of class omero.model.LightSourceAnnotationLink>` (multiple) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | details.permissions.perm1: ``long`` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | instrument: :ref:`Instrument <Hibernate version of class omero.model.Instrument>` from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | lotNumber: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | manufacturer: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | model: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | power.unit: enumeration (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`, see :javadoc:`PowerI <omero/model/PowerI.html>`
-  | power.value: ``double`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`, see :javadoc:`PowerI <omero/model/PowerI.html>`
-  | serialNumber: ``string`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | version: ``integer`` (optional) from :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
+  | annotationLinks: :ref:`LightSourceAnnotationLink <OMERO model class LightSourceAnnotationLink>` (multiple) from :ref:`LightSource <OMERO model class LightSource>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`LightSource <OMERO model class LightSource>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`LightSource <OMERO model class LightSource>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`LightSource <OMERO model class LightSource>`
+  | details.permissions.perm1: ``long`` from :ref:`LightSource <OMERO model class LightSource>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`LightSource <OMERO model class LightSource>`
+  | instrument: :ref:`Instrument <OMERO model class Instrument>` from :ref:`LightSource <OMERO model class LightSource>`
+  | lotNumber: ``string`` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | manufacturer: ``string`` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | model: ``string`` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | power.unit: enumeration of :javadoc:`Power <ome/model/units/Power.html>` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | power.value: ``double`` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | serialNumber: ``string`` (optional) from :ref:`LightSource <OMERO model class LightSource>`
+  | version: ``integer`` (optional) from :ref:`LightSource <OMERO model class LightSource>`
 
-.. _Hibernate version of class omero.model.LightPath:
+.. _OMERO model class LightPath:
 
 LightPath
 """""""""
 
-Used by: :ref:`LightPathAnnotationLink.parent <Hibernate version of class omero.model.LightPathAnnotationLink>`, :ref:`LightPathEmissionFilterLink.parent <Hibernate version of class omero.model.LightPathEmissionFilterLink>`, :ref:`LightPathExcitationFilterLink.parent <Hibernate version of class omero.model.LightPathExcitationFilterLink>`, :ref:`LogicalChannel.lightPath <Hibernate version of class omero.model.LogicalChannel>`
+Used by: :ref:`LightPathAnnotationLink.parent <OMERO model class LightPathAnnotationLink>`, :ref:`LightPathEmissionFilterLink.parent <OMERO model class LightPathEmissionFilterLink>`, :ref:`LightPathExcitationFilterLink.parent <OMERO model class LightPathExcitationFilterLink>`, :ref:`LogicalChannel.lightPath <OMERO model class LogicalChannel>`
 
 Properties:
-  | annotationLinks: :ref:`LightPathAnnotationLink <Hibernate version of class omero.model.LightPathAnnotationLink>` (multiple)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | annotationLinks: :ref:`LightPathAnnotationLink <OMERO model class LightPathAnnotationLink>` (multiple)
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | dichroic: :ref:`Dichroic <Hibernate version of class omero.model.Dichroic>` (optional)
-  | emissionFilterLink: :ref:`LightPathEmissionFilterLink <Hibernate version of class omero.model.LightPathEmissionFilterLink>` (multiple)
-  | excitationFilterLink: :ref:`LightPathExcitationFilterLink <Hibernate version of class omero.model.LightPathExcitationFilterLink>` (multiple)
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | dichroic: :ref:`Dichroic <OMERO model class Dichroic>` (optional)
+  | emissionFilterLink: :ref:`LightPathEmissionFilterLink <OMERO model class LightPathEmissionFilterLink>` (multiple)
+  | excitationFilterLink: :ref:`LightPathExcitationFilterLink <OMERO model class LightPathExcitationFilterLink>` (multiple)
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.LightPathAnnotationLink:
+.. _OMERO model class LightPathAnnotationLink:
 
 LightPathAnnotationLink
 """""""""""""""""""""""
 
-Used by: :ref:`LightPath.annotationLinks <Hibernate version of class omero.model.LightPath>`
+Used by: :ref:`LightPath.annotationLinks <OMERO model class LightPath>`
 
 Properties:
-  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Annotation <OMERO model class Annotation>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`LightPath <Hibernate version of class omero.model.LightPath>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`LightPath <OMERO model class LightPath>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.LightPathEmissionFilterLink:
+.. _OMERO model class LightPathEmissionFilterLink:
 
 LightPathEmissionFilterLink
 """""""""""""""""""""""""""
 
-Used by: :ref:`LightPath.emissionFilterLink <Hibernate version of class omero.model.LightPath>`
+Used by: :ref:`LightPath.emissionFilterLink <OMERO model class LightPath>`
 
 Properties:
-  | child: :ref:`Filter <Hibernate version of class omero.model.Filter>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Filter <OMERO model class Filter>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`LightPath <Hibernate version of class omero.model.LightPath>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`LightPath <OMERO model class LightPath>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.LightPathExcitationFilterLink:
+.. _OMERO model class LightPathExcitationFilterLink:
 
 LightPathExcitationFilterLink
 """""""""""""""""""""""""""""
 
-Used by: :ref:`LightPath.excitationFilterLink <Hibernate version of class omero.model.LightPath>`
+Used by: :ref:`LightPath.excitationFilterLink <OMERO model class LightPath>`
 
 Properties:
-  | child: :ref:`Filter <Hibernate version of class omero.model.Filter>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Filter <OMERO model class Filter>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`LightPath <Hibernate version of class omero.model.LightPath>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`LightPath <OMERO model class LightPath>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.LightSettings:
+.. _OMERO model class LightSettings:
 
 LightSettings
 """""""""""""
 
-Used by: :ref:`LogicalChannel.lightSourceSettings <Hibernate version of class omero.model.LogicalChannel>`, :ref:`MicrobeamManipulation.lightSourceSettings <Hibernate version of class omero.model.MicrobeamManipulation>`
+Used by: :ref:`LogicalChannel.lightSourceSettings <OMERO model class LogicalChannel>`, :ref:`MicrobeamManipulation.lightSourceSettings <OMERO model class MicrobeamManipulation>`
 
 Properties:
   | attenuation: ``double`` (optional)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | lightSource: :ref:`LightSource <Hibernate version of class omero.model.LightSource>`
-  | microbeamManipulation: :ref:`MicrobeamManipulation <Hibernate version of class omero.model.MicrobeamManipulation>` (optional)
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
-  | wavelength.unit: enumeration (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | wavelength.value: ``double`` (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | lightSource: :ref:`LightSource <OMERO model class LightSource>`
+  | microbeamManipulation: :ref:`MicrobeamManipulation <OMERO model class MicrobeamManipulation>` (optional)
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
+  | wavelength.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional)
+  | wavelength.value: ``double`` (optional)
 
-.. _Hibernate version of class omero.model.LightSource:
+.. _OMERO model class LightSource:
 
 LightSource
 """""""""""
 
-Subclasses: :ref:`Arc <Hibernate version of class omero.model.Arc>`, :ref:`Filament <Hibernate version of class omero.model.Filament>`, :ref:`GenericExcitationSource <Hibernate version of class omero.model.GenericExcitationSource>`, :ref:`Laser <Hibernate version of class omero.model.Laser>`, :ref:`LightEmittingDiode <Hibernate version of class omero.model.LightEmittingDiode>`
+Subclasses: :ref:`Arc <OMERO model class Arc>`, :ref:`Filament <OMERO model class Filament>`, :ref:`GenericExcitationSource <OMERO model class GenericExcitationSource>`, :ref:`Laser <OMERO model class Laser>`, :ref:`LightEmittingDiode <OMERO model class LightEmittingDiode>`
 
-Used by: :ref:`Instrument.lightSource <Hibernate version of class omero.model.Instrument>`, :ref:`Laser.pump <Hibernate version of class omero.model.Laser>`, :ref:`LightSettings.lightSource <Hibernate version of class omero.model.LightSettings>`, :ref:`LightSourceAnnotationLink.parent <Hibernate version of class omero.model.LightSourceAnnotationLink>`
+Used by: :ref:`Instrument.lightSource <OMERO model class Instrument>`, :ref:`Laser.pump <OMERO model class Laser>`, :ref:`LightSettings.lightSource <OMERO model class LightSettings>`, :ref:`LightSourceAnnotationLink.parent <OMERO model class LightSourceAnnotationLink>`
 
 Properties:
-  | annotationLinks: :ref:`LightSourceAnnotationLink <Hibernate version of class omero.model.LightSourceAnnotationLink>` (multiple)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | annotationLinks: :ref:`LightSourceAnnotationLink <OMERO model class LightSourceAnnotationLink>` (multiple)
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | instrument: :ref:`Instrument <Hibernate version of class omero.model.Instrument>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | instrument: :ref:`Instrument <OMERO model class Instrument>`
   | lotNumber: ``string`` (optional)
   | manufacturer: ``string`` (optional)
   | model: ``string`` (optional)
-  | power.unit: enumeration (optional), see :javadoc:`PowerI <omero/model/PowerI.html>`
-  | power.value: ``double`` (optional), see :javadoc:`PowerI <omero/model/PowerI.html>`
+  | power.unit: enumeration of :javadoc:`Power <ome/model/units/Power.html>` (optional)
+  | power.value: ``double`` (optional)
   | serialNumber: ``string`` (optional)
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.LightSourceAnnotationLink:
+.. _OMERO model class LightSourceAnnotationLink:
 
 LightSourceAnnotationLink
 """""""""""""""""""""""""
 
-Used by: :ref:`Arc.annotationLinks <Hibernate version of class omero.model.Arc>`, :ref:`Filament.annotationLinks <Hibernate version of class omero.model.Filament>`, :ref:`GenericExcitationSource.annotationLinks <Hibernate version of class omero.model.GenericExcitationSource>`, :ref:`Laser.annotationLinks <Hibernate version of class omero.model.Laser>`, :ref:`LightEmittingDiode.annotationLinks <Hibernate version of class omero.model.LightEmittingDiode>`, :ref:`LightSource.annotationLinks <Hibernate version of class omero.model.LightSource>`
+Used by: :ref:`Arc.annotationLinks <OMERO model class Arc>`, :ref:`Filament.annotationLinks <OMERO model class Filament>`, :ref:`GenericExcitationSource.annotationLinks <OMERO model class GenericExcitationSource>`, :ref:`Laser.annotationLinks <OMERO model class Laser>`, :ref:`LightEmittingDiode.annotationLinks <OMERO model class LightEmittingDiode>`, :ref:`LightSource.annotationLinks <OMERO model class LightSource>`
 
 Properties:
-  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Annotation <OMERO model class Annotation>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`LightSource <Hibernate version of class omero.model.LightSource>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`LightSource <OMERO model class LightSource>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.Line:
+.. _OMERO model class Line:
 
 Line
 """"
 
 Properties:
-  | annotationLinks: :ref:`ShapeAnnotationLink <Hibernate version of class omero.model.ShapeAnnotationLink>` (multiple) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.permissions.perm1: ``long`` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fillColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fillRule: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontFamily: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontSize.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | fontSize.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | fontStretch: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontStyle: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontVariant: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontWeight: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | g: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | locked: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | roi: :ref:`Roi <Hibernate version of class omero.model.Roi>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeDashArray: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeLineCap: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeWidth.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
+  | annotationLinks: :ref:`ShapeAnnotationLink <OMERO model class ShapeAnnotationLink>` (multiple) from :ref:`Shape <OMERO model class Shape>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Shape <OMERO model class Shape>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Shape <OMERO model class Shape>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Shape <OMERO model class Shape>`
+  | details.permissions.perm1: ``long`` from :ref:`Shape <OMERO model class Shape>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Shape <OMERO model class Shape>`
+  | fillColor: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fillRule: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontFamily: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontSize.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontSize.value: ``double`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontStretch: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontStyle: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontVariant: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontWeight: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | g: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | locked: ``boolean`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | roi: :ref:`Roi <OMERO model class Roi>` from :ref:`Shape <OMERO model class Shape>`
+  | strokeColor: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeDashArray: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeLineCap: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeWidth.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <OMERO model class Shape>`
   | textValue: ``text`` (optional)
-  | theC: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | theT: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | theZ: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | transform: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | vectorEffect: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | version: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | visibility: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | theC: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | theT: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | theZ: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | transform: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | vectorEffect: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | version: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | visibility: ``boolean`` (optional) from :ref:`Shape <OMERO model class Shape>`
   | x1: ``double`` (optional)
   | x2: ``double`` (optional)
   | y1: ``double`` (optional)
   | y2: ``double`` (optional)
 
-.. _Hibernate version of class omero.model.Link:
+.. _OMERO model class Link:
 
 Link
 """"
 
 Properties:
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.ListAnnotation:
+.. _OMERO model class ListAnnotation:
 
 ListAnnotation
 """"""""""""""
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | description: ``text`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.permissions.perm1: ``long`` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | name: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | ns: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | version: ``integer`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | annotationLinks: :ref:`AnnotationAnnotationLink <OMERO model class AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <OMERO model class Annotation>`
+  | description: ``text`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.permissions.perm1: ``long`` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Annotation <OMERO model class Annotation>`
+  | name: ``string`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | ns: ``string`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | version: ``integer`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
 
-.. _Hibernate version of class omero.model.LogicalChannel:
+.. _OMERO model class LogicalChannel:
 
 LogicalChannel
 """"""""""""""
 
-Used by: :ref:`Channel.logicalChannel <Hibernate version of class omero.model.Channel>`
+Used by: :ref:`Channel.logicalChannel <OMERO model class Channel>`
 
 Properties:
-  | channels: :ref:`Channel <Hibernate version of class omero.model.Channel>` (multiple)
-  | contrastMethod: :ref:`ContrastMethod <Hibernate version of class omero.model.ContrastMethod>` (optional)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | channels: :ref:`Channel <OMERO model class Channel>` (multiple)
+  | contrastMethod: :ref:`ContrastMethod <OMERO model class ContrastMethod>` (optional)
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | detectorSettings: :ref:`DetectorSettings <Hibernate version of class omero.model.DetectorSettings>` (optional)
-  | emissionWave.unit: enumeration (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | emissionWave.value: ``double`` (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | excitationWave.unit: enumeration (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | excitationWave.value: ``double`` (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | filterSet: :ref:`FilterSet <Hibernate version of class omero.model.FilterSet>` (optional)
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | detectorSettings: :ref:`DetectorSettings <OMERO model class DetectorSettings>` (optional)
+  | emissionWave.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional)
+  | emissionWave.value: ``double`` (optional)
+  | excitationWave.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional)
+  | excitationWave.value: ``double`` (optional)
+  | filterSet: :ref:`FilterSet <OMERO model class FilterSet>` (optional)
   | fluor: ``string`` (optional)
-  | illumination: :ref:`Illumination <Hibernate version of class omero.model.Illumination>` (optional)
-  | lightPath: :ref:`LightPath <Hibernate version of class omero.model.LightPath>` (optional)
-  | lightSourceSettings: :ref:`LightSettings <Hibernate version of class omero.model.LightSettings>` (optional)
-  | mode: :ref:`AcquisitionMode <Hibernate version of class omero.model.AcquisitionMode>` (optional)
+  | illumination: :ref:`Illumination <OMERO model class Illumination>` (optional)
+  | lightPath: :ref:`LightPath <OMERO model class LightPath>` (optional)
+  | lightSourceSettings: :ref:`LightSettings <OMERO model class LightSettings>` (optional)
+  | mode: :ref:`AcquisitionMode <OMERO model class AcquisitionMode>` (optional)
   | name: ``string`` (optional)
   | ndFilter: ``double`` (optional)
-  | otf: :ref:`OTF <Hibernate version of class omero.model.OTF>` (optional)
-  | photometricInterpretation: :ref:`PhotometricInterpretation <Hibernate version of class omero.model.PhotometricInterpretation>` (optional)
-  | pinHoleSize.unit: enumeration (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | pinHoleSize.value: ``double`` (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
+  | otf: :ref:`OTF <OMERO model class OTF>` (optional)
+  | photometricInterpretation: :ref:`PhotometricInterpretation <OMERO model class PhotometricInterpretation>` (optional)
+  | pinHoleSize.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional)
+  | pinHoleSize.value: ``double`` (optional)
   | pockelCellSetting: ``integer`` (optional)
   | samplesPerPixel: ``integer`` (optional)
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.LongAnnotation:
+.. _OMERO model class LongAnnotation:
 
 LongAnnotation
 """"""""""""""
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | description: ``text`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.permissions.perm1: ``long`` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | annotationLinks: :ref:`AnnotationAnnotationLink <OMERO model class AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <OMERO model class Annotation>`
+  | description: ``text`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.permissions.perm1: ``long`` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Annotation <OMERO model class Annotation>`
   | longValue: ``long`` (optional)
-  | name: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | ns: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | version: ``integer`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | name: ``string`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | ns: ``string`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | version: ``integer`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
 
-.. _Hibernate version of class omero.model.MapAnnotation:
+.. _OMERO model class MapAnnotation:
 
 MapAnnotation
 """""""""""""
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | description: ``text`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.permissions.perm1: ``long`` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | annotationLinks: :ref:`AnnotationAnnotationLink <OMERO model class AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <OMERO model class Annotation>`
+  | description: ``text`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.permissions.perm1: ``long`` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Annotation <OMERO model class Annotation>`
   | mapValue: list (multiple)
-  | name: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | ns: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | version: ``integer`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | name: ``string`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | ns: ``string`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | version: ``integer`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
 
-.. _Hibernate version of class omero.model.Mask:
+.. _OMERO model class Mask:
 
 Mask
 """"
 
 Properties:
-  | annotationLinks: :ref:`ShapeAnnotationLink <Hibernate version of class omero.model.ShapeAnnotationLink>` (multiple) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | annotationLinks: :ref:`ShapeAnnotationLink <OMERO model class ShapeAnnotationLink>` (multiple) from :ref:`Shape <OMERO model class Shape>`
   | bytes: ``binary`` (optional)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.permissions.perm1: ``long`` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fillColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fillRule: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontFamily: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontSize.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | fontSize.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | fontStretch: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontStyle: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontVariant: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontWeight: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | g: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Shape <OMERO model class Shape>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Shape <OMERO model class Shape>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Shape <OMERO model class Shape>`
+  | details.permissions.perm1: ``long`` from :ref:`Shape <OMERO model class Shape>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Shape <OMERO model class Shape>`
+  | fillColor: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fillRule: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontFamily: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontSize.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontSize.value: ``double`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontStretch: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontStyle: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontVariant: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontWeight: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | g: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
   | height: ``double`` (optional)
-  | locked: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | pixels: :ref:`Pixels <Hibernate version of class omero.model.Pixels>` (optional)
-  | roi: :ref:`Roi <Hibernate version of class omero.model.Roi>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeDashArray: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeLineCap: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeWidth.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
+  | locked: ``boolean`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | pixels: :ref:`Pixels <OMERO model class Pixels>` (optional)
+  | roi: :ref:`Roi <OMERO model class Roi>` from :ref:`Shape <OMERO model class Shape>`
+  | strokeColor: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeDashArray: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeLineCap: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeWidth.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <OMERO model class Shape>`
   | textValue: ``text`` (optional)
-  | theC: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | theT: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | theZ: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | transform: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | vectorEffect: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | version: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | visibility: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | theC: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | theT: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | theZ: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | transform: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | vectorEffect: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | version: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | visibility: ``boolean`` (optional) from :ref:`Shape <OMERO model class Shape>`
   | width: ``double`` (optional)
   | x: ``double`` (optional)
   | y: ``double`` (optional)
 
-.. _Hibernate version of class omero.model.Medium:
+.. _OMERO model class Medium:
 
 Medium
 """"""
 
-Used by: :ref:`ObjectiveSettings.medium <Hibernate version of class omero.model.ObjectiveSettings>`
+Used by: :ref:`ObjectiveSettings.medium <OMERO model class ObjectiveSettings>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
+  | value: ``string``, see :javadoc:`IEnum <ome/model/IEnum.html>`
 
-.. _Hibernate version of class omero.model.MetadataImportJob:
+.. _OMERO model class MetadataImportJob:
 
 MetadataImportJob
 """""""""""""""""
 
 Properties:
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.permissions.perm1: ``long`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | finished: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | groupname: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | message: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | originalFileLinks: :ref:`JobOriginalFileLink <Hibernate version of class omero.model.JobOriginalFileLink>` (multiple) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | scheduledFor: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | started: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | status: :ref:`JobStatus <Hibernate version of class omero.model.JobStatus>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | submitted: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | type: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | username: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | version: ``integer`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Job <OMERO model class Job>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Job <OMERO model class Job>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Job <OMERO model class Job>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Job <OMERO model class Job>`
+  | details.permissions.perm1: ``long`` from :ref:`Job <OMERO model class Job>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Job <OMERO model class Job>`
+  | finished: ``timestamp`` (optional) from :ref:`Job <OMERO model class Job>`
+  | groupname: ``string`` from :ref:`Job <OMERO model class Job>`
+  | message: ``string`` from :ref:`Job <OMERO model class Job>`
+  | originalFileLinks: :ref:`JobOriginalFileLink <OMERO model class JobOriginalFileLink>` (multiple) from :ref:`Job <OMERO model class Job>`
+  | scheduledFor: ``timestamp`` from :ref:`Job <OMERO model class Job>`
+  | started: ``timestamp`` (optional) from :ref:`Job <OMERO model class Job>`
+  | status: :ref:`JobStatus <OMERO model class JobStatus>` from :ref:`Job <OMERO model class Job>`
+  | submitted: ``timestamp`` from :ref:`Job <OMERO model class Job>`
+  | type: ``string`` from :ref:`Job <OMERO model class Job>`
+  | username: ``string`` from :ref:`Job <OMERO model class Job>`
+  | version: ``integer`` (optional) from :ref:`Job <OMERO model class Job>`
   | versionInfo: list (multiple)
 
-.. _Hibernate version of class omero.model.MicrobeamManipulation:
+.. _OMERO model class MicrobeamManipulation:
 
 MicrobeamManipulation
 """""""""""""""""""""
 
-Used by: :ref:`Experiment.microbeamManipulation <Hibernate version of class omero.model.Experiment>`, :ref:`LightSettings.microbeamManipulation <Hibernate version of class omero.model.LightSettings>`
+Used by: :ref:`Experiment.microbeamManipulation <OMERO model class Experiment>`, :ref:`LightSettings.microbeamManipulation <OMERO model class LightSettings>`
 
 Properties:
   | description: ``text`` (optional)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | experiment: :ref:`Experiment <Hibernate version of class omero.model.Experiment>`
-  | lightSourceSettings: :ref:`LightSettings <Hibernate version of class omero.model.LightSettings>` (multiple)
-  | type: :ref:`MicrobeamManipulationType <Hibernate version of class omero.model.MicrobeamManipulationType>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | experiment: :ref:`Experiment <OMERO model class Experiment>`
+  | lightSourceSettings: :ref:`LightSettings <OMERO model class LightSettings>` (multiple)
+  | type: :ref:`MicrobeamManipulationType <OMERO model class MicrobeamManipulationType>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.MicrobeamManipulationType:
+.. _OMERO model class MicrobeamManipulationType:
 
 MicrobeamManipulationType
 """""""""""""""""""""""""
 
-Used by: :ref:`MicrobeamManipulation.type <Hibernate version of class omero.model.MicrobeamManipulation>`
+Used by: :ref:`MicrobeamManipulation.type <OMERO model class MicrobeamManipulation>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
+  | value: ``string``, see :javadoc:`IEnum <ome/model/IEnum.html>`
 
-.. _Hibernate version of class omero.model.Microscope:
+.. _OMERO model class Microscope:
 
 Microscope
 """"""""""
 
-Used by: :ref:`Instrument.microscope <Hibernate version of class omero.model.Instrument>`
+Used by: :ref:`Instrument.microscope <OMERO model class Instrument>`
 
 Properties:
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
   | lotNumber: ``string`` (optional)
   | manufacturer: ``string`` (optional)
   | model: ``string`` (optional)
   | serialNumber: ``string`` (optional)
-  | type: :ref:`MicroscopeType <Hibernate version of class omero.model.MicroscopeType>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | type: :ref:`MicroscopeType <OMERO model class MicroscopeType>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.MicroscopeType:
+.. _OMERO model class MicroscopeType:
 
 MicroscopeType
 """"""""""""""
 
-Used by: :ref:`Microscope.type <Hibernate version of class omero.model.Microscope>`
+Used by: :ref:`Microscope.type <OMERO model class Microscope>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
+  | value: ``string``, see :javadoc:`IEnum <ome/model/IEnum.html>`
 
-.. _Hibernate version of class omero.model.Namespace:
+.. _OMERO model class Namespace:
 
 Namespace
 """""""""
 
-Used by: :ref:`NamespaceAnnotationLink.parent <Hibernate version of class omero.model.NamespaceAnnotationLink>`
+Used by: :ref:`NamespaceAnnotationLink.parent <OMERO model class NamespaceAnnotationLink>`
 
 Properties:
-  | annotationLinks: :ref:`NamespaceAnnotationLink <Hibernate version of class omero.model.NamespaceAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`NamespaceAnnotationLink <OMERO model class NamespaceAnnotationLink>` (multiple)
   | description: ``text`` (optional)
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | display: ``boolean`` (optional)
   | displayName: ``string`` (optional)
   | keywords: list (optional)
   | multivalued: ``boolean`` (optional)
   | name: ``string``
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.NamespaceAnnotationLink:
+.. _OMERO model class NamespaceAnnotationLink:
 
 NamespaceAnnotationLink
 """""""""""""""""""""""
 
-Used by: :ref:`Namespace.annotationLinks <Hibernate version of class omero.model.Namespace>`
+Used by: :ref:`Namespace.annotationLinks <OMERO model class Namespace>`
 
 Properties:
-  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Annotation <OMERO model class Annotation>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`Namespace <Hibernate version of class omero.model.Namespace>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`Namespace <OMERO model class Namespace>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.Node:
+.. _OMERO model class Node:
 
 Node
 """"
 
-Used by: :ref:`NodeAnnotationLink.parent <Hibernate version of class omero.model.NodeAnnotationLink>`, :ref:`Session.node <Hibernate version of class omero.model.Session>`, :ref:`Share.node <Hibernate version of class omero.model.Share>`
+Used by: :ref:`NodeAnnotationLink.parent <OMERO model class NodeAnnotationLink>`, :ref:`Session.node <OMERO model class Session>`, :ref:`Share.node <OMERO model class Share>`
 
 Properties:
-  | annotationLinks: :ref:`NodeAnnotationLink <Hibernate version of class omero.model.NodeAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`NodeAnnotationLink <OMERO model class NodeAnnotationLink>` (multiple)
   | conn: ``text``
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
   | down: ``timestamp`` (optional)
   | scale: ``integer`` (optional)
-  | sessions: :ref:`Session <Hibernate version of class omero.model.Session>` (multiple)
+  | sessions: :ref:`Session <OMERO model class Session>` (multiple)
   | up: ``timestamp``
   | uuid: ``string``
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.NodeAnnotationLink:
+.. _OMERO model class NodeAnnotationLink:
 
 NodeAnnotationLink
 """"""""""""""""""
 
-Used by: :ref:`Node.annotationLinks <Hibernate version of class omero.model.Node>`
+Used by: :ref:`Node.annotationLinks <OMERO model class Node>`
 
 Properties:
-  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Annotation <OMERO model class Annotation>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`Node <Hibernate version of class omero.model.Node>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`Node <OMERO model class Node>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.NumericAnnotation:
+.. _OMERO model class NumericAnnotation:
 
 NumericAnnotation
 """""""""""""""""
 
-Subclasses: :ref:`DoubleAnnotation <Hibernate version of class omero.model.DoubleAnnotation>`, :ref:`LongAnnotation <Hibernate version of class omero.model.LongAnnotation>`
+Subclasses: :ref:`DoubleAnnotation <OMERO model class DoubleAnnotation>`, :ref:`LongAnnotation <OMERO model class LongAnnotation>`
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | description: ``text`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.permissions.perm1: ``long`` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | name: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | ns: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | version: ``integer`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | annotationLinks: :ref:`AnnotationAnnotationLink <OMERO model class AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <OMERO model class Annotation>`
+  | description: ``text`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.permissions.perm1: ``long`` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Annotation <OMERO model class Annotation>`
+  | name: ``string`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | ns: ``string`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | version: ``integer`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
 
-.. _Hibernate version of class omero.model.OTF:
+.. _OMERO model class OTF:
 
 OTF
 """
 
-Used by: :ref:`Instrument.otf <Hibernate version of class omero.model.Instrument>`, :ref:`LogicalChannel.otf <Hibernate version of class omero.model.LogicalChannel>`
+Used by: :ref:`Instrument.otf <OMERO model class Instrument>`, :ref:`LogicalChannel.otf <OMERO model class LogicalChannel>`
 
 Properties:
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | filterSet: :ref:`FilterSet <Hibernate version of class omero.model.FilterSet>` (optional)
-  | instrument: :ref:`Instrument <Hibernate version of class omero.model.Instrument>`
-  | objective: :ref:`Objective <Hibernate version of class omero.model.Objective>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | filterSet: :ref:`FilterSet <OMERO model class FilterSet>` (optional)
+  | instrument: :ref:`Instrument <OMERO model class Instrument>`
+  | objective: :ref:`Objective <OMERO model class Objective>`
   | opticalAxisAveraged: ``boolean``
   | path: ``string``
-  | pixelsType: :ref:`PixelsType <Hibernate version of class omero.model.PixelsType>`
+  | pixelsType: :ref:`PixelsType <OMERO model class PixelsType>`
   | sizeX: ``integer``
   | sizeY: ``integer``
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.Objective:
+.. _OMERO model class Objective:
 
 Objective
 """""""""
 
-Used by: :ref:`Instrument.objective <Hibernate version of class omero.model.Instrument>`, :ref:`OTF.objective <Hibernate version of class omero.model.OTF>`, :ref:`ObjectiveAnnotationLink.parent <Hibernate version of class omero.model.ObjectiveAnnotationLink>`, :ref:`ObjectiveSettings.objective <Hibernate version of class omero.model.ObjectiveSettings>`
+Used by: :ref:`Instrument.objective <OMERO model class Instrument>`, :ref:`OTF.objective <OMERO model class OTF>`, :ref:`ObjectiveAnnotationLink.parent <OMERO model class ObjectiveAnnotationLink>`, :ref:`ObjectiveSettings.objective <OMERO model class ObjectiveSettings>`
 
 Properties:
-  | annotationLinks: :ref:`ObjectiveAnnotationLink <Hibernate version of class omero.model.ObjectiveAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`ObjectiveAnnotationLink <OMERO model class ObjectiveAnnotationLink>` (multiple)
   | calibratedMagnification: ``double`` (optional)
-  | correction: :ref:`Correction <Hibernate version of class omero.model.Correction>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | correction: :ref:`Correction <OMERO model class Correction>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | immersion: :ref:`Immersion <Hibernate version of class omero.model.Immersion>`
-  | instrument: :ref:`Instrument <Hibernate version of class omero.model.Instrument>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | immersion: :ref:`Immersion <OMERO model class Immersion>`
+  | instrument: :ref:`Instrument <OMERO model class Instrument>`
   | iris: ``boolean`` (optional)
   | lensNA: ``double`` (optional)
   | lotNumber: ``string`` (optional)
@@ -2057,226 +2059,227 @@ Properties:
   | model: ``string`` (optional)
   | nominalMagnification: ``double`` (optional)
   | serialNumber: ``string`` (optional)
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
-  | workingDistance.unit: enumeration (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | workingDistance.value: ``double`` (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
+  | workingDistance.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional)
+  | workingDistance.value: ``double`` (optional)
 
-.. _Hibernate version of class omero.model.ObjectiveAnnotationLink:
+.. _OMERO model class ObjectiveAnnotationLink:
 
 ObjectiveAnnotationLink
 """""""""""""""""""""""
 
-Used by: :ref:`Objective.annotationLinks <Hibernate version of class omero.model.Objective>`
+Used by: :ref:`Objective.annotationLinks <OMERO model class Objective>`
 
 Properties:
-  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Annotation <OMERO model class Annotation>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`Objective <Hibernate version of class omero.model.Objective>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`Objective <OMERO model class Objective>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.ObjectiveSettings:
+.. _OMERO model class ObjectiveSettings:
 
 ObjectiveSettings
 """""""""""""""""
 
-Used by: :ref:`Image.objectiveSettings <Hibernate version of class omero.model.Image>`
+Used by: :ref:`Image.objectiveSettings <OMERO model class Image>`
 
 Properties:
   | correctionCollar: ``double`` (optional)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | medium: :ref:`Medium <Hibernate version of class omero.model.Medium>` (optional)
-  | objective: :ref:`Objective <Hibernate version of class omero.model.Objective>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | medium: :ref:`Medium <OMERO model class Medium>` (optional)
+  | objective: :ref:`Objective <OMERO model class Objective>`
   | refractiveIndex: ``double`` (optional)
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.OriginalFile:
+.. _OMERO model class OriginalFile:
 
 OriginalFile
 """"""""""""
 
-Used by: :ref:`FileAnnotation.file <Hibernate version of class omero.model.FileAnnotation>`, :ref:`FilesetEntry.originalFile <Hibernate version of class omero.model.FilesetEntry>`, :ref:`JobOriginalFileLink.child <Hibernate version of class omero.model.JobOriginalFileLink>`, :ref:`OriginalFileAnnotationLink.parent <Hibernate version of class omero.model.OriginalFileAnnotationLink>`, :ref:`PixelsOriginalFileMap.parent <Hibernate version of class omero.model.PixelsOriginalFileMap>`, :ref:`Roi.source <Hibernate version of class omero.model.Roi>`
+Used by: :ref:`FileAnnotation.file <OMERO model class FileAnnotation>`, :ref:`FilesetEntry.originalFile <OMERO model class FilesetEntry>`, :ref:`JobOriginalFileLink.child <OMERO model class JobOriginalFileLink>`, :ref:`OriginalFileAnnotationLink.parent <OMERO model class OriginalFileAnnotationLink>`, :ref:`PixelsOriginalFileMap.parent <OMERO model class PixelsOriginalFileMap>`, :ref:`Roi.source <OMERO model class Roi>`
 
 Properties:
-  | annotationLinks: :ref:`OriginalFileAnnotationLink <Hibernate version of class omero.model.OriginalFileAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`OriginalFileAnnotationLink <OMERO model class OriginalFileAnnotationLink>` (multiple)
   | atime: ``timestamp`` (optional)
   | ctime: ``timestamp`` (optional)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | filesetEntries: :ref:`FilesetEntry <OMERO model class FilesetEntry>` (multiple)
   | hash: ``string`` (optional)
-  | hasher: :ref:`ChecksumAlgorithm <Hibernate version of class omero.model.ChecksumAlgorithm>` (optional)
+  | hasher: :ref:`ChecksumAlgorithm <OMERO model class ChecksumAlgorithm>` (optional)
   | mimetype: ``string`` (optional)
   | mtime: ``timestamp`` (optional)
   | name: ``string``
   | path: ``text``
-  | pixelsFileMaps: :ref:`PixelsOriginalFileMap <Hibernate version of class omero.model.PixelsOriginalFileMap>` (multiple)
+  | pixelsFileMaps: :ref:`PixelsOriginalFileMap <OMERO model class PixelsOriginalFileMap>` (multiple)
   | size: ``long`` (optional)
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.OriginalFileAnnotationLink:
+.. _OMERO model class OriginalFileAnnotationLink:
 
 OriginalFileAnnotationLink
 """"""""""""""""""""""""""
 
-Used by: :ref:`OriginalFile.annotationLinks <Hibernate version of class omero.model.OriginalFile>`
+Used by: :ref:`OriginalFile.annotationLinks <OMERO model class OriginalFile>`
 
 Properties:
-  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Annotation <OMERO model class Annotation>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`OriginalFile <Hibernate version of class omero.model.OriginalFile>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`OriginalFile <OMERO model class OriginalFile>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.ParseJob:
+.. _OMERO model class ParseJob:
 
 ParseJob
 """"""""
 
 Properties:
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.permissions.perm1: ``long`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | finished: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | groupname: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | message: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | originalFileLinks: :ref:`JobOriginalFileLink <Hibernate version of class omero.model.JobOriginalFileLink>` (multiple) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Job <OMERO model class Job>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Job <OMERO model class Job>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Job <OMERO model class Job>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Job <OMERO model class Job>`
+  | details.permissions.perm1: ``long`` from :ref:`Job <OMERO model class Job>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Job <OMERO model class Job>`
+  | finished: ``timestamp`` (optional) from :ref:`Job <OMERO model class Job>`
+  | groupname: ``string`` from :ref:`Job <OMERO model class Job>`
+  | message: ``string`` from :ref:`Job <OMERO model class Job>`
+  | originalFileLinks: :ref:`JobOriginalFileLink <OMERO model class JobOriginalFileLink>` (multiple) from :ref:`Job <OMERO model class Job>`
   | params: ``binary`` (optional)
-  | scheduledFor: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | started: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | status: :ref:`JobStatus <Hibernate version of class omero.model.JobStatus>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | submitted: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | type: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | username: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | version: ``integer`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | scheduledFor: ``timestamp`` from :ref:`Job <OMERO model class Job>`
+  | started: ``timestamp`` (optional) from :ref:`Job <OMERO model class Job>`
+  | status: :ref:`JobStatus <OMERO model class JobStatus>` from :ref:`Job <OMERO model class Job>`
+  | submitted: ``timestamp`` from :ref:`Job <OMERO model class Job>`
+  | type: ``string`` from :ref:`Job <OMERO model class Job>`
+  | username: ``string`` from :ref:`Job <OMERO model class Job>`
+  | version: ``integer`` (optional) from :ref:`Job <OMERO model class Job>`
 
-.. _Hibernate version of class omero.model.Path:
+.. _OMERO model class Path:
 
 Path
 """"
 
 Properties:
-  | annotationLinks: :ref:`ShapeAnnotationLink <Hibernate version of class omero.model.ShapeAnnotationLink>` (multiple) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | annotationLinks: :ref:`ShapeAnnotationLink <OMERO model class ShapeAnnotationLink>` (multiple) from :ref:`Shape <OMERO model class Shape>`
   | d: ``text`` (optional)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.permissions.perm1: ``long`` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fillColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fillRule: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontFamily: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontSize.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | fontSize.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | fontStretch: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontStyle: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontVariant: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontWeight: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | g: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | locked: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | roi: :ref:`Roi <Hibernate version of class omero.model.Roi>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeDashArray: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeLineCap: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeWidth.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Shape <OMERO model class Shape>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Shape <OMERO model class Shape>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Shape <OMERO model class Shape>`
+  | details.permissions.perm1: ``long`` from :ref:`Shape <OMERO model class Shape>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Shape <OMERO model class Shape>`
+  | fillColor: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fillRule: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontFamily: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontSize.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontSize.value: ``double`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontStretch: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontStyle: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontVariant: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontWeight: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | g: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | locked: ``boolean`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | roi: :ref:`Roi <OMERO model class Roi>` from :ref:`Shape <OMERO model class Shape>`
+  | strokeColor: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeDashArray: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeLineCap: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeWidth.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <OMERO model class Shape>`
   | textValue: ``text`` (optional)
-  | theC: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | theT: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | theZ: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | transform: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | vectorEffect: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | version: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | visibility: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | theC: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | theT: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | theZ: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | transform: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | vectorEffect: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | version: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | visibility: ``boolean`` (optional) from :ref:`Shape <OMERO model class Shape>`
 
-.. _Hibernate version of class omero.model.PhotometricInterpretation:
+.. _OMERO model class PhotometricInterpretation:
 
 PhotometricInterpretation
 """""""""""""""""""""""""
 
-Used by: :ref:`LogicalChannel.photometricInterpretation <Hibernate version of class omero.model.LogicalChannel>`
+Used by: :ref:`LogicalChannel.photometricInterpretation <OMERO model class LogicalChannel>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
+  | value: ``string``, see :javadoc:`IEnum <ome/model/IEnum.html>`
 
-.. _Hibernate version of class omero.model.PixelDataJob:
+.. _OMERO model class PixelDataJob:
 
 PixelDataJob
 """"""""""""
 
 Properties:
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.permissions.perm1: ``long`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | finished: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | groupname: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | message: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | originalFileLinks: :ref:`JobOriginalFileLink <Hibernate version of class omero.model.JobOriginalFileLink>` (multiple) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | scheduledFor: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | started: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | status: :ref:`JobStatus <Hibernate version of class omero.model.JobStatus>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | submitted: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | type: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | username: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | version: ``integer`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Job <OMERO model class Job>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Job <OMERO model class Job>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Job <OMERO model class Job>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Job <OMERO model class Job>`
+  | details.permissions.perm1: ``long`` from :ref:`Job <OMERO model class Job>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Job <OMERO model class Job>`
+  | finished: ``timestamp`` (optional) from :ref:`Job <OMERO model class Job>`
+  | groupname: ``string`` from :ref:`Job <OMERO model class Job>`
+  | message: ``string`` from :ref:`Job <OMERO model class Job>`
+  | originalFileLinks: :ref:`JobOriginalFileLink <OMERO model class JobOriginalFileLink>` (multiple) from :ref:`Job <OMERO model class Job>`
+  | scheduledFor: ``timestamp`` from :ref:`Job <OMERO model class Job>`
+  | started: ``timestamp`` (optional) from :ref:`Job <OMERO model class Job>`
+  | status: :ref:`JobStatus <OMERO model class JobStatus>` from :ref:`Job <OMERO model class Job>`
+  | submitted: ``timestamp`` from :ref:`Job <OMERO model class Job>`
+  | type: ``string`` from :ref:`Job <OMERO model class Job>`
+  | username: ``string`` from :ref:`Job <OMERO model class Job>`
+  | version: ``integer`` (optional) from :ref:`Job <OMERO model class Job>`
 
-.. _Hibernate version of class omero.model.Pixels:
+.. _OMERO model class Pixels:
 
 Pixels
 """"""
 
-Used by: :ref:`Channel.pixels <Hibernate version of class omero.model.Channel>`, :ref:`Image.pixels <Hibernate version of class omero.model.Image>`, :ref:`Mask.pixels <Hibernate version of class omero.model.Mask>`, :ref:`Pixels.relatedTo <Hibernate version of class omero.model.Pixels>`, :ref:`PixelsOriginalFileMap.child <Hibernate version of class omero.model.PixelsOriginalFileMap>`, :ref:`PlaneInfo.pixels <Hibernate version of class omero.model.PlaneInfo>`, :ref:`RenderingDef.pixels <Hibernate version of class omero.model.RenderingDef>`, :ref:`Thumbnail.pixels <Hibernate version of class omero.model.Thumbnail>`
+Used by: :ref:`Channel.pixels <OMERO model class Channel>`, :ref:`Image.pixels <OMERO model class Image>`, :ref:`Mask.pixels <OMERO model class Mask>`, :ref:`Pixels.relatedTo <OMERO model class Pixels>`, :ref:`PixelsOriginalFileMap.child <OMERO model class PixelsOriginalFileMap>`, :ref:`PlaneInfo.pixels <OMERO model class PlaneInfo>`, :ref:`RenderingDef.pixels <OMERO model class RenderingDef>`, :ref:`Thumbnail.pixels <OMERO model class Thumbnail>`
 
 Properties:
-  | channels: :ref:`Channel <Hibernate version of class omero.model.Channel>` (multiple)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | channels: :ref:`Channel <OMERO model class Channel>` (multiple)
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | dimensionOrder: :ref:`DimensionOrder <Hibernate version of class omero.model.DimensionOrder>`
-  | image: :ref:`Image <Hibernate version of class omero.model.Image>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | dimensionOrder: :ref:`DimensionOrder <OMERO model class DimensionOrder>`
+  | image: :ref:`Image <OMERO model class Image>`
   | methodology: ``string`` (optional)
-  | physicalSizeX.unit: enumeration (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | physicalSizeX.value: ``double`` (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | physicalSizeY.unit: enumeration (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | physicalSizeY.value: ``double`` (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | physicalSizeZ.unit: enumeration (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | physicalSizeZ.value: ``double`` (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | pixelsFileMaps: :ref:`PixelsOriginalFileMap <Hibernate version of class omero.model.PixelsOriginalFileMap>` (multiple)
-  | pixelsType: :ref:`PixelsType <Hibernate version of class omero.model.PixelsType>`
-  | planeInfo: :ref:`PlaneInfo <Hibernate version of class omero.model.PlaneInfo>` (multiple)
-  | relatedTo: :ref:`Pixels <Hibernate version of class omero.model.Pixels>` (optional)
-  | settings: :ref:`RenderingDef <Hibernate version of class omero.model.RenderingDef>` (multiple)
+  | physicalSizeX.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional)
+  | physicalSizeX.value: ``double`` (optional)
+  | physicalSizeY.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional)
+  | physicalSizeY.value: ``double`` (optional)
+  | physicalSizeZ.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional)
+  | physicalSizeZ.value: ``double`` (optional)
+  | pixelsFileMaps: :ref:`PixelsOriginalFileMap <OMERO model class PixelsOriginalFileMap>` (multiple)
+  | pixelsType: :ref:`PixelsType <OMERO model class PixelsType>`
+  | planeInfo: :ref:`PlaneInfo <OMERO model class PlaneInfo>` (multiple)
+  | relatedTo: :ref:`Pixels <OMERO model class Pixels>` (optional)
+  | settings: :ref:`RenderingDef <OMERO model class RenderingDef>` (multiple)
   | sha1: ``string``
   | significantBits: ``integer`` (optional)
   | sizeC: ``integer``
@@ -2284,1181 +2287,1181 @@ Properties:
   | sizeX: ``integer``
   | sizeY: ``integer``
   | sizeZ: ``integer``
-  | thumbnails: :ref:`Thumbnail <Hibernate version of class omero.model.Thumbnail>` (multiple)
-  | timeIncrement.unit: enumeration (optional), see :javadoc:`TimeI <omero/model/TimeI.html>`
-  | timeIncrement.value: ``double`` (optional), see :javadoc:`TimeI <omero/model/TimeI.html>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | thumbnails: :ref:`Thumbnail <OMERO model class Thumbnail>` (multiple)
+  | timeIncrement.unit: enumeration of :javadoc:`Time <ome/model/units/Time.html>` (optional)
+  | timeIncrement.value: ``double`` (optional)
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
   | waveIncrement: ``integer`` (optional)
   | waveStart: ``integer`` (optional)
 
-.. _Hibernate version of class omero.model.PixelsOriginalFileMap:
+.. _OMERO model class PixelsOriginalFileMap:
 
 PixelsOriginalFileMap
 """""""""""""""""""""
 
-Used by: :ref:`OriginalFile.pixelsFileMaps <Hibernate version of class omero.model.OriginalFile>`, :ref:`Pixels.pixelsFileMaps <Hibernate version of class omero.model.Pixels>`
+Used by: :ref:`OriginalFile.pixelsFileMaps <OMERO model class OriginalFile>`, :ref:`Pixels.pixelsFileMaps <OMERO model class Pixels>`
 
 Properties:
-  | child: :ref:`Pixels <Hibernate version of class omero.model.Pixels>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Pixels <OMERO model class Pixels>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`OriginalFile <Hibernate version of class omero.model.OriginalFile>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`OriginalFile <OMERO model class OriginalFile>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.PixelsType:
+.. _OMERO model class PixelsType:
 
 PixelsType
 """"""""""
 
-Used by: :ref:`OTF.pixelsType <Hibernate version of class omero.model.OTF>`, :ref:`Pixels.pixelsType <Hibernate version of class omero.model.Pixels>`
+Used by: :ref:`OTF.pixelsType <OMERO model class OTF>`, :ref:`Pixels.pixelsType <OMERO model class Pixels>`
 
 Properties:
   | bitSize: ``integer`` (optional)
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
+  | value: ``string``, see :javadoc:`IEnum <ome/model/IEnum.html>`
 
-.. _Hibernate version of class omero.model.PlaneInfo:
+.. _OMERO model class PlaneInfo:
 
 PlaneInfo
 """""""""
 
-Used by: :ref:`Pixels.planeInfo <Hibernate version of class omero.model.Pixels>`, :ref:`PlaneInfoAnnotationLink.parent <Hibernate version of class omero.model.PlaneInfoAnnotationLink>`
+Used by: :ref:`Pixels.planeInfo <OMERO model class Pixels>`, :ref:`PlaneInfoAnnotationLink.parent <OMERO model class PlaneInfoAnnotationLink>`
 
 Properties:
-  | annotationLinks: :ref:`PlaneInfoAnnotationLink <Hibernate version of class omero.model.PlaneInfoAnnotationLink>` (multiple)
-  | deltaT.unit: enumeration (optional), see :javadoc:`TimeI <omero/model/TimeI.html>`
-  | deltaT.value: ``double`` (optional), see :javadoc:`TimeI <omero/model/TimeI.html>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | annotationLinks: :ref:`PlaneInfoAnnotationLink <OMERO model class PlaneInfoAnnotationLink>` (multiple)
+  | deltaT.unit: enumeration of :javadoc:`Time <ome/model/units/Time.html>` (optional)
+  | deltaT.value: ``double`` (optional)
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | exposureTime.unit: enumeration (optional), see :javadoc:`TimeI <omero/model/TimeI.html>`
-  | exposureTime.value: ``double`` (optional), see :javadoc:`TimeI <omero/model/TimeI.html>`
-  | pixels: :ref:`Pixels <Hibernate version of class omero.model.Pixels>`
-  | positionX.unit: enumeration (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | positionX.value: ``double`` (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | positionY.unit: enumeration (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | positionY.value: ``double`` (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | positionZ.unit: enumeration (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | positionZ.value: ``double`` (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | exposureTime.unit: enumeration of :javadoc:`Time <ome/model/units/Time.html>` (optional)
+  | exposureTime.value: ``double`` (optional)
+  | pixels: :ref:`Pixels <OMERO model class Pixels>`
+  | positionX.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional)
+  | positionX.value: ``double`` (optional)
+  | positionY.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional)
+  | positionY.value: ``double`` (optional)
+  | positionZ.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional)
+  | positionZ.value: ``double`` (optional)
   | theC: ``integer``
   | theT: ``integer``
   | theZ: ``integer``
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.PlaneInfoAnnotationLink:
+.. _OMERO model class PlaneInfoAnnotationLink:
 
 PlaneInfoAnnotationLink
 """""""""""""""""""""""
 
-Used by: :ref:`PlaneInfo.annotationLinks <Hibernate version of class omero.model.PlaneInfo>`
+Used by: :ref:`PlaneInfo.annotationLinks <OMERO model class PlaneInfo>`
 
 Properties:
-  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Annotation <OMERO model class Annotation>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`PlaneInfo <Hibernate version of class omero.model.PlaneInfo>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`PlaneInfo <OMERO model class PlaneInfo>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.PlaneSlicingContext:
+.. _OMERO model class PlaneSlicingContext:
 
 PlaneSlicingContext
 """""""""""""""""""
 
 Properties:
   | constant: ``boolean``
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
-  | details.permissions.perm1: ``long`` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`CodomainMapContext <OMERO model class CodomainMapContext>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`CodomainMapContext <OMERO model class CodomainMapContext>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`CodomainMapContext <OMERO model class CodomainMapContext>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`CodomainMapContext <OMERO model class CodomainMapContext>`
+  | details.permissions.perm1: ``long`` from :ref:`CodomainMapContext <OMERO model class CodomainMapContext>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`CodomainMapContext <OMERO model class CodomainMapContext>`
   | lowerLimit: ``integer``
   | planePrevious: ``integer``
   | planeSelected: ``integer``
-  | renderingDef: :ref:`RenderingDef <Hibernate version of class omero.model.RenderingDef>` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
+  | renderingDef: :ref:`RenderingDef <OMERO model class RenderingDef>` from :ref:`CodomainMapContext <OMERO model class CodomainMapContext>`
   | upperLimit: ``integer``
-  | version: ``integer`` (optional) from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
+  | version: ``integer`` (optional) from :ref:`CodomainMapContext <OMERO model class CodomainMapContext>`
 
-.. _Hibernate version of class omero.model.Plate:
+.. _OMERO model class Plate:
 
 Plate
 """""
 
-Used by: :ref:`PlateAcquisition.plate <Hibernate version of class omero.model.PlateAcquisition>`, :ref:`PlateAnnotationLink.parent <Hibernate version of class omero.model.PlateAnnotationLink>`, :ref:`ScreenPlateLink.child <Hibernate version of class omero.model.ScreenPlateLink>`, :ref:`Well.plate <Hibernate version of class omero.model.Well>`
+Used by: :ref:`PlateAcquisition.plate <OMERO model class PlateAcquisition>`, :ref:`PlateAnnotationLink.parent <OMERO model class PlateAnnotationLink>`, :ref:`ScreenPlateLink.child <OMERO model class ScreenPlateLink>`, :ref:`Well.plate <OMERO model class Well>`
 
 Properties:
-  | annotationLinks: :ref:`PlateAnnotationLink <Hibernate version of class omero.model.PlateAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`PlateAnnotationLink <OMERO model class PlateAnnotationLink>` (multiple)
   | columnNamingConvention: ``string`` (optional)
   | columns: ``integer`` (optional)
   | defaultSample: ``integer`` (optional)
   | description: ``text`` (optional)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
   | externalIdentifier: ``string`` (optional)
   | name: ``string``
-  | plateAcquisitions: :ref:`PlateAcquisition <Hibernate version of class omero.model.PlateAcquisition>` (multiple)
+  | plateAcquisitions: :ref:`PlateAcquisition <OMERO model class PlateAcquisition>` (multiple)
   | rowNamingConvention: ``string`` (optional)
   | rows: ``integer`` (optional)
-  | screenLinks: :ref:`ScreenPlateLink <Hibernate version of class omero.model.ScreenPlateLink>` (multiple)
+  | screenLinks: :ref:`ScreenPlateLink <OMERO model class ScreenPlateLink>` (multiple)
   | status: ``string`` (optional)
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
-  | wellOriginX.unit: enumeration (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | wellOriginX.value: ``double`` (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | wellOriginY.unit: enumeration (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | wellOriginY.value: ``double`` (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | wells: :ref:`Well <Hibernate version of class omero.model.Well>` (multiple)
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
+  | wellOriginX.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional)
+  | wellOriginX.value: ``double`` (optional)
+  | wellOriginY.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional)
+  | wellOriginY.value: ``double`` (optional)
+  | wells: :ref:`Well <OMERO model class Well>` (multiple)
 
-.. _Hibernate version of class omero.model.PlateAcquisition:
+.. _OMERO model class PlateAcquisition:
 
 PlateAcquisition
 """"""""""""""""
 
-Used by: :ref:`Plate.plateAcquisitions <Hibernate version of class omero.model.Plate>`, :ref:`PlateAcquisitionAnnotationLink.parent <Hibernate version of class omero.model.PlateAcquisitionAnnotationLink>`, :ref:`WellSample.plateAcquisition <Hibernate version of class omero.model.WellSample>`
+Used by: :ref:`Plate.plateAcquisitions <OMERO model class Plate>`, :ref:`PlateAcquisitionAnnotationLink.parent <OMERO model class PlateAcquisitionAnnotationLink>`, :ref:`WellSample.plateAcquisition <OMERO model class WellSample>`
 
 Properties:
-  | annotationLinks: :ref:`PlateAcquisitionAnnotationLink <Hibernate version of class omero.model.PlateAcquisitionAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`PlateAcquisitionAnnotationLink <OMERO model class PlateAcquisitionAnnotationLink>` (multiple)
   | description: ``text`` (optional)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
   | endTime: ``timestamp`` (optional)
   | maximumFieldCount: ``integer`` (optional)
   | name: ``string`` (optional)
-  | plate: :ref:`Plate <Hibernate version of class omero.model.Plate>`
+  | plate: :ref:`Plate <OMERO model class Plate>`
   | startTime: ``timestamp`` (optional)
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
-  | wellSample: :ref:`WellSample <Hibernate version of class omero.model.WellSample>` (multiple)
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
+  | wellSample: :ref:`WellSample <OMERO model class WellSample>` (multiple)
 
-.. _Hibernate version of class omero.model.PlateAcquisitionAnnotationLink:
+.. _OMERO model class PlateAcquisitionAnnotationLink:
 
 PlateAcquisitionAnnotationLink
 """"""""""""""""""""""""""""""
 
-Used by: :ref:`PlateAcquisition.annotationLinks <Hibernate version of class omero.model.PlateAcquisition>`
+Used by: :ref:`PlateAcquisition.annotationLinks <OMERO model class PlateAcquisition>`
 
 Properties:
-  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Annotation <OMERO model class Annotation>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`PlateAcquisition <Hibernate version of class omero.model.PlateAcquisition>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`PlateAcquisition <OMERO model class PlateAcquisition>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.PlateAnnotationLink:
+.. _OMERO model class PlateAnnotationLink:
 
 PlateAnnotationLink
 """""""""""""""""""
 
-Used by: :ref:`Plate.annotationLinks <Hibernate version of class omero.model.Plate>`
+Used by: :ref:`Plate.annotationLinks <OMERO model class Plate>`
 
 Properties:
-  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Annotation <OMERO model class Annotation>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`Plate <Hibernate version of class omero.model.Plate>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`Plate <OMERO model class Plate>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.Point:
+.. _OMERO model class Point:
 
 Point
 """""
 
 Properties:
-  | annotationLinks: :ref:`ShapeAnnotationLink <Hibernate version of class omero.model.ShapeAnnotationLink>` (multiple) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | annotationLinks: :ref:`ShapeAnnotationLink <OMERO model class ShapeAnnotationLink>` (multiple) from :ref:`Shape <OMERO model class Shape>`
   | cx: ``double`` (optional)
   | cy: ``double`` (optional)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.permissions.perm1: ``long`` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fillColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fillRule: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontFamily: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontSize.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | fontSize.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | fontStretch: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontStyle: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontVariant: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontWeight: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | g: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | locked: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | roi: :ref:`Roi <Hibernate version of class omero.model.Roi>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeDashArray: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeLineCap: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeWidth.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Shape <OMERO model class Shape>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Shape <OMERO model class Shape>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Shape <OMERO model class Shape>`
+  | details.permissions.perm1: ``long`` from :ref:`Shape <OMERO model class Shape>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Shape <OMERO model class Shape>`
+  | fillColor: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fillRule: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontFamily: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontSize.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontSize.value: ``double`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontStretch: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontStyle: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontVariant: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontWeight: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | g: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | locked: ``boolean`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | roi: :ref:`Roi <OMERO model class Roi>` from :ref:`Shape <OMERO model class Shape>`
+  | strokeColor: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeDashArray: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeLineCap: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeWidth.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <OMERO model class Shape>`
   | textValue: ``text`` (optional)
-  | theC: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | theT: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | theZ: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | transform: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | vectorEffect: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | version: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | visibility: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | theC: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | theT: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | theZ: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | transform: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | vectorEffect: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | version: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | visibility: ``boolean`` (optional) from :ref:`Shape <OMERO model class Shape>`
 
-.. _Hibernate version of class omero.model.Polygon:
+.. _OMERO model class Polygon:
 
 Polygon
 """""""
 
 Properties:
-  | annotationLinks: :ref:`ShapeAnnotationLink <Hibernate version of class omero.model.ShapeAnnotationLink>` (multiple) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.permissions.perm1: ``long`` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fillColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fillRule: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontFamily: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontSize.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | fontSize.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | fontStretch: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontStyle: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontVariant: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontWeight: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | g: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | locked: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | annotationLinks: :ref:`ShapeAnnotationLink <OMERO model class ShapeAnnotationLink>` (multiple) from :ref:`Shape <OMERO model class Shape>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Shape <OMERO model class Shape>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Shape <OMERO model class Shape>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Shape <OMERO model class Shape>`
+  | details.permissions.perm1: ``long`` from :ref:`Shape <OMERO model class Shape>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Shape <OMERO model class Shape>`
+  | fillColor: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fillRule: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontFamily: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontSize.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontSize.value: ``double`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontStretch: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontStyle: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontVariant: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontWeight: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | g: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | locked: ``boolean`` (optional) from :ref:`Shape <OMERO model class Shape>`
   | points: ``text`` (optional)
-  | roi: :ref:`Roi <Hibernate version of class omero.model.Roi>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeDashArray: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeLineCap: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeWidth.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
+  | roi: :ref:`Roi <OMERO model class Roi>` from :ref:`Shape <OMERO model class Shape>`
+  | strokeColor: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeDashArray: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeLineCap: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeWidth.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <OMERO model class Shape>`
   | textValue: ``text`` (optional)
-  | theC: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | theT: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | theZ: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | transform: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | vectorEffect: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | version: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | visibility: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | theC: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | theT: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | theZ: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | transform: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | vectorEffect: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | version: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | visibility: ``boolean`` (optional) from :ref:`Shape <OMERO model class Shape>`
 
-.. _Hibernate version of class omero.model.Polyline:
+.. _OMERO model class Polyline:
 
 Polyline
 """"""""
 
 Properties:
-  | annotationLinks: :ref:`ShapeAnnotationLink <Hibernate version of class omero.model.ShapeAnnotationLink>` (multiple) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.permissions.perm1: ``long`` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fillColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fillRule: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontFamily: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontSize.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | fontSize.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | fontStretch: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontStyle: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontVariant: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontWeight: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | g: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | locked: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | annotationLinks: :ref:`ShapeAnnotationLink <OMERO model class ShapeAnnotationLink>` (multiple) from :ref:`Shape <OMERO model class Shape>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Shape <OMERO model class Shape>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Shape <OMERO model class Shape>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Shape <OMERO model class Shape>`
+  | details.permissions.perm1: ``long`` from :ref:`Shape <OMERO model class Shape>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Shape <OMERO model class Shape>`
+  | fillColor: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fillRule: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontFamily: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontSize.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontSize.value: ``double`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontStretch: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontStyle: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontVariant: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontWeight: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | g: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | locked: ``boolean`` (optional) from :ref:`Shape <OMERO model class Shape>`
   | points: ``text`` (optional)
-  | roi: :ref:`Roi <Hibernate version of class omero.model.Roi>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeDashArray: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeLineCap: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeWidth.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
+  | roi: :ref:`Roi <OMERO model class Roi>` from :ref:`Shape <OMERO model class Shape>`
+  | strokeColor: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeDashArray: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeLineCap: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeWidth.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <OMERO model class Shape>`
   | textValue: ``text`` (optional)
-  | theC: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | theT: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | theZ: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | transform: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | vectorEffect: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | version: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | visibility: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | theC: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | theT: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | theZ: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | transform: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | vectorEffect: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | version: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | visibility: ``boolean`` (optional) from :ref:`Shape <OMERO model class Shape>`
 
-.. _Hibernate version of class omero.model.Project:
+.. _OMERO model class Project:
 
 Project
 """""""
 
-Used by: :ref:`ProjectAnnotationLink.parent <Hibernate version of class omero.model.ProjectAnnotationLink>`, :ref:`ProjectDatasetLink.parent <Hibernate version of class omero.model.ProjectDatasetLink>`
+Used by: :ref:`ProjectAnnotationLink.parent <OMERO model class ProjectAnnotationLink>`, :ref:`ProjectDatasetLink.parent <OMERO model class ProjectDatasetLink>`
 
 Properties:
-  | annotationLinks: :ref:`ProjectAnnotationLink <Hibernate version of class omero.model.ProjectAnnotationLink>` (multiple)
-  | datasetLinks: :ref:`ProjectDatasetLink <Hibernate version of class omero.model.ProjectDatasetLink>` (multiple)
+  | annotationLinks: :ref:`ProjectAnnotationLink <OMERO model class ProjectAnnotationLink>` (multiple)
+  | datasetLinks: :ref:`ProjectDatasetLink <OMERO model class ProjectDatasetLink>` (multiple)
   | description: ``text`` (optional)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
   | name: ``string``
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.ProjectAnnotationLink:
+.. _OMERO model class ProjectAnnotationLink:
 
 ProjectAnnotationLink
 """""""""""""""""""""
 
-Used by: :ref:`Project.annotationLinks <Hibernate version of class omero.model.Project>`
+Used by: :ref:`Project.annotationLinks <OMERO model class Project>`
 
 Properties:
-  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Annotation <OMERO model class Annotation>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`Project <Hibernate version of class omero.model.Project>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`Project <OMERO model class Project>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.ProjectDatasetLink:
+.. _OMERO model class ProjectDatasetLink:
 
 ProjectDatasetLink
 """"""""""""""""""
 
-Used by: :ref:`Dataset.projectLinks <Hibernate version of class omero.model.Dataset>`, :ref:`Project.datasetLinks <Hibernate version of class omero.model.Project>`
+Used by: :ref:`Dataset.projectLinks <OMERO model class Dataset>`, :ref:`Project.datasetLinks <OMERO model class Project>`
 
 Properties:
-  | child: :ref:`Dataset <Hibernate version of class omero.model.Dataset>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Dataset <OMERO model class Dataset>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`Project <Hibernate version of class omero.model.Project>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`Project <OMERO model class Project>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.Pulse:
+.. _OMERO model class Pulse:
 
 Pulse
 """""
 
-Used by: :ref:`Laser.pulse <Hibernate version of class omero.model.Laser>`
+Used by: :ref:`Laser.pulse <OMERO model class Laser>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
+  | value: ``string``, see :javadoc:`IEnum <ome/model/IEnum.html>`
 
-.. _Hibernate version of class omero.model.QuantumDef:
+.. _OMERO model class QuantumDef:
 
 QuantumDef
 """"""""""
 
-Used by: :ref:`RenderingDef.quantization <Hibernate version of class omero.model.RenderingDef>`
+Used by: :ref:`RenderingDef.quantization <OMERO model class RenderingDef>`
 
 Properties:
   | bitResolution: ``integer``
   | cdEnd: ``integer``
   | cdStart: ``integer``
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.Reagent:
+.. _OMERO model class Reagent:
 
 Reagent
 """""""
 
-Used by: :ref:`ReagentAnnotationLink.parent <Hibernate version of class omero.model.ReagentAnnotationLink>`, :ref:`Screen.reagents <Hibernate version of class omero.model.Screen>`, :ref:`WellReagentLink.child <Hibernate version of class omero.model.WellReagentLink>`
+Used by: :ref:`ReagentAnnotationLink.parent <OMERO model class ReagentAnnotationLink>`, :ref:`Screen.reagents <OMERO model class Screen>`, :ref:`WellReagentLink.child <OMERO model class WellReagentLink>`
 
 Properties:
-  | annotationLinks: :ref:`ReagentAnnotationLink <Hibernate version of class omero.model.ReagentAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`ReagentAnnotationLink <OMERO model class ReagentAnnotationLink>` (multiple)
   | description: ``text`` (optional)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
   | name: ``string`` (optional)
   | reagentIdentifier: ``string`` (optional)
-  | screen: :ref:`Screen <Hibernate version of class omero.model.Screen>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
-  | wellLinks: :ref:`WellReagentLink <Hibernate version of class omero.model.WellReagentLink>` (multiple)
+  | screen: :ref:`Screen <OMERO model class Screen>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
+  | wellLinks: :ref:`WellReagentLink <OMERO model class WellReagentLink>` (multiple)
 
-.. _Hibernate version of class omero.model.ReagentAnnotationLink:
+.. _OMERO model class ReagentAnnotationLink:
 
 ReagentAnnotationLink
 """""""""""""""""""""
 
-Used by: :ref:`Reagent.annotationLinks <Hibernate version of class omero.model.Reagent>`
+Used by: :ref:`Reagent.annotationLinks <OMERO model class Reagent>`
 
 Properties:
-  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Annotation <OMERO model class Annotation>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`Reagent <Hibernate version of class omero.model.Reagent>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`Reagent <OMERO model class Reagent>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.Rect:
+.. _OMERO model class Rect:
 
 Rect
 """"
 
 Properties:
-  | annotationLinks: :ref:`ShapeAnnotationLink <Hibernate version of class omero.model.ShapeAnnotationLink>` (multiple) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.permissions.perm1: ``long`` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fillColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fillRule: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontFamily: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontSize.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | fontSize.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | fontStretch: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontStyle: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontVariant: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | fontWeight: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | g: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | annotationLinks: :ref:`ShapeAnnotationLink <OMERO model class ShapeAnnotationLink>` (multiple) from :ref:`Shape <OMERO model class Shape>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Shape <OMERO model class Shape>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Shape <OMERO model class Shape>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Shape <OMERO model class Shape>`
+  | details.permissions.perm1: ``long`` from :ref:`Shape <OMERO model class Shape>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Shape <OMERO model class Shape>`
+  | fillColor: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fillRule: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontFamily: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontSize.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontSize.value: ``double`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontStretch: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontStyle: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontVariant: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | fontWeight: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | g: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
   | height: ``double`` (optional)
-  | locked: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | roi: :ref:`Roi <Hibernate version of class omero.model.Roi>` from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | locked: ``boolean`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | roi: :ref:`Roi <OMERO model class Roi>` from :ref:`Shape <OMERO model class Shape>`
   | rx: ``double`` (optional)
-  | strokeColor: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeDashArray: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeLineCap: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | strokeWidth.unit: enumeration (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :javadoc:`LengthI <omero/model/LengthI.html>`
+  | strokeColor: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeDashArray: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeDashOffset: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeLineCap: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeLineJoin: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeMiterLimit: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeWidth.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | strokeWidth.value: ``double`` (optional) from :ref:`Shape <OMERO model class Shape>`
   | textValue: ``text`` (optional)
-  | theC: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | theT: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | theZ: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | transform: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | vectorEffect: ``string`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | version: ``integer`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
-  | visibility: ``boolean`` (optional) from :ref:`Shape <Hibernate version of class omero.model.Shape>`
+  | theC: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | theT: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | theZ: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | transform: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | vectorEffect: ``string`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | version: ``integer`` (optional) from :ref:`Shape <OMERO model class Shape>`
+  | visibility: ``boolean`` (optional) from :ref:`Shape <OMERO model class Shape>`
   | width: ``double`` (optional)
   | x: ``double`` (optional)
   | y: ``double`` (optional)
 
-.. _Hibernate version of class omero.model.RenderingDef:
+.. _OMERO model class RenderingDef:
 
 RenderingDef
 """"""""""""
 
-Used by: :ref:`ChannelBinding.renderingDef <Hibernate version of class omero.model.ChannelBinding>`, :ref:`CodomainMapContext.renderingDef <Hibernate version of class omero.model.CodomainMapContext>`, :ref:`ContrastStretchingContext.renderingDef <Hibernate version of class omero.model.ContrastStretchingContext>`, :ref:`Pixels.settings <Hibernate version of class omero.model.Pixels>`, :ref:`PlaneSlicingContext.renderingDef <Hibernate version of class omero.model.PlaneSlicingContext>`, :ref:`ReverseIntensityContext.renderingDef <Hibernate version of class omero.model.ReverseIntensityContext>`
+Used by: :ref:`ChannelBinding.renderingDef <OMERO model class ChannelBinding>`, :ref:`CodomainMapContext.renderingDef <OMERO model class CodomainMapContext>`, :ref:`ContrastStretchingContext.renderingDef <OMERO model class ContrastStretchingContext>`, :ref:`Pixels.settings <OMERO model class Pixels>`, :ref:`PlaneSlicingContext.renderingDef <OMERO model class PlaneSlicingContext>`, :ref:`ReverseIntensityContext.renderingDef <OMERO model class ReverseIntensityContext>`
 
 Properties:
   | compression: ``double`` (optional)
   | defaultT: ``integer``
   | defaultZ: ``integer``
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | model: :ref:`RenderingModel <Hibernate version of class omero.model.RenderingModel>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | model: :ref:`RenderingModel <OMERO model class RenderingModel>`
   | name: ``string`` (optional)
-  | pixels: :ref:`Pixels <Hibernate version of class omero.model.Pixels>`
-  | quantization: :ref:`QuantumDef <Hibernate version of class omero.model.QuantumDef>`
-  | spatialDomainEnhancement: :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>` (multiple)
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
-  | waveRendering: :ref:`ChannelBinding <Hibernate version of class omero.model.ChannelBinding>` (multiple)
+  | pixels: :ref:`Pixels <OMERO model class Pixels>`
+  | quantization: :ref:`QuantumDef <OMERO model class QuantumDef>`
+  | spatialDomainEnhancement: :ref:`CodomainMapContext <OMERO model class CodomainMapContext>` (multiple)
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
+  | waveRendering: :ref:`ChannelBinding <OMERO model class ChannelBinding>` (multiple)
 
-.. _Hibernate version of class omero.model.RenderingModel:
+.. _OMERO model class RenderingModel:
 
 RenderingModel
 """"""""""""""
 
-Used by: :ref:`RenderingDef.model <Hibernate version of class omero.model.RenderingDef>`
+Used by: :ref:`RenderingDef.model <OMERO model class RenderingDef>`
 
 Properties:
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | value: ``string``, see :source:`IEnum <components/model/src/ome/model/IEnum.java>`
+  | value: ``string``, see :javadoc:`IEnum <ome/model/IEnum.html>`
 
-.. _Hibernate version of class omero.model.ReverseIntensityContext:
+.. _OMERO model class ReverseIntensityContext:
 
 ReverseIntensityContext
 """""""""""""""""""""""
 
 Properties:
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
-  | details.permissions.perm1: ``long`` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
-  | renderingDef: :ref:`RenderingDef <Hibernate version of class omero.model.RenderingDef>` from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`CodomainMapContext <OMERO model class CodomainMapContext>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`CodomainMapContext <OMERO model class CodomainMapContext>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`CodomainMapContext <OMERO model class CodomainMapContext>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`CodomainMapContext <OMERO model class CodomainMapContext>`
+  | details.permissions.perm1: ``long`` from :ref:`CodomainMapContext <OMERO model class CodomainMapContext>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`CodomainMapContext <OMERO model class CodomainMapContext>`
+  | renderingDef: :ref:`RenderingDef <OMERO model class RenderingDef>` from :ref:`CodomainMapContext <OMERO model class CodomainMapContext>`
   | reverse: ``boolean``
-  | version: ``integer`` (optional) from :ref:`CodomainMapContext <Hibernate version of class omero.model.CodomainMapContext>`
+  | version: ``integer`` (optional) from :ref:`CodomainMapContext <OMERO model class CodomainMapContext>`
 
-.. _Hibernate version of class omero.model.Roi:
+.. _OMERO model class Roi:
 
 Roi
 """
 
-Used by: :ref:`Ellipse.roi <Hibernate version of class omero.model.Ellipse>`, :ref:`Image.rois <Hibernate version of class omero.model.Image>`, :ref:`Label.roi <Hibernate version of class omero.model.Label>`, :ref:`Line.roi <Hibernate version of class omero.model.Line>`, :ref:`Mask.roi <Hibernate version of class omero.model.Mask>`, :ref:`Path.roi <Hibernate version of class omero.model.Path>`, :ref:`Point.roi <Hibernate version of class omero.model.Point>`, :ref:`Polygon.roi <Hibernate version of class omero.model.Polygon>`, :ref:`Polyline.roi <Hibernate version of class omero.model.Polyline>`, :ref:`Rect.roi <Hibernate version of class omero.model.Rect>`, :ref:`RoiAnnotationLink.parent <Hibernate version of class omero.model.RoiAnnotationLink>`, :ref:`Shape.roi <Hibernate version of class omero.model.Shape>`
+Used by: :ref:`Ellipse.roi <OMERO model class Ellipse>`, :ref:`Image.rois <OMERO model class Image>`, :ref:`Label.roi <OMERO model class Label>`, :ref:`Line.roi <OMERO model class Line>`, :ref:`Mask.roi <OMERO model class Mask>`, :ref:`Path.roi <OMERO model class Path>`, :ref:`Point.roi <OMERO model class Point>`, :ref:`Polygon.roi <OMERO model class Polygon>`, :ref:`Polyline.roi <OMERO model class Polyline>`, :ref:`Rect.roi <OMERO model class Rect>`, :ref:`RoiAnnotationLink.parent <OMERO model class RoiAnnotationLink>`, :ref:`Shape.roi <OMERO model class Shape>`
 
 Properties:
-  | annotationLinks: :ref:`RoiAnnotationLink <Hibernate version of class omero.model.RoiAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`RoiAnnotationLink <OMERO model class RoiAnnotationLink>` (multiple)
   | description: ``text`` (optional)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | image: :ref:`Image <Hibernate version of class omero.model.Image>` (optional)
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | image: :ref:`Image <OMERO model class Image>` (optional)
   | keywords: list (optional)
   | name: ``string`` (optional)
   | namespaces: list (optional)
-  | shapes: :ref:`Shape <Hibernate version of class omero.model.Shape>` (multiple)
-  | source: :ref:`OriginalFile <Hibernate version of class omero.model.OriginalFile>` (optional)
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | shapes: :ref:`Shape <OMERO model class Shape>` (multiple)
+  | source: :ref:`OriginalFile <OMERO model class OriginalFile>` (optional)
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.RoiAnnotationLink:
+.. _OMERO model class RoiAnnotationLink:
 
 RoiAnnotationLink
 """""""""""""""""
 
-Used by: :ref:`Roi.annotationLinks <Hibernate version of class omero.model.Roi>`
+Used by: :ref:`Roi.annotationLinks <OMERO model class Roi>`
 
 Properties:
-  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Annotation <OMERO model class Annotation>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`Roi <Hibernate version of class omero.model.Roi>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`Roi <OMERO model class Roi>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.Screen:
+.. _OMERO model class Screen:
 
 Screen
 """"""
 
-Used by: :ref:`Reagent.screen <Hibernate version of class omero.model.Reagent>`, :ref:`ScreenAnnotationLink.parent <Hibernate version of class omero.model.ScreenAnnotationLink>`, :ref:`ScreenPlateLink.parent <Hibernate version of class omero.model.ScreenPlateLink>`
+Used by: :ref:`Reagent.screen <OMERO model class Reagent>`, :ref:`ScreenAnnotationLink.parent <OMERO model class ScreenAnnotationLink>`, :ref:`ScreenPlateLink.parent <OMERO model class ScreenPlateLink>`
 
 Properties:
-  | annotationLinks: :ref:`ScreenAnnotationLink <Hibernate version of class omero.model.ScreenAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`ScreenAnnotationLink <OMERO model class ScreenAnnotationLink>` (multiple)
   | description: ``text`` (optional)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
   | name: ``string``
-  | plateLinks: :ref:`ScreenPlateLink <Hibernate version of class omero.model.ScreenPlateLink>` (multiple)
+  | plateLinks: :ref:`ScreenPlateLink <OMERO model class ScreenPlateLink>` (multiple)
   | protocolDescription: ``string`` (optional)
   | protocolIdentifier: ``string`` (optional)
   | reagentSetDescription: ``string`` (optional)
   | reagentSetIdentifier: ``string`` (optional)
-  | reagents: :ref:`Reagent <Hibernate version of class omero.model.Reagent>` (multiple)
+  | reagents: :ref:`Reagent <OMERO model class Reagent>` (multiple)
   | type: ``string`` (optional)
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.ScreenAnnotationLink:
+.. _OMERO model class ScreenAnnotationLink:
 
 ScreenAnnotationLink
 """"""""""""""""""""
 
-Used by: :ref:`Screen.annotationLinks <Hibernate version of class omero.model.Screen>`
+Used by: :ref:`Screen.annotationLinks <OMERO model class Screen>`
 
 Properties:
-  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Annotation <OMERO model class Annotation>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`Screen <Hibernate version of class omero.model.Screen>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`Screen <OMERO model class Screen>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.ScreenPlateLink:
+.. _OMERO model class ScreenPlateLink:
 
 ScreenPlateLink
 """""""""""""""
 
-Used by: :ref:`Plate.screenLinks <Hibernate version of class omero.model.Plate>`, :ref:`Screen.plateLinks <Hibernate version of class omero.model.Screen>`
+Used by: :ref:`Plate.screenLinks <OMERO model class Plate>`, :ref:`Screen.plateLinks <OMERO model class Screen>`
 
 Properties:
-  | child: :ref:`Plate <Hibernate version of class omero.model.Plate>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Plate <OMERO model class Plate>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`Screen <Hibernate version of class omero.model.Screen>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`Screen <OMERO model class Screen>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.ScriptJob:
+.. _OMERO model class ScriptJob:
 
 ScriptJob
 """""""""
 
 Properties:
   | description: ``string`` (optional)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.permissions.perm1: ``long`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | finished: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | groupname: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | message: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | originalFileLinks: :ref:`JobOriginalFileLink <Hibernate version of class omero.model.JobOriginalFileLink>` (multiple) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | scheduledFor: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | started: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | status: :ref:`JobStatus <Hibernate version of class omero.model.JobStatus>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | submitted: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | type: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | username: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | version: ``integer`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Job <OMERO model class Job>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Job <OMERO model class Job>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Job <OMERO model class Job>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Job <OMERO model class Job>`
+  | details.permissions.perm1: ``long`` from :ref:`Job <OMERO model class Job>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Job <OMERO model class Job>`
+  | finished: ``timestamp`` (optional) from :ref:`Job <OMERO model class Job>`
+  | groupname: ``string`` from :ref:`Job <OMERO model class Job>`
+  | message: ``string`` from :ref:`Job <OMERO model class Job>`
+  | originalFileLinks: :ref:`JobOriginalFileLink <OMERO model class JobOriginalFileLink>` (multiple) from :ref:`Job <OMERO model class Job>`
+  | scheduledFor: ``timestamp`` from :ref:`Job <OMERO model class Job>`
+  | started: ``timestamp`` (optional) from :ref:`Job <OMERO model class Job>`
+  | status: :ref:`JobStatus <OMERO model class JobStatus>` from :ref:`Job <OMERO model class Job>`
+  | submitted: ``timestamp`` from :ref:`Job <OMERO model class Job>`
+  | type: ``string`` from :ref:`Job <OMERO model class Job>`
+  | username: ``string`` from :ref:`Job <OMERO model class Job>`
+  | version: ``integer`` (optional) from :ref:`Job <OMERO model class Job>`
 
-.. _Hibernate version of class omero.model.Session:
+.. _OMERO model class Session:
 
 Session
 """""""
 
-Subclasses: :ref:`Share <Hibernate version of class omero.model.Share>`
+Subclasses: :ref:`Share <OMERO model class Share>`
 
-Used by: :ref:`Event.session <Hibernate version of class omero.model.Event>`, :ref:`Node.sessions <Hibernate version of class omero.model.Node>`, :ref:`SessionAnnotationLink.parent <Hibernate version of class omero.model.SessionAnnotationLink>`
+Used by: :ref:`Event.session <OMERO model class Event>`, :ref:`Node.sessions <OMERO model class Node>`, :ref:`SessionAnnotationLink.parent <OMERO model class SessionAnnotationLink>`
 
 Properties:
-  | annotationLinks: :ref:`SessionAnnotationLink <Hibernate version of class omero.model.SessionAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`SessionAnnotationLink <OMERO model class SessionAnnotationLink>` (multiple)
   | closed: ``timestamp`` (optional)
   | defaultEventType: ``string``
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | events: :ref:`Event <Hibernate version of class omero.model.Event>` (multiple)
+  | events: :ref:`Event <OMERO model class Event>` (multiple)
   | message: ``text`` (optional)
-  | node: :ref:`Node <Hibernate version of class omero.model.Node>`
-  | owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | node: :ref:`Node <OMERO model class Node>`
+  | owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | started: ``timestamp``
   | timeToIdle: ``long``
   | timeToLive: ``long``
   | userAgent: ``string`` (optional)
   | userIP: ``string`` (optional)
   | uuid: ``string``
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.SessionAnnotationLink:
+.. _OMERO model class SessionAnnotationLink:
 
 SessionAnnotationLink
 """""""""""""""""""""
 
-Used by: :ref:`Session.annotationLinks <Hibernate version of class omero.model.Session>`, :ref:`Share.annotationLinks <Hibernate version of class omero.model.Share>`
+Used by: :ref:`Session.annotationLinks <OMERO model class Session>`, :ref:`Share.annotationLinks <OMERO model class Share>`
 
 Properties:
-  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Annotation <OMERO model class Annotation>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`Session <Hibernate version of class omero.model.Session>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`Session <OMERO model class Session>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.Shape:
+.. _OMERO model class Shape:
 
 Shape
 """""
 
-Subclasses: :ref:`Ellipse <Hibernate version of class omero.model.Ellipse>`, :ref:`Label <Hibernate version of class omero.model.Label>`, :ref:`Line <Hibernate version of class omero.model.Line>`, :ref:`Mask <Hibernate version of class omero.model.Mask>`, :ref:`Path <Hibernate version of class omero.model.Path>`, :ref:`Point <Hibernate version of class omero.model.Point>`, :ref:`Polygon <Hibernate version of class omero.model.Polygon>`, :ref:`Polyline <Hibernate version of class omero.model.Polyline>`, :ref:`Rect <Hibernate version of class omero.model.Rect>`
+Subclasses: :ref:`Ellipse <OMERO model class Ellipse>`, :ref:`Label <OMERO model class Label>`, :ref:`Line <OMERO model class Line>`, :ref:`Mask <OMERO model class Mask>`, :ref:`Path <OMERO model class Path>`, :ref:`Point <OMERO model class Point>`, :ref:`Polygon <OMERO model class Polygon>`, :ref:`Polyline <OMERO model class Polyline>`, :ref:`Rect <OMERO model class Rect>`
 
-Used by: :ref:`Roi.shapes <Hibernate version of class omero.model.Roi>`, :ref:`ShapeAnnotationLink.parent <Hibernate version of class omero.model.ShapeAnnotationLink>`
+Used by: :ref:`Roi.shapes <OMERO model class Roi>`, :ref:`ShapeAnnotationLink.parent <OMERO model class ShapeAnnotationLink>`
 
 Properties:
-  | annotationLinks: :ref:`ShapeAnnotationLink <Hibernate version of class omero.model.ShapeAnnotationLink>` (multiple)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | annotationLinks: :ref:`ShapeAnnotationLink <OMERO model class ShapeAnnotationLink>` (multiple)
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
   | fillColor: ``integer`` (optional)
   | fillRule: ``string`` (optional)
   | fontFamily: ``string`` (optional)
-  | fontSize.unit: enumeration (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | fontSize.value: ``double`` (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
+  | fontSize.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional)
+  | fontSize.value: ``double`` (optional)
   | fontStretch: ``string`` (optional)
   | fontStyle: ``string`` (optional)
   | fontVariant: ``string`` (optional)
   | fontWeight: ``string`` (optional)
   | g: ``string`` (optional)
   | locked: ``boolean`` (optional)
-  | roi: :ref:`Roi <Hibernate version of class omero.model.Roi>`
+  | roi: :ref:`Roi <OMERO model class Roi>`
   | strokeColor: ``integer`` (optional)
   | strokeDashArray: ``string`` (optional)
   | strokeDashOffset: ``integer`` (optional)
   | strokeLineCap: ``string`` (optional)
   | strokeLineJoin: ``string`` (optional)
   | strokeMiterLimit: ``integer`` (optional)
-  | strokeWidth.unit: enumeration (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | strokeWidth.value: ``double`` (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
+  | strokeWidth.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional)
+  | strokeWidth.value: ``double`` (optional)
   | theC: ``integer`` (optional)
   | theT: ``integer`` (optional)
   | theZ: ``integer`` (optional)
   | transform: ``string`` (optional)
   | vectorEffect: ``string`` (optional)
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
   | visibility: ``boolean`` (optional)
 
-.. _Hibernate version of class omero.model.ShapeAnnotationLink:
+.. _OMERO model class ShapeAnnotationLink:
 
 ShapeAnnotationLink
 """""""""""""""""""
 
-Used by: :ref:`Ellipse.annotationLinks <Hibernate version of class omero.model.Ellipse>`, :ref:`Label.annotationLinks <Hibernate version of class omero.model.Label>`, :ref:`Line.annotationLinks <Hibernate version of class omero.model.Line>`, :ref:`Mask.annotationLinks <Hibernate version of class omero.model.Mask>`, :ref:`Path.annotationLinks <Hibernate version of class omero.model.Path>`, :ref:`Point.annotationLinks <Hibernate version of class omero.model.Point>`, :ref:`Polygon.annotationLinks <Hibernate version of class omero.model.Polygon>`, :ref:`Polyline.annotationLinks <Hibernate version of class omero.model.Polyline>`, :ref:`Rect.annotationLinks <Hibernate version of class omero.model.Rect>`, :ref:`Shape.annotationLinks <Hibernate version of class omero.model.Shape>`
+Used by: :ref:`Ellipse.annotationLinks <OMERO model class Ellipse>`, :ref:`Label.annotationLinks <OMERO model class Label>`, :ref:`Line.annotationLinks <OMERO model class Line>`, :ref:`Mask.annotationLinks <OMERO model class Mask>`, :ref:`Path.annotationLinks <OMERO model class Path>`, :ref:`Point.annotationLinks <OMERO model class Point>`, :ref:`Polygon.annotationLinks <OMERO model class Polygon>`, :ref:`Polyline.annotationLinks <OMERO model class Polyline>`, :ref:`Rect.annotationLinks <OMERO model class Rect>`, :ref:`Shape.annotationLinks <OMERO model class Shape>`
 
 Properties:
-  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Annotation <OMERO model class Annotation>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`Shape <Hibernate version of class omero.model.Shape>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`Shape <OMERO model class Shape>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.Share:
+.. _OMERO model class Share:
 
 Share
 """""
 
-Used by: :ref:`ShareMember.parent <Hibernate version of class omero.model.ShareMember>`
+Used by: :ref:`ShareMember.parent <OMERO model class ShareMember>`
 
 Properties:
   | active: ``boolean``
-  | annotationLinks: :ref:`SessionAnnotationLink <Hibernate version of class omero.model.SessionAnnotationLink>` (multiple) from :ref:`Session <Hibernate version of class omero.model.Session>`
-  | closed: ``timestamp`` (optional) from :ref:`Session <Hibernate version of class omero.model.Session>`
+  | annotationLinks: :ref:`SessionAnnotationLink <OMERO model class SessionAnnotationLink>` (multiple) from :ref:`Session <OMERO model class Session>`
+  | closed: ``timestamp`` (optional) from :ref:`Session <OMERO model class Session>`
   | data: ``binary``
-  | defaultEventType: ``string`` from :ref:`Session <Hibernate version of class omero.model.Session>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Session <Hibernate version of class omero.model.Session>`
-  | details.permissions.perm1: ``long`` from :ref:`Session <Hibernate version of class omero.model.Session>`
-  | events: :ref:`Event <Hibernate version of class omero.model.Event>` (multiple) from :ref:`Session <Hibernate version of class omero.model.Session>`
-  | group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
+  | defaultEventType: ``string`` from :ref:`Session <OMERO model class Session>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Session <OMERO model class Session>`
+  | details.permissions.perm1: ``long`` from :ref:`Session <OMERO model class Session>`
+  | events: :ref:`Event <OMERO model class Event>` (multiple) from :ref:`Session <OMERO model class Session>`
+  | group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
   | itemCount: ``long``
-  | message: ``text`` (optional) from :ref:`Session <Hibernate version of class omero.model.Session>`
-  | node: :ref:`Node <Hibernate version of class omero.model.Node>` from :ref:`Session <Hibernate version of class omero.model.Session>`
-  | owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Session <Hibernate version of class omero.model.Session>`
-  | started: ``timestamp`` from :ref:`Session <Hibernate version of class omero.model.Session>`
-  | timeToIdle: ``long`` from :ref:`Session <Hibernate version of class omero.model.Session>`
-  | timeToLive: ``long`` from :ref:`Session <Hibernate version of class omero.model.Session>`
-  | userAgent: ``string`` (optional) from :ref:`Session <Hibernate version of class omero.model.Session>`
-  | userIP: ``string`` (optional) from :ref:`Session <Hibernate version of class omero.model.Session>`
-  | uuid: ``string`` from :ref:`Session <Hibernate version of class omero.model.Session>`
-  | version: ``integer`` (optional) from :ref:`Session <Hibernate version of class omero.model.Session>`
+  | message: ``text`` (optional) from :ref:`Session <OMERO model class Session>`
+  | node: :ref:`Node <OMERO model class Node>` from :ref:`Session <OMERO model class Session>`
+  | owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Session <OMERO model class Session>`
+  | started: ``timestamp`` from :ref:`Session <OMERO model class Session>`
+  | timeToIdle: ``long`` from :ref:`Session <OMERO model class Session>`
+  | timeToLive: ``long`` from :ref:`Session <OMERO model class Session>`
+  | userAgent: ``string`` (optional) from :ref:`Session <OMERO model class Session>`
+  | userIP: ``string`` (optional) from :ref:`Session <OMERO model class Session>`
+  | uuid: ``string`` from :ref:`Session <OMERO model class Session>`
+  | version: ``integer`` (optional) from :ref:`Session <OMERO model class Session>`
 
-.. _Hibernate version of class omero.model.ShareMember:
+.. _OMERO model class ShareMember:
 
 ShareMember
 """""""""""
 
 Properties:
-  | child: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
+  | child: :ref:`Experimenter <OMERO model class Experimenter>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
   | details.permissions.perm1: ``long``
-  | parent: :ref:`Share <Hibernate version of class omero.model.Share>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | parent: :ref:`Share <OMERO model class Share>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.StageLabel:
+.. _OMERO model class StageLabel:
 
 StageLabel
 """"""""""
 
-Used by: :ref:`Image.stageLabel <Hibernate version of class omero.model.Image>`
+Used by: :ref:`Image.stageLabel <OMERO model class Image>`
 
 Properties:
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
   | name: ``string``
-  | positionX.unit: enumeration (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | positionX.value: ``double`` (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | positionY.unit: enumeration (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | positionY.value: ``double`` (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | positionZ.unit: enumeration (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | positionZ.value: ``double`` (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | positionX.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional)
+  | positionX.value: ``double`` (optional)
+  | positionY.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional)
+  | positionY.value: ``double`` (optional)
+  | positionZ.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional)
+  | positionZ.value: ``double`` (optional)
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.StatsInfo:
+.. _OMERO model class StatsInfo:
 
 StatsInfo
 """""""""
 
-Used by: :ref:`Channel.statsInfo <Hibernate version of class omero.model.Channel>`
+Used by: :ref:`Channel.statsInfo <OMERO model class Channel>`
 
 Properties:
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
   | globalMax: ``double``
   | globalMin: ``double``
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.TagAnnotation:
+.. _OMERO model class TagAnnotation:
 
 TagAnnotation
 """""""""""""
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | description: ``text`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.permissions.perm1: ``long`` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | name: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | ns: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | textValue: ``text`` (optional) from :ref:`TextAnnotation <Hibernate version of class omero.model.TextAnnotation>`
-  | version: ``integer`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | annotationLinks: :ref:`AnnotationAnnotationLink <OMERO model class AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <OMERO model class Annotation>`
+  | description: ``text`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.permissions.perm1: ``long`` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Annotation <OMERO model class Annotation>`
+  | name: ``string`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | ns: ``string`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | textValue: ``text`` (optional) from :ref:`TextAnnotation <OMERO model class TextAnnotation>`
+  | version: ``integer`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
 
-.. _Hibernate version of class omero.model.TermAnnotation:
+.. _OMERO model class TermAnnotation:
 
 TermAnnotation
 """"""""""""""
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | description: ``text`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.permissions.perm1: ``long`` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | name: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | ns: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | annotationLinks: :ref:`AnnotationAnnotationLink <OMERO model class AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <OMERO model class Annotation>`
+  | description: ``text`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.permissions.perm1: ``long`` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Annotation <OMERO model class Annotation>`
+  | name: ``string`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | ns: ``string`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
   | termValue: ``text`` (optional)
-  | version: ``integer`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | version: ``integer`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
 
-.. _Hibernate version of class omero.model.TextAnnotation:
+.. _OMERO model class TextAnnotation:
 
 TextAnnotation
 """"""""""""""
 
-Subclasses: :ref:`CommentAnnotation <Hibernate version of class omero.model.CommentAnnotation>`, :ref:`TagAnnotation <Hibernate version of class omero.model.TagAnnotation>`, :ref:`XmlAnnotation <Hibernate version of class omero.model.XmlAnnotation>`
+Subclasses: :ref:`CommentAnnotation <OMERO model class CommentAnnotation>`, :ref:`TagAnnotation <OMERO model class TagAnnotation>`, :ref:`XmlAnnotation <OMERO model class XmlAnnotation>`
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | description: ``text`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.permissions.perm1: ``long`` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | name: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | ns: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | annotationLinks: :ref:`AnnotationAnnotationLink <OMERO model class AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <OMERO model class Annotation>`
+  | description: ``text`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.permissions.perm1: ``long`` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Annotation <OMERO model class Annotation>`
+  | name: ``string`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | ns: ``string`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
   | textValue: ``text`` (optional)
-  | version: ``integer`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | version: ``integer`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
 
-.. _Hibernate version of class omero.model.Thumbnail:
+.. _OMERO model class Thumbnail:
 
 Thumbnail
 """""""""
 
-Used by: :ref:`Pixels.thumbnails <Hibernate version of class omero.model.Pixels>`
+Used by: :ref:`Pixels.thumbnails <OMERO model class Pixels>`
 
 Properties:
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
   | mimeType: ``string``
-  | pixels: :ref:`Pixels <Hibernate version of class omero.model.Pixels>`
+  | pixels: :ref:`Pixels <OMERO model class Pixels>`
   | ref: ``string`` (optional)
   | sizeX: ``integer``
   | sizeY: ``integer``
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.ThumbnailGenerationJob:
+.. _OMERO model class ThumbnailGenerationJob:
 
 ThumbnailGenerationJob
 """"""""""""""""""""""
 
 Properties:
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.permissions.perm1: ``long`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | finished: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | groupname: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | message: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | originalFileLinks: :ref:`JobOriginalFileLink <Hibernate version of class omero.model.JobOriginalFileLink>` (multiple) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | scheduledFor: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | started: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | status: :ref:`JobStatus <Hibernate version of class omero.model.JobStatus>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | submitted: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | type: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | username: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | version: ``integer`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Job <OMERO model class Job>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Job <OMERO model class Job>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Job <OMERO model class Job>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Job <OMERO model class Job>`
+  | details.permissions.perm1: ``long`` from :ref:`Job <OMERO model class Job>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Job <OMERO model class Job>`
+  | finished: ``timestamp`` (optional) from :ref:`Job <OMERO model class Job>`
+  | groupname: ``string`` from :ref:`Job <OMERO model class Job>`
+  | message: ``string`` from :ref:`Job <OMERO model class Job>`
+  | originalFileLinks: :ref:`JobOriginalFileLink <OMERO model class JobOriginalFileLink>` (multiple) from :ref:`Job <OMERO model class Job>`
+  | scheduledFor: ``timestamp`` from :ref:`Job <OMERO model class Job>`
+  | started: ``timestamp`` (optional) from :ref:`Job <OMERO model class Job>`
+  | status: :ref:`JobStatus <OMERO model class JobStatus>` from :ref:`Job <OMERO model class Job>`
+  | submitted: ``timestamp`` from :ref:`Job <OMERO model class Job>`
+  | type: ``string`` from :ref:`Job <OMERO model class Job>`
+  | username: ``string`` from :ref:`Job <OMERO model class Job>`
+  | version: ``integer`` (optional) from :ref:`Job <OMERO model class Job>`
 
-.. _Hibernate version of class omero.model.TimestampAnnotation:
+.. _OMERO model class TimestampAnnotation:
 
 TimestampAnnotation
 """""""""""""""""""
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | description: ``text`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.permissions.perm1: ``long`` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | name: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | ns: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | annotationLinks: :ref:`AnnotationAnnotationLink <OMERO model class AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <OMERO model class Annotation>`
+  | description: ``text`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.permissions.perm1: ``long`` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Annotation <OMERO model class Annotation>`
+  | name: ``string`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | ns: ``string`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
   | timeValue: ``timestamp`` (optional)
-  | version: ``integer`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | version: ``integer`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
 
-.. _Hibernate version of class omero.model.TransmittanceRange:
+.. _OMERO model class TransmittanceRange:
 
 TransmittanceRange
 """"""""""""""""""
 
-Used by: :ref:`Filter.transmittanceRange <Hibernate version of class omero.model.Filter>`
+Used by: :ref:`Filter.transmittanceRange <OMERO model class Filter>`
 
 Properties:
-  | cutIn.unit: enumeration (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | cutIn.value: ``double`` (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | cutInTolerance.unit: enumeration (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | cutInTolerance.value: ``double`` (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | cutOut.unit: enumeration (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | cutOut.value: ``double`` (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | cutOutTolerance.unit: enumeration (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | cutOutTolerance.value: ``double`` (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | cutIn.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional)
+  | cutIn.value: ``double`` (optional)
+  | cutInTolerance.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional)
+  | cutInTolerance.value: ``double`` (optional)
+  | cutOut.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional)
+  | cutOut.value: ``double`` (optional)
+  | cutOutTolerance.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional)
+  | cutOutTolerance.value: ``double`` (optional)
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
   | transmittance: ``double`` (optional)
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.TypeAnnotation:
+.. _OMERO model class TypeAnnotation:
 
 TypeAnnotation
 """"""""""""""
 
-Subclasses: :ref:`FileAnnotation <Hibernate version of class omero.model.FileAnnotation>`
+Subclasses: :ref:`FileAnnotation <OMERO model class FileAnnotation>`
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | description: ``text`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.permissions.perm1: ``long`` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | name: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | ns: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | version: ``integer`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | annotationLinks: :ref:`AnnotationAnnotationLink <OMERO model class AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <OMERO model class Annotation>`
+  | description: ``text`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.permissions.perm1: ``long`` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Annotation <OMERO model class Annotation>`
+  | name: ``string`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | ns: ``string`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | version: ``integer`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
 
-.. _Hibernate version of class omero.model.UploadJob:
+.. _OMERO model class UploadJob:
 
 UploadJob
 """""""""
 
 Properties:
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.permissions.perm1: ``long`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | finished: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | groupname: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | message: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | originalFileLinks: :ref:`JobOriginalFileLink <Hibernate version of class omero.model.JobOriginalFileLink>` (multiple) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | scheduledFor: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | started: ``timestamp`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | status: :ref:`JobStatus <Hibernate version of class omero.model.JobStatus>` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | submitted: ``timestamp`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | type: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | username: ``string`` from :ref:`Job <Hibernate version of class omero.model.Job>`
-  | version: ``integer`` (optional) from :ref:`Job <Hibernate version of class omero.model.Job>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Job <OMERO model class Job>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Job <OMERO model class Job>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Job <OMERO model class Job>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Job <OMERO model class Job>`
+  | details.permissions.perm1: ``long`` from :ref:`Job <OMERO model class Job>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Job <OMERO model class Job>`
+  | finished: ``timestamp`` (optional) from :ref:`Job <OMERO model class Job>`
+  | groupname: ``string`` from :ref:`Job <OMERO model class Job>`
+  | message: ``string`` from :ref:`Job <OMERO model class Job>`
+  | originalFileLinks: :ref:`JobOriginalFileLink <OMERO model class JobOriginalFileLink>` (multiple) from :ref:`Job <OMERO model class Job>`
+  | scheduledFor: ``timestamp`` from :ref:`Job <OMERO model class Job>`
+  | started: ``timestamp`` (optional) from :ref:`Job <OMERO model class Job>`
+  | status: :ref:`JobStatus <OMERO model class JobStatus>` from :ref:`Job <OMERO model class Job>`
+  | submitted: ``timestamp`` from :ref:`Job <OMERO model class Job>`
+  | type: ``string`` from :ref:`Job <OMERO model class Job>`
+  | username: ``string`` from :ref:`Job <OMERO model class Job>`
+  | version: ``integer`` (optional) from :ref:`Job <OMERO model class Job>`
   | versionInfo: list (multiple)
 
-.. _Hibernate version of class omero.model.Well:
+.. _OMERO model class Well:
 
 Well
 """"
 
-Used by: :ref:`Plate.wells <Hibernate version of class omero.model.Plate>`, :ref:`WellAnnotationLink.parent <Hibernate version of class omero.model.WellAnnotationLink>`, :ref:`WellReagentLink.parent <Hibernate version of class omero.model.WellReagentLink>`, :ref:`WellSample.well <Hibernate version of class omero.model.WellSample>`
+Used by: :ref:`Plate.wells <OMERO model class Plate>`, :ref:`WellAnnotationLink.parent <OMERO model class WellAnnotationLink>`, :ref:`WellReagentLink.parent <OMERO model class WellReagentLink>`, :ref:`WellSample.well <OMERO model class WellSample>`
 
 Properties:
   | alpha: ``integer`` (optional)
-  | annotationLinks: :ref:`WellAnnotationLink <Hibernate version of class omero.model.WellAnnotationLink>` (multiple)
+  | annotationLinks: :ref:`WellAnnotationLink <OMERO model class WellAnnotationLink>` (multiple)
   | blue: ``integer`` (optional)
   | column: ``integer`` (optional)
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
   | externalDescription: ``string`` (optional)
   | externalIdentifier: ``string`` (optional)
   | green: ``integer`` (optional)
-  | plate: :ref:`Plate <Hibernate version of class omero.model.Plate>`
-  | reagentLinks: :ref:`WellReagentLink <Hibernate version of class omero.model.WellReagentLink>` (multiple)
+  | plate: :ref:`Plate <OMERO model class Plate>`
+  | reagentLinks: :ref:`WellReagentLink <OMERO model class WellReagentLink>` (multiple)
   | red: ``integer`` (optional)
   | row: ``integer`` (optional)
   | status: ``string`` (optional)
   | type: ``string`` (optional)
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
-  | wellSamples: :ref:`WellSample <Hibernate version of class omero.model.WellSample>` (multiple)
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
+  | wellSamples: :ref:`WellSample <OMERO model class WellSample>` (multiple)
 
-.. _Hibernate version of class omero.model.WellAnnotationLink:
+.. _OMERO model class WellAnnotationLink:
 
 WellAnnotationLink
 """"""""""""""""""
 
-Used by: :ref:`Well.annotationLinks <Hibernate version of class omero.model.Well>`
+Used by: :ref:`Well.annotationLinks <OMERO model class Well>`
 
 Properties:
-  | child: :ref:`Annotation <Hibernate version of class omero.model.Annotation>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Annotation <OMERO model class Annotation>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`Well <Hibernate version of class omero.model.Well>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`Well <OMERO model class Well>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.WellReagentLink:
+.. _OMERO model class WellReagentLink:
 
 WellReagentLink
 """""""""""""""
 
-Used by: :ref:`Reagent.wellLinks <Hibernate version of class omero.model.Reagent>`, :ref:`Well.reagentLinks <Hibernate version of class omero.model.Well>`
+Used by: :ref:`Reagent.wellLinks <OMERO model class Reagent>`, :ref:`Well.reagentLinks <OMERO model class Well>`
 
 Properties:
-  | child: :ref:`Reagent <Hibernate version of class omero.model.Reagent>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | child: :ref:`Reagent <OMERO model class Reagent>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | parent: :ref:`Well <Hibernate version of class omero.model.Well>`, see :source:`ILink <components/model/src/ome/model/ILink.java>`
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | parent: :ref:`Well <OMERO model class Well>`, see :javadoc:`ILink <ome/model/ILink.html>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 
-.. _Hibernate version of class omero.model.WellSample:
+.. _OMERO model class WellSample:
 
 WellSample
 """"""""""
 
-Used by: :ref:`Image.wellSamples <Hibernate version of class omero.model.Image>`, :ref:`PlateAcquisition.wellSample <Hibernate version of class omero.model.PlateAcquisition>`, :ref:`Well.wellSamples <Hibernate version of class omero.model.Well>`
+Used by: :ref:`Image.wellSamples <OMERO model class Image>`, :ref:`PlateAcquisition.wellSample <OMERO model class PlateAcquisition>`, :ref:`Well.wellSamples <OMERO model class Well>`
 
 Properties:
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional)
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional)
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>`
   | details.permissions.perm1: ``long``
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>`
-  | image: :ref:`Image <Hibernate version of class omero.model.Image>`
-  | plateAcquisition: :ref:`PlateAcquisition <Hibernate version of class omero.model.PlateAcquisition>` (optional)
-  | posX.unit: enumeration (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | posX.value: ``double`` (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | posY.unit: enumeration (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
-  | posY.value: ``double`` (optional), see :javadoc:`LengthI <omero/model/LengthI.html>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>`
+  | image: :ref:`Image <OMERO model class Image>`
+  | plateAcquisition: :ref:`PlateAcquisition <OMERO model class PlateAcquisition>` (optional)
+  | posX.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional)
+  | posX.value: ``double`` (optional)
+  | posY.unit: enumeration of :javadoc:`Length <ome/model/units/Length.html>` (optional)
+  | posY.value: ``double`` (optional)
   | timepoint: ``timestamp`` (optional)
-  | version: ``integer`` (optional), see :source:`IMutable <components/model/src/ome/model/IMutable.java>`
-  | well: :ref:`Well <Hibernate version of class omero.model.Well>`
+  | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
+  | well: :ref:`Well <OMERO model class Well>`
 
-.. _Hibernate version of class omero.model.XmlAnnotation:
+.. _OMERO model class XmlAnnotation:
 
 XmlAnnotation
 """""""""""""
 
 Properties:
-  | annotationLinks: :ref:`AnnotationAnnotationLink <Hibernate version of class omero.model.AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | description: ``text`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.creationEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.externalInfo: :ref:`ExternalInfo <Hibernate version of class omero.model.ExternalInfo>` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.group: :ref:`ExperimenterGroup <Hibernate version of class omero.model.ExperimenterGroup>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.owner: :ref:`Experimenter <Hibernate version of class omero.model.Experimenter>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.permissions.perm1: ``long`` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | details.updateEvent: :ref:`Event <Hibernate version of class omero.model.Event>` from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | name: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | ns: ``string`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
-  | textValue: ``text`` (optional) from :ref:`TextAnnotation <Hibernate version of class omero.model.TextAnnotation>`
-  | version: ``integer`` (optional) from :ref:`Annotation <Hibernate version of class omero.model.Annotation>`
+  | annotationLinks: :ref:`AnnotationAnnotationLink <OMERO model class AnnotationAnnotationLink>` (multiple) from :ref:`Annotation <OMERO model class Annotation>`
+  | description: ``text`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | details.creationEvent: :ref:`Event <OMERO model class Event>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.externalInfo: :ref:`ExternalInfo <OMERO model class ExternalInfo>` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | details.group: :ref:`ExperimenterGroup <OMERO model class ExperimenterGroup>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.owner: :ref:`Experimenter <OMERO model class Experimenter>` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.permissions.perm1: ``long`` from :ref:`Annotation <OMERO model class Annotation>`
+  | details.updateEvent: :ref:`Event <OMERO model class Event>` from :ref:`Annotation <OMERO model class Annotation>`
+  | name: ``string`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | ns: ``string`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
+  | textValue: ``text`` (optional) from :ref:`TextAnnotation <OMERO model class TextAnnotation>`
+  | version: ``integer`` (optional) from :ref:`Annotation <OMERO model class Annotation>`
 


### PR DESCRIPTION
Automatically generated from https://github.com/openmicroscopy/openmicroscopy/pull/4010. Staged at http://www.openmicroscopy.org/site/support/omero5.2-staging/developers/Model/EveryObject.html. There should now be links from dimensioned quantities to reasonable units Javadoc.

Also shortens anchor names.

--rebased-to #1260
