### PR TITLE
Contributing: snoopy URLs

### DIFF
--- a/contributing/ci-bio-formats.txt
+++ b/contributing/ci-bio-formats.txt
@@ -95,7 +95,8 @@ The branch for the 5.1.x series of Bio-Formats is develop.
 		#. Builds the Java generated sources using ``ant clean ome-xml-src``
 		#. Builds the C++ generated sources using ``cmake .. && make gensrc``
 		#. Commits all the generated sources
-		#. Pushes the branch to develop/latest/generated-sources. This branch
+		#. Pushes the branch to 
+		   :bf_scc_branch:`develop/latest/generated_sources`. This branch
 		   can be used as the baseline for comparison with other generated
 		   source jobs like :term:`BIOFORMATS-5.1-merge-generated-sources`
 
@@ -124,14 +125,13 @@ The branch for the 5.1.x series of Bio-Formats is develop.
 		This job merges all the PRs opened against develop
 
 		#. |merge|
-		#. Pushes the branch to develop/merge/daily
+		#. Pushes the branch to :bf_scc_branch:`develop/merge/daily`
 
 	:jenkinsjob:`BIOFORMATS-5.1-merge-build`
 
 		This job builds the merge artifacts of Bio-Formats
 
-		#. Checks out the develop/merge/daily branch of the
-		   snoopycrimecop fork of bioformats.git_
+		#. Checks out :bf_scc_branch:`develop/merge/daily`
 		#. |buildBF|
 		#. |fulltestBF|
 		#. Triggers :term:`BIOFORMATS-5.1-merge-matlab`
@@ -140,12 +140,11 @@ The branch for the 5.1.x series of Bio-Formats is develop.
 
 		This job builds the merge generated sources of Bio-Formats
 
-		#. Checks out the develop/merge/daily branch of the
-		   snoopycrimecop fork of bioformats.git_
+		#. Checks out :bf_scc_branch:`develop/merge/daily`
 		#. Builds the Java generated sources using ``ant clean ome-xml-src``
 		#. Builds the C++ generated sources using ``cmake .. && make gensrc``
-		#. Commits all the generated sources and pushes to the
-		   develop/merge/generated-sources branch
+		#. Commits all the generated sources and pushes to
+		   :bf_scc_branch:`develop/merge/generated_sources` branch
 		#. Computes the diff with develop/latest/generated-sources and archives
 		   the artifacts
 
@@ -167,16 +166,14 @@ The branch for the 5.1.x series of Bio-Formats is develop.
 
 		This job runs automated tests against the full repository on Linux
 
-		#. Checks out the develop/merge/daily branch of the
-		   snoopycrimecop fork of bioformats.git_
+		#. Checks out :bf_scc_branch:`develop/merge/daily`
 		#. Runs automated tests against :file:`/ome/data_repo/from_skyking/`
 
 	:jenkinsjob:`BIOFORMATS-5.1-merge-full-repository-win`
 
 		This job runs automated tests against the full repository on Windows
 
-		#. Checks out the develop/merge/daily branch of the
-		   snoopycrimecop fork of bioformats.git_
+		#. Checks out :bf_scc_branch:`develop/merge/daily`
 		#. Runs automated tests against
 		   :file:`\\\\squig.openmicroscopy.org.uk\\ome-data-repo\\from_skyking`
 
@@ -185,8 +182,7 @@ The branch for the 5.1.x series of Bio-Formats is develop.
 		This job runs automated tests against the test_images_good subset on
 		Linux
 
-		#. Checks out the develop/merge/daily branch of the
-		   snoopycrimecop fork of bioformats.git_
+		#. Checks out :bf_scc_branch:`develop/merge/daily`
 		#. Runs automated tests against
 		   :file:`/ome/data_repo/test_images_good`
 
@@ -195,8 +191,7 @@ The branch for the 5.1.x series of Bio-Formats is develop.
 		This job runs automated tests against the test_images_good subset on
 		Windows
 
-		#. Checks out the develop/merge/daily branch of the
-		   snoopycrimecop fork of bioformats.git_
+		#. Checks out :bf_scc_branch:`develop/merge/daily`
 		#. Runs automated tests against
 		   :file:`\\\\squig.openmicroscopy.org.uk\\ome-data-repo\\test_images_good`
 
@@ -214,8 +209,7 @@ The branch for the 5.1.x series of Bio-Formats is develop.
 
 		This job runs openBytes performance tests against directories on squig
 
-		#. Checks out the develop/merge/daily branch of the
-		   snoopycrimecop fork of bioformats.git_
+		#. Checks out the :bf_scc_branch:`develop/merge/daily`
 		#. Runs ``loci.tests.testng.OmeroOpenBytesTest`` and
 		   ``loci.tests.testng.OpenBytesPerformanceTest`` tests against
 		   directories specified by
@@ -253,14 +247,13 @@ Jenkins.
 		This job merges all the breaking PRs opened against develop
 
 		#. |merge| labeled as breaking
-		#. Pushes the branch to develop/breaking/trigger
+		#. Pushes the branch to :bf_scc_branch:`develop/breaking/trigger`
 
 	:jenkinsjob:`BIOFORMATS-5.1-breaking-build`
 
 		This job builds the merge artifacts of Bio-Formats
 
-		#. Checks out the develop/breaking/trigger branch of the
-		   snoopycrimecop fork of bioformats.git_
+		#. Checks out :bf_scc_branch:`develop/breaking/trigger`
 		#. |buildBF|
 		#. |fulltestBF|
 		#. Triggers :term:`BIOFORMATS-5.1-breaking-matlab`
