### PR TITLE
Updating conf.py files for develop branch

### DIFF
--- a/common/conf.py
+++ b/common/conf.py
@@ -159,15 +159,15 @@ extlinks = {
     'schema_plone' : (oo_root + '/Schemas/%s', ''),
     'omero_plone' : (oo_site_root + '/products/omero/%s', ''),
     'secvuln' : (oo_root + '/info/vulnerabilities/%s', ''),
-    'omero_doc' : (oo_site_root + '/support/omero5.1/%s', ''),
+    'omero_doc' : (oo_site_root + '/support/omero5.2/%s', ''),
     'model_doc' : (oo_site_root + '/support/ome-model/%s', ''),
     'devs_doc' : (oo_site_root + '/support/contributing/%s', ''),
     'bf_plone' : (oo_site_root + '/products/bio-formats/%s', ''),
-    'bf_doc' : (oo_site_root + '/support/bio-formats5.1/%s', ''),
+    'bf_doc' : (oo_site_root + '/support/bio-formats5.2/%s', ''),
     'partner_plone' : (oo_site_root + '/products/partner/%s', ''),
     # Downloads
-    'downloads' : (downloads_root + '/latest/omero5.1/%s', ''),
-    'bf_downloads' : (downloads_root + '/latest/bio-formats5.1/%s', ''),
+    'downloads' : (downloads_root + '/latest/omero5.2/%s', ''),
+    'bf_downloads' : (downloads_root + '/latest/bio-formats5.2/%s', ''),
     # Help links
     'help' : (help_root + '/%s', ''),
     # Miscellaneous links

--- a/common/conf.py
+++ b/common/conf.py
@@ -159,15 +159,12 @@ extlinks = {
     'schema_plone' : (oo_root + '/Schemas/%s', ''),
     'omero_plone' : (oo_site_root + '/products/omero/%s', ''),
     'secvuln' : (oo_root + '/info/vulnerabilities/%s', ''),
-    'omero_doc' : (oo_site_root + '/support/omero5.2/%s', ''),
+    'bf_plone' : (oo_site_root + '/products/bio-formats/%s', ''),
+    'partner_plone' : (oo_site_root + '/products/partner/%s', ''),
+    # One branch only doc links. Branched docs links in conf.py files for
+    # individual doc sets
     'model_doc' : (oo_site_root + '/support/ome-model/%s', ''),
     'devs_doc' : (oo_site_root + '/support/contributing/%s', ''),
-    'bf_plone' : (oo_site_root + '/products/bio-formats/%s', ''),
-    'bf_doc' : (oo_site_root + '/support/bio-formats5.2/%s', ''),
-    'partner_plone' : (oo_site_root + '/products/partner/%s', ''),
-    # Downloads
-    'downloads' : (downloads_root + '/latest/omero5.2/%s', ''),
-    'bf_downloads' : (downloads_root + '/latest/bio-formats5.2/%s', ''),
     # Help links
     'help' : (help_root + '/%s', ''),
     # Miscellaneous links

--- a/contributing/conf.py
+++ b/contributing/conf.py
@@ -34,6 +34,9 @@ contributing_extlinks = {
     'bf_source' : (bf_github_root + 'blob/'+ branch + '/%s', ''),
     'bf_sourcedir' : (bf_github_root + 'tree/'+ branch + '/%s', ''),
     'bf_commit' : (bf_github_root + 'commit/%s', ''),
+    # Doc links
+    'omero_doc' : (oo_site_root + '/support/omero/%s', ''),
+    'bf_doc' : (oo_site_root + '/support/bio-formats/%s', ''),
     }
 extlinks.update(contributing_extlinks)
 

--- a/formats/conf.py
+++ b/formats/conf.py
@@ -43,6 +43,11 @@ model_extlinks = {
     'omero_source' : (omero_github_root + 'blob/'+ branch + '/%s', ''),
     # API
     'javadoc' : (downloads_root + '/latest/bio-formats5.1/api/%s', ''),
+    # Doc links
+    'omero_doc' : (oo_site_root + '/support/omero5.1/%s', ''),
+    'bf_doc' : (oo_site_root + '/support/bio-formats5.1/%s', ''),
+    # Downloads
+    'bf_downloads' : (downloads_root + '/latest/bio-formats5.1/%s', ''),
     }
 extlinks.update(model_extlinks)
 

--- a/omero/conf.py
+++ b/omero/conf.py
@@ -82,9 +82,13 @@ omero_extlinks = {
     'commit' : (omero_github_root + 'commit/%s', ''),
     'omedocs' : (doc_github_root + '%s', ''),
     # API links
-    'javadoc' : (downloads_root + '/latest/omero5.2/api/%s', ''),
-    'pythondoc' : (downloads_root + '/latest/omero5.2/api/python/%s', ''),
-    # Virtual Appliance downloads
+    'javadoc' : (downloads_root + '/latest/omero/api/%s', ''),
+    'pythondoc' : (downloads_root + '/latest/omero/api/python/%s', ''),
+    # Doc links
+    'bf_doc' : (oo_site_root + '/support/bio-formats/%s', ''),
+    # Downloads
+    'downloads' : (downloads_root + '/latest/omero/%s', ''),
+    'bf_downloads' : (downloads_root + '/latest/bio-formats/%s', ''),
     'downloads_va' : (downloads_root + '/latest/omero-virtual-appliance/%s', ''),
     # Miscellaneous links
     'springdoc' : ('http://docs.spring.io/spring/docs/%s', ''),

--- a/omero/conf.py
+++ b/omero/conf.py
@@ -46,8 +46,8 @@ else:
     release = 'UNKNOWN'
 
 rst_prolog = """
-.. note:: **This documentation is for the new OMERO 5.1. version.** See the `latest OMERO 5.0.x
-    version <http://www.openmicroscopy.org/site/support/omero5.0/>`_ or the
+.. note:: **This documentation is for the new OMERO 5.2 version.** See the `latest OMERO 5.1.x
+    version <http://www.openmicroscopy.org/site/support/omero5.1/>`_ or the
     :legacy_plone:`previous versions <>` page to find documentation for the
     OMERO version you are using if you have not upgraded yet.
 """
@@ -82,8 +82,8 @@ omero_extlinks = {
     'commit' : (omero_github_root + 'commit/%s', ''),
     'omedocs' : (doc_github_root + '%s', ''),
     # API links
-    'javadoc' : (downloads_root + '/latest/omero5.1/api/%s', ''),
-    'pythondoc' : (downloads_root + '/latest/omero5.1/api/python/%s', ''),
+    'javadoc' : (downloads_root + '/latest/omero5.2/api/%s', ''),
+    'pythondoc' : (downloads_root + '/latest/omero5.2/api/python/%s', ''),
     # Virtual Appliance downloads
     'downloads_va' : (downloads_root + '/latest/omero-virtual-appliance/%s', ''),
     # Miscellaneous links

--- a/omero/conf.py
+++ b/omero/conf.py
@@ -88,7 +88,6 @@ omero_extlinks = {
     'bf_doc' : (oo_site_root + '/support/bio-formats/%s', ''),
     # Downloads
     'downloads' : (downloads_root + '/latest/omero/%s', ''),
-    'bf_downloads' : (downloads_root + '/latest/bio-formats/%s', ''),
     'downloads_va' : (downloads_root + '/latest/omero-virtual-appliance/%s', ''),
     # Miscellaneous links
     'springdoc' : ('http://docs.spring.io/spring/docs/%s', ''),

--- a/omero/developers/testing.txt
+++ b/omero/developers/testing.txt
@@ -53,7 +53,7 @@ Integration tests assume that:
   :file:`etc/ice.config` file should be enough to configure a running server
   for integration testing. This means that code creating a client connection
   as outlined in
-  :omero_doc:`developers/GettingStarted/AdvancedClientDevelopment.html`
+  :doc:`GettingStarted/AdvancedClientDevelopment`
   should execute without errors.
 - An OMERO.server instance is running on the host and port specified in
   the :envvar:`ICE_CONFIG` file.


### PR DESCRIPTION
Linking to branched/version-specific docs in the common folder isn't compatible with our new decoupled strategy so this moves the branch-specific links into the conf.py files for the specific docs sets. Current Model & format docs are versioned for 5.1 so I've kept those links version specific while making the links for OMERO 5.2 just point at latest for now as for example, no 5.2 downloads are available yet. 

Also tidied a link that was mistakenly using an external formatted link for an internal doc link and updated the banner for the 5.2 staging docs so as not to confuse anyone.
