### PR TITLE
add note of Chmod2 to graphs documentation

### DIFF
--- a/omero/developers/Server/GraphsMigration.txt
+++ b/omero/developers/Server/GraphsMigration.txt
@@ -9,9 +9,11 @@ through the API via :javadoc:`Chgrp2
 <slice2html/omero/cmd/Chgrp2.html>`, :javadoc:`Chown2
 <slice2html/omero/cmd/Chown2.html>`, :javadoc:`Delete2
 <slice2html/omero/cmd/Delete2.html>`, and their superclass
-:javadoc:`GraphModify2 <slice2html/omero/cmd/GraphModify2.html>`. The
+:javadoc:`GraphModify2 <slice2html/omero/cmd/GraphModify2.html>`. OMERO
+5.1.2 adds :javadoc:`Chmod2 <slice2html/omero/cmd/Chmod2.html>`. The
 legacy request operations :javadoc:`Chgrp
-<slice2html/omero/cmd/Chgrp.html>`, :javadoc:`Chown
+<slice2html/omero/cmd/Chgrp.html>`, :javadoc:`Chmod
+<slice2html/omero/cmd/Chmod.html>`, :javadoc:`Chown
 <slice2html/omero/cmd/Chown.html>`, :javadoc:`Delete
 <slice2html/omero/cmd/Delete.html>`, and their superclass
 :javadoc:`GraphModify <slice2html/omero/cmd/GraphModify.html>`, are now

--- a/omero/developers/whatsnew.txt
+++ b/omero/developers/whatsnew.txt
@@ -51,7 +51,8 @@ deprecated. They are replaced by :javadoc:`Chgrp2
 <slice2html/omero/cmd/Chgrp2.html>`, :javadoc:`Chown2
 <slice2html/omero/cmd/Chown2.html>`, :javadoc:`Delete2
 <slice2html/omero/cmd/Delete2.html>`, and their superclass
-:javadoc:`GraphModify2 <slice2html/omero/cmd/GraphModify2.html>`. To
+:javadoc:`GraphModify2 <slice2html/omero/cmd/GraphModify2.html>`. OMERO
+5.1.2 adds :javadoc:`Chmod2 <slice2html/omero/cmd/Chmod2.html>`. To
 allow each deprecated request to be implemented by its corresponding
 replacement, a partial API compatibility layer is included in OMERO 5.1
 and is activated by default through the new configuration property


### PR DESCRIPTION
See http://www.openmicroscopy.org/site/support/omero5.1/developers/whatsnew.html and http://www.openmicroscopy.org/site/support/omero5.1/developers/Server/GraphsMigration.html for mentions of how Chmod has been replaced.