@@ -285,8 +278,7 @@ Jenkins.
 		This job runs automated tests against the test_images_good subset on
 		Linux
 
-		#. Checks out the develop/breaking/trigger branch of the
-		   snoopycrimecop fork of bioformats.git_
+		#. Checks out :bf_scc_branch:`develop/breaking/trigger`
 		#. Runs automated tests against
 		   :file:`/ome/data_repo/test_images_good`
 
@@ -295,8 +287,7 @@ Jenkins.
 		This job runs automated tests against the test_images_good subset on
 		Windows
 
-		#. Checks out the develop/breaking/trigger of the
-		   snoopycrimecop fork of bioformats.git_
+		#. Checks out :bf_scc_branch:`develop/breaking/trigger`
 		#. Runs automated tests against
 		   :file:`\\\\squig.openmicroscopy.org.uk\\ome-data-repo\\test_images_good`
 
@@ -304,8 +295,7 @@ Jenkins.
 
 		This job runs automated tests against the full repository on Linux
 
-		#. Checks out the develop/breaking/trigger branch of the
-		   snoopycrimecop fork of bioformats.git_
+		#. Checks out :bf_scc_branch:`develop/breaking/trigger`
 		#. Run automated tests against :file:`/ome/data_repo/from_skyking/`
 
 	:jenkinsjob:`BIOFORMATS-5.1-breaking-repository-subset`

--- a/contributing/ci-bio-formats.txt
+++ b/contributing/ci-bio-formats.txt
@@ -145,7 +145,8 @@ The branch for the 5.1.x series of Bio-Formats is develop.
 		#. Builds the C++ generated sources using ``cmake .. && make gensrc``
 		#. Commits all the generated sources and pushes to
 		   :bf_scc_branch:`develop/merge/generated_sources` branch
-		#. Computes the diff with develop/latest/generated-sources and archives
+		#. Computes the diff with
+		   :bf_scc_branch:`develop/latest/generated_sources` and archives
 		   the artifacts
 
 	:jenkinsjob:`BIOFORMATS-5.1-merge-cpp`
@@ -235,10 +236,7 @@ Jenkins.
 		across a representative subset of the data repository
 
 		#. Triggers :term:`BIOFORMATS-5.1-breaking-push`
-		#. Triggers :term:`BIOFORMATS-5.1-breaking-build`,
-		   :term:`BIOFORMATS-5.1-breaking-cpp`,
-		   :term:`BIOFORMATS-5.1-breaking-test_images_good` and
-		   :term:`BIOFORMATS-5.1-breaking-test_images_good-win`
+		#. Triggers downstream jobs
 
 		See :jenkinsjob:`the build graph <BIOFORMATS-5.1-breaking-trigger/lastSuccessfulBuild/BuildGraph>`
 
@@ -267,6 +265,19 @@ Jenkins.
 		   :term:`BIOFORMATS-5.1-breaking-build`
 		#. Runs the MATLAB unit tests under
 		   :file:`components/bio-formats/test/matlab` and collect the results
+
+	:jenkinsjob:`BIOFORMATS-5.1-breaking-generated-sources`
+
+		This job builds the breaking generated sources of Bio-Formats
+
+		#. Checks out :bf_scc_branch:`develop/breaking/trigger`
+		#. Builds the Java generated sources using ``ant clean ome-xml-src``
+		#. Builds the C++ generated sources using ``cmake .. && make gensrc``
+		#. Commits all the generated sources and pushes to
+		   :bf_scc_branch:`develop/breaking/generated_sources` branch
+		#. Computes the diff with
+		   :bf_scc_branch:`develop/latest/generated_sources` and archives
+		   the artifacts
 
 	:jenkinsjob:`BIOFORMATS-5.1-breaking-cpp`
 

--- a/contributing/ci-bio-formats.txt
+++ b/contributing/ci-bio-formats.txt
@@ -201,7 +201,7 @@ The branch for the 5.1.x series of Bio-Formats is develop.
 		This job runs automated tests against a subset of the data repository
 
 		#. |merge|
-		#. Run automated tests against a subset of format directories under
+		#. Runs automated tests against a subset of format directories under
 		   :file:`/ome/data_repo/from_skyking/`. The list of directories to
 		   test by setting a space-separated list of formats for the
 		   ``DEFAULT_FORMAT_LIST`` variable.
@@ -307,14 +307,14 @@ Jenkins.
 		This job runs automated tests against the full repository on Linux
 
 		#. Checks out :bf_scc_branch:`develop/breaking/trigger`
-		#. Run automated tests against :file:`/ome/data_repo/from_skyking/`
+		#. Runs automated tests against :file:`/ome/data_repo/from_skyking/`
 
 	:jenkinsjob:`BIOFORMATS-5.1-breaking-repository-subset`
 
 		This job runs automated tests against a subset of the data repository
 
 		#. |merge| labeled as breaking
-		#. Run automated tests against a subset of format directories under
+		#. Runs automated tests against a subset of format directories under
 		   :file:`/ome/data_repo/from_skyking/`. The list of directories to
 		   test by setting a space-separated list of formats for the
 		   ``DEFAULT_FORMAT_LIST`` variable.

--- a/contributing/ci-consortium.txt
+++ b/contributing/ci-consortium.txt
@@ -51,7 +51,7 @@ https://github.com/openmicroscopy/Imperial-FLIMfit
 		FLIMfit with OMERO 4.4 or 5.0
 
 		#. Polls the repo for SCM change
-		#. Check out the `master` branch of FLIMfit
+		#. Checks out the `master` branch of FLIMfit
 		#. Build FLIMfit using :file:`compile.m`
 		#. Trigger `FLIMfit-latest-win`
 
