### PR TITLE
Updating branch of 'source/edit on github' links

### DIFF
--- a/common/conf.py
+++ b/common/conf.py
@@ -54,7 +54,7 @@ extensions = ['omerodocs', 'sphinx.ext.extlinks', 'edit_on_github']
 
 # Configuration for the edit_on_github extension
 edit_on_github_project = 'openmicroscopy/ome-documentation'
-edit_on_github_branch = 'develop'
+edit_on_github_branch = 'dev_5_1'
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['../common/_templates']

--- a/common/conf.py
+++ b/common/conf.py
@@ -110,7 +110,7 @@ pygments_style = 'sphinx'
 if "SOURCE_BRANCH" in os.environ and len(os.environ.get('SOURCE_BRANCH')) > 0:
     branch = os.environ.get('SOURCE_BRANCH')
 else:
-    branch = 'develop'
+    branch = 'dev_5_1'
 
 if "SOURCE_USER" in os.environ and len(os.environ.get('SOURCE_USER')) > 0:
     user = os.environ.get('SOURCE_USER')


### PR DESCRIPTION
See https://trello.com/c/3yYuGGxL/155-dev-5-1-branch-creation-tasks
Once built, the 'Show on Github' and 'Edit on Github' links at the bottom of the sidebar on all the OMERO 5.1-staging pages should point at the dev_5_1 branch rather than develop