### PR TITLE
Modify CLI tag page

### DIFF
--- a/omero/users/cli/delete.txt
+++ b/omero/users/cli/delete.txt
@@ -112,6 +112,8 @@ contained elsewhere, excluding any images in those datasets but including
 any file annotations linked to the deleted datasets. In this case the images
 that are not otherwise contained in datasets will be orphaned.
 
+For an example on deleting tags directly see :ref:`delete_tags`.
+
 Further options
 ^^^^^^^^^^^^^^^
 

--- a/omero/users/cli/tag.txt
+++ b/omero/users/cli/tag.txt
@@ -64,3 +64,18 @@ command. The object must be specified as ``object_type:object_id``. To link
 the tag of identifier ``1260`` to the Image of identifier ``1000``, use::
 
     $ bin/omero tag link Image:1000 1260
+
+Delete tags
+^^^^^^^^^^^
+
+Tags can be deleted using the :omerocmd:`delete` command. The tag or tag set
+must be specified as ``TagAnnotation:tag_id``. To delete tag ``123`` use::
+
+    $ bin/omero delete TagAnnotation:123
+
+By default the tags within a tag set will not be deleted with the tag set. To
+delete any included tags use the :option:`--include` option::
+
+    $ bin/omero delete TagAnnotation:123 --include TagAnnotation
+
+.. seealso:: :doc:`/users/cli/delete`

--- a/omero/users/cli/tag.txt
+++ b/omero/users/cli/tag.txt
@@ -65,6 +65,8 @@ the tag of identifier ``1260`` to the Image of identifier ``1000``, use::
 
     $ bin/omero tag link Image:1000 1260
 
+.. _delete_tags:
+
 Delete tags
 ^^^^^^^^^^^
 

--- a/omero/users/cli/tag.txt
+++ b/omero/users/cli/tag.txt
@@ -13,17 +13,15 @@ To create a new tag annotation, use the :omerocmd:`tag create` command::
 
     $ bin/omero tag create
     Please enter a name for this tag: my_tag
-    Please enter a description for this tag: description of my_tag
 
 To create a tag set containing two existing tags of known identifiers
 ``1259`` and ``1260``, use the :omerocmd:`tag createset` command::
 
 	$ bin/omero tag createset --tag 1259 1260
 	Please enter a name for this tag set: my_tag_set
-	Please enter a description for this tag set: description of my_tag_set
 
-For both tags and tag sets, the name and description can be passed using the
-:option:`--name` and :option:`--desc` options::
+For both tags and tag sets, the name and an optional description can be
+passed using the :option:`--name` and :option:`--desc` options::
 
 	$ bin/omero tag create --name my_tag --desc 'description of my_tag'
 	$ bin/omero tag createset --tag 1259 1260 --name my_tag_set --desc 'description of my_tag_set'


### PR DESCRIPTION
This PR makes a couple of chnages to the CLI tag documenation. One is related to a commit on https://github.com/openmicroscopy/openmicroscopy/pull/4061 allowing tags to be created without a description.

The second relates to deleting tags and is in response to https://www.openmicroscopy.org/community/viewtopic.php?f=4&t=7884&p=16139#p16137 

A question regarding this second commit is whether the examples should be added to the `delete` page and a simple link be provided or if it is okay to have this explanation of one aspect of a command on anthor command page.

--rebased-to #1270 