@@ -60,7 +60,7 @@ https://github.com/openmicroscopy/Imperial-FLIMfit
 		This job is used to build the latest Windows compiled version of
 		FLIMfit with OMERO 4.4 or 5.0
 
-		#. Check out the `master` branch of FLIMfit
+		#. Checks out the `master` branch of FLIMfit
 		#. Build FLIMfit using :file:`compile.m`
 
 	:jenkinsjob:`FLIMfit-release`
@@ -93,7 +93,7 @@ https://github.com/openmicroscopy/Imperial-FLIMfit
 
 		This job is used to build the FLIMfit downloads page
 
-		#. Check out the `dev_5_0` branch of
+		#. Checks out the `dev_5_0` branch of
 		   https://github.com/openmicroscopy/ome-release
 		#. Merge PRs opened against `dev_5_0`
 		#. Copy the FLIMfit Windows artifacts over SSH to
@@ -165,7 +165,7 @@ u-track
 		This job is used to build the latest version of u-track
 
 		#. Build u-track
-		#. Run the unit and integration tests
+		#. Runs the unit and integration tests
 
 	:jenkinsjob:`U-TRACK-release`
 
@@ -180,7 +180,7 @@ u-track
 
 		This job is used to build the u-track downloads page
 
-		#. Check out the `dev_5_0` branch of
+		#. Checks out the `dev_5_0` branch of
 		   https://github.com/openmicroscopy/ome-release
 		#. Merge PRs opened against `dev_5_0`
 		#. Build the u-track downloads pages using :command:`make u-track`

--- a/contributing/ci-docs.txt
+++ b/contributing/ci-docs.txt
@@ -174,7 +174,7 @@ dev_5_1.
 		#. Builds Bio-Formats using ``ant clean jars``
 		#. Runs the auto-generation using ``ant gen-format-pages gen-original-meta-support gen-meta-support gen-meta-support``
 		   from :file:`components/autogen`
-		#. Check for file changes under :file:`docs/sphinx`
+		#. Checks for file changes under :file:`docs/sphinx`
 		#. Pushes the auto-generated changes to
 		   :bf_scc_branch:`develop/latest/autogen`
 
@@ -189,7 +189,7 @@ dev_5_1.
 		#. Builds Bio-Formats using ``ant clean jars``
 		#. Runs the auto-generation using ``ant gen-format-pages gen-original-meta-support gen-meta-support gen-meta-support``
 		   from :file:`components/autogen`
-		#. Check for file changes under :file:`docs/sphinx`
+		#. Checks for file changes under :file:`docs/sphinx`
 		#. Pushes the auto-generated changes to 
 		   :bf_scc_branch:`develop/merge/autogen`
 

--- a/contributing/ci-docs.txt
+++ b/contributing/ci-docs.txt
@@ -176,7 +176,7 @@ dev_5_1.
 		   from :file:`components/autogen`
 		#. Check for file changes under :file:`docs/sphinx`
 		#. Pushes the auto-generated changes to
-		   :bf_scc_branch:`dev_5_1/latest/autogen`
+		   :bf_scc_branch:`develop/latest/autogen`
 
 
 
@@ -185,13 +185,13 @@ dev_5_1.
 		This job is used to build the merge auto-generated pages for the
 		dev_5_1 branch of the Bio-Formats documentation
 
-		#. Checks out :bf_scc_branch:`dev_5_1/merge/daily`
+		#. Checks out :bf_scc_branch:`develop/merge/daily`
 		#. Builds Bio-Formats using ``ant clean jars``
 		#. Runs the auto-generation using ``ant gen-format-pages gen-original-meta-support gen-meta-support gen-meta-support``
 		   from :file:`components/autogen`
 		#. Check for file changes under :file:`docs/sphinx`
 		#. Pushes the auto-generated changes to 
-		   :bf_scc_branch:`dev_5_1/merge/autogen`
+		   :bf_scc_branch:`develop/merge/autogen`
 
 	:jenkinsjob:`OMERO-5.1-latest-docs-autogen`
 

--- a/contributing/ci-docs.txt
+++ b/contributing/ci-docs.txt
@@ -134,7 +134,7 @@ dev_5_1.
 
 	:jenkinsjob:`BIOFORMATS-5.1-latest-docs`
 
-		This job is used to build the dev_5_1 branch of the Bio-Formats
+		This job is used to build the develop branch of the Bio-Formats
 		documentation and publish the official documentation for the 5.1.x
 		release of Bio-Formats
 
@@ -157,7 +157,7 @@ dev_5_1.
 
 	:jenkinsjob:`BIOFORMATS-5.1-merge-docs`
 
-		This job is used to review the PRs opened against the dev_5_1 branch
+		This job is used to review the PRs opened against the develop branch
 		of the Bio-Formats documentation
 
 		#. |merge|
@@ -169,7 +169,7 @@ dev_5_1.
 	:jenkinsjob:`BIOFORMATS-5.1-latest-docs-autogen`
 
 		This job is used to build the latest auto-generated formats and
-		readers pages for the dev_5_1 branch of the Bio-Formats documentation
+		readers pages for the develop branch of the Bio-Formats documentation
 
 		#. Builds Bio-Formats using ``ant clean jars``
 		#. Runs the auto-generation using ``ant gen-format-pages gen-original-meta-support gen-meta-support gen-meta-support``
@@ -183,7 +183,7 @@ dev_5_1.
 	:jenkinsjob:`BIOFORMATS-5.1-merge-docs-autogen`
 
 		This job is used to build the merge auto-generated pages for the
