### PR TITLE
Deprecate fastcgi (rebased onto develop)

### DIFF
--- a/omero/developers/Web/Deployment.txt
+++ b/omero/developers/Web/Deployment.txt
@@ -81,15 +81,15 @@ Using FastCGI (Unix/Linux) (DEPRECATED)
 ---------------------------------------
 
 .. note::
-    Deprecated since version 5.1.4: OMERO.web deployment using FastCGI
+    **Deprecated since version 5.1.4**
+    
+    OMERO.web deployment using FastCGI
     is deprecated and will be removed in OMERO 5.2.
-    Use :doc:`install-wsgi` as an alternative.
+    Use :ref:`wsgi_configuration` as an alternative.
 
 
-For convenience you may wish to run a web server under your local user account
-instead of using a system server for testing. Install Nginx
-(See :doc:`/sysadmins/unix/install-web`) but generate a configuration file
-using the following command:
+As above, install Nginx (See :doc:`/sysadmins/unix/install-web`) but generate
+a configuration file using the following command:
 
 ::
 

--- a/omero/developers/Web/Deployment.txt
+++ b/omero/developers/Web/Deployment.txt
@@ -80,6 +80,12 @@ listening on 127.0.0.1:4080 that will autoreload on source change:
 Using FastCGI (Unix/Linux) (DEPRECATED)
 ---------------------------------------
 
+.. note::
+    Deprecated since version 5.1.4: OMERO.web deployment using FastCGI
+    is deprecated and will be removed in OMERO 5.2.
+    Use :doc:`install-wsgi` as an alternative.
+
+
 For convenience you may wish to run a web server under your local user account
 instead of using a system server for testing. Install Nginx
 (See :doc:`/sysadmins/unix/install-web`) but generate a configuration file

--- a/omero/developers/Web/Deployment.txt
+++ b/omero/developers/Web/Deployment.txt
@@ -55,8 +55,30 @@ Debugging on and start the server up:
     Starting development server at http://0.0.0.0:4080/
     Quit the server with CTRL-BREAK.
 
-Using FastCGI (Unix/Linux)
---------------------------
+Using WSGI (Unix/Linux)
+-----------------------
+
+For convenience you may wish to run a web server under your local user account
+instead of using a system server for testing. Install Nginx
+(See :doc:`/sysadmins/unix/install-web`) but generate a configuration file
+using the following command:
+
+::
+
+    $ bin/omero web config nginx-wsgi-development > nginx-wsgi-development.conf
+
+Start nginx and the Gunicorn worker processes running one thread
+listening on 127.0.0.1:4080 that will autoreload on source change:
+
+::
+
+    $ nginx -c $PWD/nginx-development.conf
+    $ bin/omero config set omero.web.application_server 'wsgi-tcp'
+    $ bin/omero config set omero.web.application_server.max_requests 1
+    $ bin/omero web start  --wsgi-args ' --reload'
+
+Using FastCGI (Unix/Linux) (DEPRECATED)
+---------------------------------------
 
 For convenience you may wish to run a web server under your local user account
 instead of using a system server for testing. Install Nginx

--- a/omero/developers/Web/Deployment.txt
+++ b/omero/developers/Web/Deployment.txt
@@ -80,9 +80,7 @@ listening on 127.0.0.1:4080 that will autoreload on source change:
 Using FastCGI (Unix/Linux) (DEPRECATED)
 ---------------------------------------
 
-.. note::
-    **Deprecated since version 5.1.4**
-    
+.. deprecated:: 5.1.4
     OMERO.web deployment using FastCGI
     is deprecated and will be removed in OMERO 5.2.
     Use :ref:`wsgi_configuration` as an alternative.

--- a/omero/sysadmins/unix/install-web.txt
+++ b/omero/sysadmins/unix/install-web.txt
@@ -17,16 +17,10 @@ with:
    `nginx <http://nginx.org/>`_ and `gunicorn <http://docs.gunicorn.org/>`_,
 -  The built-in Django lightweight development server (for **testing**
    only; see the :doc:`/developers/Web/Deployment` page).
--  FastCGI is DEPRECATED as of 5.1.4 but if you cannot use WSGI as an
-   alternative, a FastCGI capable web server such as
-   `Apache 2.2 <http://httpd.apache.org/>`_ (with
-   `mod\_fastcgi <http://www.fastcgi.com/drupal/>`_ enabled),
-   `Apache 2.4+ <http://httpd.apache.org/>`_ (with the bundled   
-   `mod\_proxy\_fcgi` enabled), `nginx <http://nginx.org/>`_ or
-   `lighttpd <http://www.lighttpd.net/>`_ is still usable on the 5.1.x line
-   (although note that support will be removed in 5.2). You can find more
-   information about FastCGI and where to get modules or packages for your
-   distribution on the `FastCGI website <http://www.fastcgi.com/drupal/node/3>`_.
+-  FastCGI is DEPRECATED as of 5.1.4 and note that support will be removed in
+   5.2. You can find more information about FastCGI and where to get modules
+   or packages for your distribution on the
+   `FastCGI website <http://www.fastcgi.com/drupal/node/3>`_.
 
 If you need help configuring your firewall rules, see the
 :doc:`/sysadmins/server-security` page.
