### PR TITLE
Updating web example links to webtest

### DIFF
--- a/omero/developers/Web/ViewPort.txt
+++ b/omero/developers/Web/ViewPort.txt
@@ -118,5 +118,5 @@ Then in ``<BODY>`` insert the following:
 The viewport can be made more interactive by adding buttons or links to allow
 display of scalebars, ROIs, zooming and selection of channels. Full examples
 of how to embed microscopy or Whole Slide Image are available
-:source:`here <examples/Web>`.
+:source:`here <templates/webtest/examples>`.
 

--- a/omero/developers/Web/ViewPort.txt
+++ b/omero/developers/Web/ViewPort.txt
@@ -117,6 +117,6 @@ Then in ``<BODY>`` insert the following:
 
 The viewport can be made more interactive by adding buttons or links to allow
 display of scalebars, ROIs, zooming and selection of channels. Full examples
-of how to embed microscopy or Whole Slide Image are available
-:source:`here <templates/webtest/examples>`.
+of how to embed microscopy or Whole Slide Image are available in the
+`Webtest Github repository <https://github.com/openmicroscopy/webtest/tree/master/templates/webtest/examples>`_.
 


### PR DESCRIPTION
Ola's PR https://github.com/openmicroscopy/openmicroscopy/pull/4023 removed the web examples as they are now in webtest, this updates the link in the web developer docs to point at the new location.