-		dev_5_1 branch of the Bio-Formats documentation
+		develop branch of the Bio-Formats documentation
 
 		#. Checks out :bf_scc_branch:`develop/merge/daily`
 		#. Builds Bio-Formats using ``ant clean jars``

--- a/contributing/ci-docs.txt
+++ b/contributing/ci-docs.txt
@@ -7,40 +7,40 @@ tab of Jenkins.
 .. list-table::
 	:header-rows: 1
 
-	- 	* Job task
+	-	* Job task
 		* 5.1.x series
 		* 5.2.x series
 
-	- 	* Builds the latest OMERO documentation for publishing
+	-	* Builds the latest OMERO documentation for publishing
 		* :term:`OMERO-5.1-latest-docs`
 		* :term:`OMERO-DEV-latest-docs`
 
-	- 	* Builds the latest Bio-Formats documentation for publishing
+	-	* Builds the latest Bio-Formats documentation for publishing
 		* :term:`BIOFORMATS-5.1-latest-docs`
 		*
 
-	- 	* Builds the OMERO documentation for review
+	-	* Builds the OMERO documentation for review
 		* :term:`OMERO-5.1-merge-docs`
 		* :term:`OMERO-DEV-merge-docs`
 
 
-	- 	* Builds the Bio-Formats documentation for review
+	-	* Builds the Bio-Formats documentation for review
 		* :term:`BIOFORMATS-5.1-merge-docs`
 		*
 
-	- 	* Builds the auto-generated OMERO documentation
+	-	* Builds the auto-generated OMERO documentation
 		* :term:`OMERO-5.1-latest-docs-autogen`
 		* :term:`OMERO-DEV-latest-docs-autogen`
 
-	- 	* Builds the auto-generated OMERO documentation for review
+	-	* Builds the auto-generated OMERO documentation for review
 		* :term:`OMERO-5.1-merge-docs-autogen`
 		* :term:`OMERO-DEV-merge-docs-autogen`
 
-	- 	* Builds the auto-generated Bio-Formats documentation
+	-	* Builds the auto-generated Bio-Formats documentation
 		* :term:`BIOFORMATS-5.1-latest-docs-autogen`
 		*
 
-	- 	* Builds the auto-generated OMERO documentation for review
+	-	* Builds the auto-generated OMERO documentation for review
 		* :term:`BIOFORMATS-5.1-merge-docs-autogen`
 		*
 
@@ -51,25 +51,25 @@ independent of the current OMERO/Bio-Formats version.
 .. list-table::
 	:header-rows: 1
 
-	- 	* Job task
+	-	* Job task
 		*
 
-	- 	* Publish OME Model documentation
+	-	* Publish OME Model documentation
 		* :term:`FORMATS-latest-docs`
 
-	- 	* Publish OME Contributing documentation
+	-	* Publish OME Contributing documentation
 		* :term:`CONTRIBUTING-latest-docs`
 
-	- 	* Review OME Model documentation PRs
+	-	* Review OME Model documentation PRs
 		* :term:`FORMATS-merge-docs`
 
-	- 	* Review OME Contributing documentation PRs
+	-	* Review OME Contributing documentation PRs
 		* :term:`CONTRIBUTING-merge-docs`
 
-	- 	* Review OME help documentation PRs
+	-	* Review OME help documentation PRs
 		* :term:`OME-help-staging`
 
-	- 	* Publish OME help documentation
+	-	* Publish OME help documentation
 		* :term:`OME-help-release`
 
 Since OMERO.figure came under the management of the wider OME team, there are also builds to manage its GitHub pages website, which operate the same way as the help builds.
@@ -77,13 +77,13 @@ Since OMERO.figure came under the management of the wider OME team, there are al
 .. list-table::
 	:header-rows: 1
 
-	- 	* Job task
+	-	* Job task
 		*
 
-	- 	* Review Figure website PRs
+	-	* Review Figure website PRs
 		* :term:`FIGURE-help-staging`
 
-	- 	* Publish Figure website
+	-	* Publish Figure website
 		* :term:`FIGURE-help-release`
 
 
@@ -175,8 +175,9 @@ dev_5_1.
 		#. Runs the auto-generation using ``ant gen-format-pages gen-original-meta-support gen-meta-support gen-meta-support``
 		   from :file:`components/autogen`
 		#. Check for file changes under :file:`docs/sphinx`
-		#. Pushes the auto-generated changes to the `dev_5_1/latest/autogen`
-		   branch of https://github.com/snoopycrimecop/bioformats
+		#. Pushes the auto-generated changes to
+		   :bf_scc_branch:`dev_5_1/latest/autogen`
+
 
 
 	:jenkinsjob:`BIOFORMATS-5.1-merge-docs-autogen`
@@ -184,14 +185,13 @@ dev_5_1.
 		This job is used to build the merge auto-generated pages for the
 		dev_5_1 branch of the Bio-Formats documentation
 
-		#. Checks out the dev_5_1/merge/daily branch of the
-		   snoopycrimecop fork of bioformats.git_
+		#. Checks out :bf_scc_branch:`dev_5_1/merge/daily`
 		#. Builds Bio-Formats using ``ant clean jars``
 		#. Runs the auto-generation using ``ant gen-format-pages gen-original-meta-support gen-meta-support gen-meta-support``
 		   from :file:`components/autogen`
 		#. Check for file changes under :file:`docs/sphinx`
-		#. Pushes the auto-generated changes to the `dev_5_1/merge/autogen`
-		   branch of https://github.com/snoopycrimecop/bioformats
+		#. Pushes the auto-generated changes to 
+		   :bf_scc_branch:`dev_5_1/merge/autogen`
 
 	:jenkinsjob:`OMERO-5.1-latest-docs-autogen`
 