@@ -51,9 +45,8 @@ Deployment
 There is a number of good ways to easily deploy OMERO.web.
 If you have installed Nginx or Apache OMERO can automatically generate a
 configuration file for your web server, see :doc:`install-web/install-wsgi`
-(or :doc:`install-web/install-fastcgi` if you do not have a WSGI capable web
-server). The location of the file will depend on your system, please refer to
-your web server's manual. See
+(or :doc:`install-web/install-fastcgi`). The location of the file will depend
+on your system, please refer to your web server's manual. See
 :ref:`customizing_your_omero_web_installation_unix` for additional
 customization options.
 

--- a/omero/sysadmins/unix/install-web.txt
+++ b/omero/sysadmins/unix/install-web.txt
@@ -10,13 +10,6 @@ includes OMERO.webadmin for managing users and groups.
 OMERO.web is an integral part of the OMERO platform and can be deployed
 with:
 
--  FastCGI using a FastCGI capable web server such as
-   `Apache 2.2 <http://httpd.apache.org/>`_ (with
-   `mod\_fastcgi <http://www.fastcgi.com/drupal/>`_ enabled),
-   `Apache 2.4+ <http://httpd.apache.org/>`_ (with the bundled
-   `mod\_proxy\_fcgi` enabled),
-   `nginx <http://nginx.org/>`_ or
-   `lighttpd <http://www.lighttpd.net/>`_ (since OMERO 4.2.1)
 -  `WSGI <http://wsgi.readthedocs.org>`_ using a WSGI capable web server
    such as
    `Apache 2.2+ <http://httpd.apache.org/>`_ (with
@@ -24,12 +17,19 @@ with:
    `nginx <http://nginx.org/>`_ and `gunicorn <http://docs.gunicorn.org/>`_,
 -  The built-in Django lightweight development server (for **testing**
    only; see the :doc:`/developers/Web/Deployment` page).
+-  FastCGI is DEPRECATED as of 5.1.4 but if you cannot use WSGI as an
+   alternative, a FastCGI capable web server such as
+   `Apache 2.2 <http://httpd.apache.org/>`_ (with
+   `mod\_fastcgi <http://www.fastcgi.com/drupal/>`_ enabled),
+   `Apache 2.4+ <http://httpd.apache.org/>`_ (with the bundled   
+   `mod\_proxy\_fcgi` enabled), `nginx <http://nginx.org/>`_ or
+   `lighttpd <http://www.lighttpd.net/>`_ is still usable on the 5.1.x line
+   (although note that support will be removed in 5.2). You can find more
+   information about FastCGI and where to get modules or packages for your
+   distribution on the `FastCGI website <http://www.fastcgi.com/drupal/node/3>`_.
 
-You can find more information about FastCGI and where to get modules or
-packages for your distribution on the
-`FastCGI website <http://www.fastcgi.com/drupal/node/3>`_.
-
-If you need help configuring your firewall rules, see the :doc:`/sysadmins/server-security` page.
+If you need help configuring your firewall rules, see the
+:doc:`/sysadmins/server-security` page.
 
 Prerequisites
 -------------
@@ -42,18 +42,19 @@ Prerequisites
 
    -  Matplotlib_ should be available for your distribution
 
--  A FastCGI or WSGI capable web server
+-  A WSGI (or FastCGI) capable web server
 
 
 Deployment
 ----------
 
-There’s a number of good ways to easily deploy OMERO.web.
+There is a number of good ways to easily deploy OMERO.web.
 If you have installed Nginx or Apache OMERO can automatically generate a
-configuration file for your web server, see :doc:`install-web/install-fastcgi`
-or :doc:`install-web/install-wsgi`. The location of the file will depend on
-your system, please refer to your web server's manual.
-See :ref:`customizing_your_omero_web_installation_unix` for additional
+configuration file for your web server, see :doc:`install-web/install-wsgi`
+(or :doc:`install-web/install-fastcgi` if you do not have a WSGI capable web
+server). The location of the file will depend on your system, please refer to
+your web server's manual. See
+:ref:`customizing_your_omero_web_installation_unix` for additional
 customization options.
 
 .. toctree::

--- a/omero/sysadmins/unix/install-web.txt
+++ b/omero/sysadmins/unix/install-web.txt
@@ -60,8 +60,8 @@ customization options.
     :maxdepth: 1
     :titlesonly:
 
-    install-web/install-fastcgi
     install-web/install-wsgi
+    install-web/install-fastcgi
 
 
 Logging in to OMERO.web

--- a/omero/sysadmins/unix/install-web/install-fastcgi.txt
+++ b/omero/sysadmins/unix/install-web/install-fastcgi.txt
@@ -2,9 +2,10 @@ OMERO.web FastCGI deployment (DEPRECATED)
 =========================================
 
 .. note::
-    Deprecated since version 5.1.4: OMERO.web deployment using FastCGI
-    is deprecated and will be removed in OMERO 5.2.
-    Use :doc:`install-wsgi` as an alternative.
+    **Deprecated since version 5.1.4**
+    
+    OMERO.web deployment using FastCGI is deprecated and will be removed in
+    OMERO 5.2. Use :doc:`install-wsgi` as an alternative.
 
 
 .. _fastcgi_configuration:

--- a/omero/sysadmins/unix/install-web/install-fastcgi.txt
+++ b/omero/sysadmins/unix/install-web/install-fastcgi.txt
@@ -1,9 +1,7 @@
 OMERO.web FastCGI deployment (DEPRECATED)
 =========================================
 
-.. note::
-    **Deprecated since version 5.1.4**
-    
+.. deprecated:: 5.1.4
     OMERO.web deployment using FastCGI is deprecated and will be removed in
     OMERO 5.2. Use :doc:`install-wsgi` as an alternative.
 

--- a/omero/sysadmins/unix/install-web/install-fastcgi.txt
+++ b/omero/sysadmins/unix/install-web/install-fastcgi.txt
@@ -1,5 +1,11 @@
-OMERO.web FastCGI deployment
-============================
+OMERO.web FastCGI deployment (DEPRECATED)
+=========================================
+
+.. note::
+    Deprecated since version 5.1.4: OMERO.web deployment using FastCGI
+    is deprecated and will be removed in OMERO 5.2.
+    Use (see :doc:`install-wsgi`)
+
 
 .. _fastcgi_configuration:
 

--- a/omero/sysadmins/unix/install-web/install-fastcgi.txt
+++ b/omero/sysadmins/unix/install-web/install-fastcgi.txt
@@ -4,7 +4,7 @@ OMERO.web FastCGI deployment (DEPRECATED)
 .. note::
     Deprecated since version 5.1.4: OMERO.web deployment using FastCGI
     is deprecated and will be removed in OMERO 5.2.
-    Use (see :doc:`install-wsgi`)
+    Use :doc:`install-wsgi` as an alternative.
 
 
 .. _fastcgi_configuration:

--- a/omero/sysadmins/unix/install-web/install-wsgi.txt
+++ b/omero/sysadmins/unix/install-web/install-wsgi.txt
@@ -91,13 +91,18 @@ Start the Gunicorn worker processes running one thread listening on 127.0.0.1:40
 
 Additional settings can be configured from command line arguments:
 
-* `--workers WORKERS` - the number of worker processes for handling requests.
+.. option:: --workers WORKERS
 
-* `--worker-connections WORKER_CONNECTIONS` - the maximum number of
-  simultaneous clients.
+    The number of worker processes for handling requests.
 
-* `--wsgi-args WSGI_ARGS` - additional arguments. For more details
-  check `Gunicorn Documentation <http://docs.gunicorn.org/en/latest/settings.html>`_.
+.. option:: --worker-connections WORKER_CONNECTIONS
+
+    The maximum number of simultaneous clients.
+
+.. option:: --wsgi-args WSGI_ARGS
+
+    Additional arguments. For more details check
+    `Gunicorn Documentation <http://docs.gunicorn.org/en/latest/settings.html>`_.
 
 
 The Gunicorn workers are managed **separately** from other OMERO.server

--- a/omero/sysadmins/unix/install-web/install-wsgi.txt
+++ b/omero/sysadmins/unix/install-web/install-wsgi.txt
@@ -91,6 +91,8 @@ Start the Gunicorn worker processes running one thread listening on 127.0.0.1:40
 
 Additional settings can be configured from command line arguments:
 
+.. program:: omero web start
+
 .. option:: --workers WORKERS
 
     The number of worker processes for handling requests.

--- a/omero/sysadmins/unix/install-web/install-wsgi.txt
+++ b/omero/sysadmins/unix/install-web/install-wsgi.txt
@@ -89,6 +89,18 @@ Start the Gunicorn worker processes running one thread listening on 127.0.0.1:40
     ... static files copied to '/usr/local/dev/openmicroscopy/dist/lib/python/omeroweb/static'.
     Starting OMERO.web... [OK]
 
+.. note::
+    Additional setting can be configured from command line arguments:
+
+    * --workers WORKERS - The number of worker processes for handling requests.
+
+    * --worker-connections WORKER_CONNECTIONS - he maximum number of
+      simultaneous clients.
+
+    * --wsgi-args WSGI_ARGS - Additional arguments. For more details
+      check `Gunicorn Documentation <http://docs.gunicorn.org/en/latest/settings.html>`_.
+
+
 The Gunicorn workers are managed **separately** from other OMERO.server
 processes. You can check their status or stop them using the
 following commands:

--- a/omero/sysadmins/unix/install-web/install-wsgi.txt
+++ b/omero/sysadmins/unix/install-web/install-wsgi.txt
@@ -93,7 +93,7 @@ Additional settings can be configured from command line arguments:
 
 * `--workers WORKERS` - the number of worker processes for handling requests.
 
-* `--worker-connections` WORKER_CONNECTIONS - the maximum number of
+* `--worker-connections WORKER_CONNECTIONS` - the maximum number of
   simultaneous clients.
 
 * `--wsgi-args WSGI_ARGS` - additional arguments. For more details

--- a/omero/sysadmins/unix/install-web/install-wsgi.txt
+++ b/omero/sysadmins/unix/install-web/install-wsgi.txt
@@ -89,16 +89,15 @@ Start the Gunicorn worker processes running one thread listening on 127.0.0.1:40
     ... static files copied to '/usr/local/dev/openmicroscopy/dist/lib/python/omeroweb/static'.
     Starting OMERO.web... [OK]
 
-.. note::
-    Additional setting can be configured from command line arguments:
+Additional settings can be configured from command line arguments:
 
-    * --workers WORKERS - The number of worker processes for handling requests.
+* `--workers WORKERS` - the number of worker processes for handling requests.
 
-    * --worker-connections WORKER_CONNECTIONS - he maximum number of
-      simultaneous clients.
+* `--worker-connections` WORKER_CONNECTIONS - the maximum number of
+  simultaneous clients.
 
-    * --wsgi-args WSGI_ARGS - Additional arguments. For more details
-      check `Gunicorn Documentation <http://docs.gunicorn.org/en/latest/settings.html>`_.
+* `--wsgi-args WSGI_ARGS` - additional arguments. For more details
+  check `Gunicorn Documentation <http://docs.gunicorn.org/en/latest/settings.html>`_.
 
 
 The Gunicorn workers are managed **separately** from other OMERO.server

--- a/omero/sysadmins/windows/install-web.txt
+++ b/omero/sysadmins/windows/install-web.txt
@@ -11,21 +11,20 @@ OMERO.web is an integral part of the OMERO platform and can be deployed
 with:
 
 -  IIS 6.0 or 7.0 on Microsoft Windows
--  FastCGI using a FastCGI capable web server such as
-   `Apache 2.2 <http://httpd.apache.org/>`_ (with
-   `mod\_fastcgi <http://www.fastcgi.com/drupal/>`_ enabled),
-   `Apache 2.4+ <http://httpd.apache.org/>`_ (with the bundled
-   `mod\_proxy\_fcgi` enabled),
-   `nginx <http://nginx.org/>`_ or
-   `lighttpd <http://www.lighttpd.net/>`_ (since OMERO 4.2.1)
+-  `WSGI <http://wsgi.readthedocs.org/en/latest/>`_ using a WSGI capable web
+   server such as `Apache 2.2+ <http://httpd.apache.org>`_ (with
+   `mod wsgi <http://modwsgi.readthedocs.org/en/develop/>`_ enabled) or
+   `nginx <http://nginx.org>`_ and
+   `gunicorn <http://docs.gunicorn.org/en/19.3/>`_.
 -  The built-in Django lightweight development server (for **testing**
    only; see the :doc:`/developers/Web/Deployment` page)
+-  FastCGI is DEPRECATED as of 5.1.4 and note that support will be removed in
+   5.2. You can find more information about FastCGI and where to get modules
+   or packages for your distribution on the
+   `FastCGI website <http://www.fastcgi.com/drupal/node/3>`_.
 
-You can find more information about FastCGI and where to get modules or
-packages for your distribution on the
-`FastCGI website <http://www.fastcgi.com/drupal/node/3>`_.
-
-If you need help configuring your firewall rules, see the :doc:`/sysadmins/server-security` page.
+If you need help configuring your firewall rules, see the
+:doc:`/sysadmins/server-security` page.
 
 Prerequisites
 -------------
@@ -38,7 +37,7 @@ Prerequisites
 
    -  Matplotlib_ should be available for your distribution
 
--  IIS or a FastCGI capable web server
+-  IIS or WSGI (or FastCGI) capable web server
 
 Quick start
 -----------


### PR DESCRIPTION
This is the same as gh-1275 but rebased onto develop.

This will need updating once fastcgi is actually removed but keeps the updates to the related pages in sync for now.