@@ -202,21 +202,20 @@ dev_5_1.
 		#. Downloads the OMERO.server and OMERO.clients from
 		   :term:`OMERO-5.1-latest`
 		#. Runs the :file:`omero/autogen_docs` autogeneration script
-		#. Pushes the auto-generated changes to the `dev_5_1/latest/autogen`
-		   branch of https://github.com/snoopycrimecop/ome-documentation
+		#. Pushes the auto-generated changes to
+		   :omedoc_scc_branch:`dev_5_1/latest/autogen`
 
 	:jenkinsjob:`OMERO-5.1-merge-docs-autogen`
 
 		This job is used to review the component auto-generation for the
 		dev_5_1 branch of the OMERO documentation
 
-		#. Checks out the dev_5_1/merge/daily branch of the
-		   snoopycrimecop fork of ome-documentation.git_
+		#. Checks out :omedoc_scc_branch:`dev_5_1/merge/daily`
 		#. Downloads the OMERO.server and OMERO.clients from
 		   :term:`OMERO-5.1-merge-build`
 		#. Runs the :file:`omero/autogen_docs` autogeneration script
-		#. Pushes the auto-generated changes to the `dev_5_1/merge/autogen`
-		   branch of https://github.com/snoopycrimecop/ome-documentation
+		#. Pushes the auto-generated changes to
+		   :omedoc_scc_branch:`dev_5_1/merge/autogen`
 
 5.2.x series
 ^^^^^^^^^^^^
@@ -243,6 +242,7 @@ develop.
 		of the OMERO documentation
 
 		#. |merge|
+		#. Pushes the branch to :omedoc_scc_branch:`develop/merge/daily`
 		#. |sphinxbuild|
 		#. |linkcheck|
 		#. |ssh-doc| :file:`omero-5.2-staging.tmp`
@@ -257,21 +257,20 @@ develop.
 		#. Downloads the OMERO.server and OMERO.clients from
 		   :term:`OMERO-DEV-latest`
 		#. Runs the :file:`omero/autogen_docs` autogeneration script
-		#. Pushes the auto-generated changes to the `develop/latest/autogen`
-		   branch of https://github.com/snoopycrimecop/ome-documentation
+		#. Pushes the auto-generated changes to
+		   :omedoc_scc_branch:`develop/latest/autogen`
 
 	:jenkinsjob:`OMERO-DEV-merge-docs-autogen`
 
 		This job is used to review the component auto-generation for the
 		develop branch of the OMERO documentation
 
-		#. Checks out the develop/merge/daily branch of the
-		   snoopycrimecop fork of ome-documentation.git_
+		#. Checks out :omedoc_scc_branch:`develop/merge/daily`
 		#. Downloads the OMERO.server and OMERO.clients from
 		   :term:`OMERO-DEV-merge-build`
 		#. Runs the :file:`omero/autogen_docs` autogeneration script
-		#. Pushes the auto-generated changes to the `develop/merge/autogen`
-		   branch of https://github.com/snoopycrimecop/ome-documentation
+		#. Pushes the auto-generated changes to
+		   :omedoc_scc_branch:`develop/merge/autogen`
 
 OME Model and OME Contributing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -335,10 +334,9 @@ The repository for the OME help is https://github.com/openmicroscopy/ome-help.
 		This job is used to review the PRs opened against the master branch
 		of the OME help documentation
 
-		#. |merge| (and also incorporates
-		   https://github.com/snoopycrimecop/ome-help/tree/cname_staging to
-		   allow  deployment to a non-GitHub URL) then pushes the resulting
-		   branch to https://github.com/snoopycrimecop/ome-help/tree/gh-pages
+		#. |merge| (and also incorporates :omehelp_scc_branch:`cname_staging`
+		   to allow	 deployment to a non-GitHub URL) then pushes the resulting
+		   branch to :omehelp_scc_branch:`gh-pages`
 		#. The GitHub Pages service updates the content of
 		   http://help.staging.openmicroscopy.org
 
@@ -369,10 +367,9 @@ The repository for OMERO.figure is https://github.com/ome/figure.
 		This job is used to review the PRs opened against the gh-pages-staging
 		branch of figure repository
 
-		#. |merge| (and also incorporates
-		   https://github.com/snoopycrimecop/figure/tree/cname_staging to
+		#. |merge| (and also incorporates :figure_scc_branch:`cname_staging` to
 		   allow  deployment to a non-GitHub URL) then pushes the resulting
-		   branch to https://github.com/snoopycrimecop/figure/tree/gh-pages
+		   branch to :figure_scc_branch:`gh-pages`
 		#. The GitHub Pages service updates the content of
 		   http://figure.staging.openmicroscopy.org
 
@@ -400,12 +397,12 @@ parsed using the `Warnings Plugin`_. Depending on the nature of the links,
 warnings are generated as described in the following table:
 
 ====== ================ ========
-Type   Error code       Priority
+Type   Error code		Priority
 ====== ================ ========
-local                   High
-broken HTTP Error 404   Normal
+local					High
+broken HTTP Error 404	Normal
 broken Anchor not found Normal
-broken HTTP Error 403   Low
+broken HTTP Error 403	Low
 ====== ================ ========
 
 The build is marked as FAILED or UNSTABLE if the number of warnings of a given
@@ -415,7 +412,7 @@ all the documentation builds:
 ======== ====== ========
 Priority FAILED UNSTABLE
 ======== ====== ========
-High     0
-Normal          0
-Low             10
+High	 0
+Normal			0
+Low				10
 ======== ====== ========

--- a/contributing/ci-omero.txt
+++ b/contributing/ci-omero.txt
@@ -213,7 +213,7 @@ under the :jenkinsview:`5.1` view tab of Jenkins.
         This job updates the submodules on the dev_5_1 branch
 
         #. |updatesubmodules| and pushes the merge branch to
-           snoopycrimecop/dev_5_1/latest/submodules
+           :omero_scc_branch:`dev_5_1/latest/submodules`
         #. If the submodules are updated, opens a new PR or updates the
            existing dev_5_1 submodules PR
 
@@ -234,14 +234,13 @@ under the :jenkinsview:`5.1` view tab of Jenkins.
         This job merges all the PRs opened against dev_5_1
 
         #. |merge|
-        #. Pushes the branch to snoopycrimecop/dev_5_1/merge/daily
+        #. Pushes the branch to :omero_scc_branch:`dev_5_1/merge/daily`
 
     :jenkinsjob:`OMERO-5.1-merge-build`
 
         These jobs builds the OMERO components with Ice 3.4 or 3.5
 
-        #. Checks out the dev_5_1/merge/daily branch of the
-           snoopycrimecop fork of openmicroscopy.git_
+        #. Checks out :omero_scc_branch:`dev_5_1/merge/daily`
         #. |buildOMERO| for each version of Ice
         #. |archiveOMEROartifacts|
 
@@ -264,8 +263,7 @@ under the :jenkinsview:`5.1` view tab of Jenkins.
 
         This job runs the integration tests of OMERO
 
-        #. Checks out the dev_5_1/merge/daily branch of the
-           snoopycrimecop fork of openmicroscopy.git_
+        #. Checks out :omero_scc_branch:`dev_5_1/merge/daily`
         #. Builds OMERO.server and starts it
         #. Runs the OMERO.java, OMERO.py and OMERO.web integration tests
         #. Archives the results
@@ -315,8 +313,7 @@ under the :jenkinsview:`5.1` view tab of Jenkins.
 
         This job runs the OMERO.matlab tests
 
-        #. Checks out the dev_5_1/merge/daily branch of the
-           snoopycrimecop fork of openmicroscopy.git_
+        #. Checks out :omero_scc_branch:`dev_5_1/merge/daily`
         #. Collects the MATLAB artifacts from :term:`OMERO-5.1-merge-build`
         #. Runs the MATLAB unit tests under
            :file:`components/tools/OmeroM/test/unit` and collect the results
@@ -336,8 +333,7 @@ under the :jenkinsview:`5.1` view tab of Jenkins.
 
         This job runs the robot framework tests of OMERO
 
-        #. Checks out the dev_5_1/merge/daily branch of the
-           snoopycrimecop fork of openmicroscopy.git_
+        #. Checks out :omero_scc_branch:`dev_5_1/merge/daily`
         #. Builds OMERO.server and starts it
         #. Runs the robot framework tests and collect the results
 
@@ -386,7 +382,7 @@ under the :jenkinsview:`DEV` view tab of Jenkins.
         This job updates the submodules on the develop branch
 
         #. |updatesubmodules| and pushes the merge branch to
-           snoopycrimecop/develop/latest/submodules
+           :omero_scc_branch:`develop/latest/submodules`
         #. If the submodules are updated, opens a new PR or updates the
            existing develop submodules PR
 
@@ -407,14 +403,13 @@ under the :jenkinsview:`DEV` view tab of Jenkins.
         This job merges all the PRs opened against develop
 
         #. |merge|
-        #. Pushes the branch to snoopycrimecop/develop/merge/daily
+        #. Pushes the branch to :omero_scc_branch:`develop/merge/daily`
 
     :jenkinsjob:`OMERO-DEV-merge-build`
 
         These jobs builds the OMERO components with Ice 3.5 or 3.6
 
-        #. Checks out the develop/merge/daily branch of the
-           snoopycrimecop fork of openmicroscopy.git_
+        #. Checks out :omero_scc_branch:`develop/merge/daily` 
         #. |buildOMERO| for each version of Ice
         #. |archiveOMEROartifacts|
 
@@ -427,8 +422,7 @@ under the :jenkinsview:`DEV` view tab of Jenkins.
 
         This job runs the integration tests of OMERO
 
-        #. Checks out the develop/merge/daily branch of the
-           snoopycrimecop fork of openmicroscopy.git_
+        #. Checks out :omero_scc_branch:`develop/merge/daily` 
         #. Builds OMERO.server and starts it
         #. Runs the OMERO.java, OMERO.py and OMERO.web integration tests
         #. Archives the results
@@ -478,8 +472,7 @@ under the :jenkinsview:`DEV` view tab of Jenkins.
 
         This job runs the OMERO.matlab tests
 
-        #. Checks out the develop/merge/daily branch of the
-           snoopycrimecop fork of openmicroscopy.git_
+        #. Checks out :omero_scc_branch:`develop/merge/daily` 
         #. Collects the MATLAB artifacts from :term:`OMERO-DEV-merge-build`
         #. Runs the MATLAB unit tests under
            :file:`components/tools/OmeroM/test/unit` and collect the results
@@ -499,8 +492,7 @@ under the :jenkinsview:`DEV` view tab of Jenkins.
 
         This job runs the robot framework tests of OMERO
 
-        #. Checks out the develop/merge/daily branch of the
-           snoopycrimecop fork of openmicroscopy.git_
+        #. Checks out :omero_scc_branch:`develop/merge/daily` 
         #. Builds OMERO.server and starts it
         #. Runs the robot framework tests and collect the results
 
@@ -531,14 +523,13 @@ Jenkins.
         This job merges all the breaking PRs
 
         #. |merge| including only PRs labeled as `breaking`
-        #. Push the branch to snoopycrimecop/develop/breaking/trigger
+        #. Push the branch to :omero_scc_branch:`develop/breaking/trigger` 
 
     :jenkinsjob:`OMERO-DEV-breaking-build`
 
         This matrix jobs builds the OMERO components with Ice 3.4 or 3.5
 
-        #. Checks out the develop/breaking/trigger branch of the
-           snoopycrimecop fork of openmicroscopy.git_
+        #. Checks out :omero_scc_branch:`develop/breaking/trigger` 
         #. |buildOMERO| for each version of Ice
         #. |archiveOMEROartifacts|
 
@@ -550,8 +541,7 @@ Jenkins.
 
         This job runs the integration tests of OMERO
 
-        #. Checks out the develop/breaking/trigger branch of the
-           snoopycrimecop fork of openmicroscopy.git_
+        #. Checks out :omero_scc_branch:`develop/breaking/trigger` 
         #. Builds OMERO.server and starts it
         #. Runs the OMERO.java, OMERO.py and OMERO.web integration tests
         #. Archives the results

--- a/contributing/ci-omero.txt
+++ b/contributing/ci-omero.txt
@@ -85,7 +85,7 @@ OMERO jobs
         *
         *
 
-    -   * Push SNAPSHOTS to Maven
+    -   * Pushes SNAPSHOTS to Maven
         * | :term:`OMERO-5.1-latest-maven`
           | :term:`OMERO-5.1-merge-maven`
         * | :term:`OMERO-DEV-latest-maven`
@@ -523,7 +523,7 @@ Jenkins.
         This job merges all the breaking PRs
 
         #. |merge| including only PRs labeled as `breaking`
-        #. Push the branch to :omero_scc_branch:`develop/breaking/trigger` 
+        #. Pushes the branch to :omero_scc_branch:`develop/breaking/trigger` 
 
     :jenkinsjob:`OMERO-DEV-breaking-build`
 

--- a/contributing/ci-release.txt
+++ b/contributing/ci-release.txt
@@ -112,7 +112,6 @@ clients of the deployment jobs described above:
         #. Checks out the :envvar:`RELEASE` tag of the
            snoopycrimecop fork of openmicroscopy.git_
         #. |buildOMERO| for each version of Ice
-        #. |buildVM|
         #. Executes the `release-hudson` target for the `ome.staging` Maven
            repository
         #. |copyreleaseartifacts|
@@ -242,7 +241,6 @@ clients of the deployment jobs described above:
         #. Checks out the :envvar:`RELEASE` tag of the
            snoopycrimecop fork of openmicroscopy.git_
         #. |buildOMERO| for each version of Ice
-        #. |buildVM|
         #. Executes the `release-hudson` target for the `ome.staging` Maven
            repository
         #. |copyreleaseartifacts|

--- a/contributing/conf.py
+++ b/contributing/conf.py
@@ -28,9 +28,9 @@ title = project + u' Documentation'
 # OME contributing-specific extlinks
 contributing_extlinks = {
     # Github links
-    'source' : (omero_github_root + 'blob/'+ branch + '/%s', ''),
-    'sourcedir' : (omero_github_root + 'tree/'+ branch + '/%s', ''),
-    'commit' : (omero_github_root + 'commit/%s', ''),
+    'omero_source' : (omero_github_root + 'blob/'+ branch + '/%s', ''),
+    'omero_sourcedir' : (omero_github_root + 'tree/'+ branch + '/%s', ''),
+    'omero_commit' : (omero_github_root + 'commit/%s', ''),
     'bf_source' : (bf_github_root + 'blob/'+ branch + '/%s', ''),
     'bf_sourcedir' : (bf_github_root + 'tree/'+ branch + '/%s', ''),
     'bf_commit' : (bf_github_root + 'commit/%s', ''),
@@ -54,11 +54,10 @@ rst_epilog += """
 .. _ome-documentation.git: https://github.com/openmicroscopy/ome-documentation
 .. _scripts.git: https://github.com/ome/scripts
 ..  |merge| replace:: Merges PRs using :ref:`scc merge`
-..  |buildOMERO| replace:: Builds the OMERO.server and the clients using :source:`OMERO.sh <docs/hudson/OMERO.sh>`
+..  |buildOMERO| replace:: Builds the OMERO.server and the clients using :omero_source:`OMERO.sh <docs/hudson/OMERO.sh>`
 ..  |archiveOMEROartifacts| replace:: Archives the build artifacts
 ..  |copyreleaseartifacts| replace:: Copies the build artifacts to a LDAP-protected folder under downloads.openmicroscopy.org
 ..  |promoteOMERO| replace:: copies the artifacts to necromancer
-..  |buildVM| replace:: Builds a |VM| using :source:`omerovm.sh <docs/install/VM/omerovm.sh>`
 ..  |updatesubmodules| replace:: Updates submodules using ``scc update-submodules``
 ..  |buildBF| replace:: Builds Bio-Formats using ``ant clean jars tools tools-ome utils dist-bftools``
 ..  |testBF| replace:: Runs Bio-Formats tests using ``ant test-common test-ome-xml test-formats test-ome-io``

--- a/contributing/conf.py
+++ b/contributing/conf.py
@@ -25,15 +25,23 @@ from conf import *
 project = u'OME Contributing Developer'
 title = project + u' Documentation'
 
+scc_github_root = github_root + 'snoopycrimecop'
+
 # OME contributing-specific extlinks
 contributing_extlinks = {
     # Github links
     'omero_source' : (omero_github_root + 'blob/'+ branch + '/%s', ''),
     'omero_sourcedir' : (omero_github_root + 'tree/'+ branch + '/%s', ''),
     'omero_commit' : (omero_github_root + 'commit/%s', ''),
+    'omero_scc_branch' : (scc_github_root + '/openmicroscopy/tree/%s', ''),
     'bf_source' : (bf_github_root + 'blob/'+ branch + '/%s', ''),
     'bf_sourcedir' : (bf_github_root + 'tree/'+ branch + '/%s', ''),
     'bf_commit' : (bf_github_root + 'commit/%s', ''),
+    'bf_scc_branch' : (scc_github_root + '/bioformats/tree/%s', ''),
+    'omedoc_scc_branch' : (scc_github_root + '/ome-documentation/tree/%s', ''),
+    'omehelp_scc_branch' : (scc_github_root + '/ome-help/tree/%s', ''),
+    'figure_scc_branch' : (scc_github_root + '/figure/tree/%s', ''),
+    
     # Doc links
     'omero_doc' : (oo_site_root + '/support/omero/%s', ''),
     'bf_doc' : (oo_site_root + '/support/bio-formats/%s', ''),

--- a/contributing/schema-changes.txt
+++ b/contributing/schema-changes.txt
@@ -37,23 +37,23 @@ Model object proxies
 --------------------
 
 Changes to model objects that are passed from the server to clients may
-require corresponding changes to be made to the :source:`IceMapper
+require corresponding changes to be made to the :omero_source:`IceMapper
 <components/blitz/src/omero/util/IceMapper.java>` class so that the
 client-side proxy objects are properly populated.
 
-For example, :commit:`commit 8815a409
+For example, :omero_commit:`commit 8815a409
 <8815a409e24b41ff4c68829657ad98a278594ade>` adds fields to the `Roles` class
-in the server's :source:`System.ice
+in the server's :omero_source:`System.ice
 <components/blitz/resources/omero/System.ice>` whose instances can be passed
-to clients via the :source:`admin service API
+to clients via the :omero_source:`admin service API
 <components/blitz/resources/omero/api/IAdmin.ice>` so a further
-:commit:`commit 2426042a <2426042a4f0b5e31a6e9743844da168a9e550375>` was
+:omero_commit:`commit 2426042a <2426042a4f0b5e31a6e9743844da168a9e550375>` was
 needed to populate those fields in the proxy object.
 
 Database patch numbers
 ----------------------
 
-:source:`omero.properties <etc/omero.properties>` contains a
+:omero_source:`omero.properties <etc/omero.properties>` contains a
 configuration setting for :literal:`omero.db.patch`. An existing OMERO
 database records the patch number of its schema, as demonstrated from
 the :literal:`psql` shell:
@@ -84,16 +84,16 @@ Users may wish to upgrade their database from an older version of OMERO to one
 that has your new schema. SQL upgrade scripts are provided to allow users to
 upgrade easily without having to understand the schema changes themselves, and
 part of the upgrade script will involve making the schema changes entailed
-with your pull request.  The :source:`sql/README.txt` file describes where to
-find the appropriate script for you to adjust. SQL upgrade scripts must be
-supplied as part of the code changes to upgrade the database from:
+with your pull request.  The :omero_source:`sql/README.txt` file describes
+where to find the appropriate script for you to adjust. SQL upgrade scripts
+must be supplied as part of the code changes to upgrade the database from:
 
 * the last release database, e.g. :file:`sql/psql/OMERO5.1DEV__5/OMERO5.0__0`,
 * the previous patch's database, e.g.
   :file:`sql/psql/OMERO5.1DEV__5/OMERO5.1DEV__4`.
 
 In your git branch with the code that requires a schema change, edit
-:source:`omero.properties <etc/omero.properties>` and increment the
+:omero_source:`omero.properties <etc/omero.properties>` and increment the
 value of :literal:`omero.db.patch`. For instance, in the above
 example, edit the file so that
 
@@ -122,8 +122,8 @@ that your code requires. Use this script to set up your database so
 that you can start OMERO.server and test your changes thoroughly.
 
 When you commit your code and issue a pull request, include the
-changes to :source:`omero.properties <etc/omero.properties>` and
-:sourcedir:`sql/psql` among the commits in the pull request.
+changes to :omero_source:`omero.properties <etc/omero.properties>` and
+:omero_sourcedir:`sql/psql` among the commits in the pull request.
 
 Review workflow
 ---------------

--- a/contributing/schema-changes.txt
+++ b/contributing/schema-changes.txt
@@ -84,7 +84,7 @@ Users may wish to upgrade their database from an older version of OMERO to one
 that has your new schema. SQL upgrade scripts are provided to allow users to
 upgrade easily without having to understand the schema changes themselves, and
 part of the upgrade script will involve making the schema changes entailed
-with your pull request.  The :omero_source:`sql/README.txt` file describes
+with your pull request. The :omero_source:`sql/README.txt` file describes
 where to find the appropriate script for you to adjust. SQL upgrade scripts
 must be supplied as part of the code changes to upgrade the database from:
 


### PR DESCRIPTION
With the snoopycrimecop CI branch names now being unified, we can consider them as stable for development purposes. This PR implements this by setting up extlinks to the scc branches used by the CI jobs. All source/commit extlinks under contributing are also prefixed to distinguish between them.

To test this PR:
- check the https://ci.openmicroscopy.org/view/Docs/job/CONTRIBUTING-merge-docs/ is still green
- check there is no missing branch that needs to be replaced in the same manner

--no-rebase
