### PR TITLE
Matlab: add documentation for write functions group support (rebased onto develop)

### DIFF
--- a/omero/developers/Matlab.txt
+++ b/omero/developers/Matlab.txt
@@ -643,7 +643,7 @@ function::
     tagAnnotation = writeTagAnnotation(session, 'tag name');
     % Create a timestamp annotation
     timestampAnnotation = writeTimestampAnnotation(session, now);
-    % Create a XML annotation
+    % Create an XML annotation
     xmlAnnotation = writeXmlAnnotation(session, xmlString);
 
 File annotations can also be created from the content of a

--- a/omero/developers/Matlab.txt
+++ b/omero/developers/Matlab.txt
@@ -692,15 +692,17 @@ Writing data
 Projects and datasets can be created in the context of the session group
 using the :source:`createProject <components/tools/OmeroM/src/io/createProject.m>` and :source:`createDataset <components/tools/OmeroM/src/io/createDataset.m>` functions::
 
-    % Create a new project and a dataset
+    % Create a new project in the context of the session group
     newproject = createProject(session, 'project name');
+    % Create a new dataset in the context of the session group
     newdataset = createDataset(session, 'dataset name');
 
 Writing projects/datasets in a different context than the session group can be
 achieved by passing the group identifier using the `group` parameter::
 
-    % Create a new project and a linked dataset in the specified group
+    % Create a new project in the specified group
     newproject = createProject(session, 'project name', 'group', groupId);
+    % Create a new dataset in the specified group
     newdataset = createDataset(session, 'dataset name', 'group', groupId);
 
 When creating a dataset, it is possible to link it to an existing project
@@ -719,15 +721,17 @@ context is determined by the parent project:
 Screens and plates can be created in the context of the session group
 using the :source:`createScreen <components/tools/OmeroM/src/io/createScreen.m>` and :source:`createPlate <components/tools/OmeroM/src/io/createPlate.m>` functions::
 
-    % Create a new screen and a plate
+    % Create a new screen in the context of the session group
     newscreen = createScreen(session, 'screen name');
+    % Create a new plate in the context of the session group
     newplate = createPlate(session, 'plate name');
 
 Writing screens/plates in a different context than the session group can be
 achieved by passing the group identifier using the `group` parameter::
 
-    % Create a new screen and a linked plate in the specified group
+    % Create a new screen in the specified group
     newscreen = createScreen(session, 'screen name', 'group', groupId);
+    % Create a new plate in the specified group
     newplate = createPlate(session, 'plate name', 'group', groupId);
 
 When creating a plate, it is possible to link it to an existing screen

--- a/omero/developers/Matlab.txt
+++ b/omero/developers/Matlab.txt
@@ -664,21 +664,56 @@ by the content of ``local_file_path`` using::
 Writing data
 ------------
 
--  **Create a Dataset** and link it to an existing project.
+-  **Projects/Datasets**
 
-::
+Projects and datasets can be created in the context of the session group
+using the :source:`createProject <components/tools/OmeroM/src/io/createProject.m>` and :source:`createDataset <components/tools/OmeroM/src/io/createDataset.m>` functions::
 
-    dataset = omero.model.DatasetI;
-    dataset.setName(omero.rtypes.rstring(char('name dataset')));
-    dataset.setDescription(omero.rtypes.rstring(char('description dataset')));
+    % Create a new project and a dataset
+    newproject = createProject(session, 'project name');
+    newdataset = createDataset(session, 'dataset name');
 
-    % Link Dataset and Project
+When creating a dataset, it is possible to link it to an existing project
+using either the project object or its identifier::
 
-    link = omero.model.ProjectDatasetLinkI;
-    link.setChild(dataset);
-    link.setParent(omero.model.ProjectI(projectId, false));
+    % Create a new dataset linked to an existing project
+    newdataset = createDataset(session, 'dataset name', project);
+    newdataset = createDataset(session, 'dataset name', projectId);
 
-    session.getUpdateService().saveAndReturnObject(link);
+Writing projects/datasets in a different context than the session group can be
+achieved by passing the group identifier using the `group` parameter::
+
+    % Create a new project and a linked dataset in the specified group
+    newproject = createProject(session, 'project name', 'group', groupId);
+    newdataset = createDataset(session, 'dataset name', project, 'group', groupId);
+
+-  **Screens/Plates**
+
+Screens and plates can be created in the context of the session group
+using the :source:`createScreen <components/tools/OmeroM/src/io/createScreen.m>` and :source:`createPlate <components/tools/OmeroM/src/io/createPlate.m>` functions::
+
+    % Create a new screen and a plate
+    newscreen = createScreen(session, 'screen name');
+    newplate = createPlate(session, 'plate name');
+
+When creating a plate, it is possible to link it to an existing screen
+using either the screen object or its identifier::
+
+    % Create a new plate linked to an existing screen
+    newplate = createPlate(session, 'plate name', screen);
+    newplate = createPlate(session, 'plate name', screenId);
+
+Writing screens/plates in a different context than the session group can be
+achieved by passing the group identifier using the `group` parameter::
+
+    % Create a new screen and a linked plate in the specified group
+    newscreen = createScreen(session, 'screen name', 'group', groupId);
+    newplate = createPlate(session, 'plate name', screen, 'group', groupId);
+
+.. seealso::
+  :source:`WriteData.m <examples/Training/matlab/WriteData.m>`
+    Example script showing methods to create projects, datasets, plates and
+    screens
 
 How to use OMERO tables
 -----------------------

--- a/omero/developers/Matlab.txt
+++ b/omero/developers/Matlab.txt
@@ -707,7 +707,7 @@ achieved by passing the group identifier using the `group` parameter::
 
 When creating a dataset, it is possible to link it to an existing project
 using either the project object or its identifier. In this case, the group
-context is determined by the parent project:
+context is determined by the parent project::
 
     % Create two new projects in different groups
     project1 = createProject(session, 'project name');
@@ -736,7 +736,7 @@ achieved by passing the group identifier using the `group` parameter::
 
 When creating a plate, it is possible to link it to an existing screen
 using either the screen object or its identifier. In this case, the group
-context is determined by the parent screen:
+context is determined by the parent screen::
 
     % Create two new projects in different groups
     screen1 = createScreen(session, 'screen name');

--- a/omero/developers/Matlab.txt
+++ b/omero/developers/Matlab.txt
@@ -631,14 +631,37 @@ known::
 -  **Writing and linking annotations**
 
 New annotations can be created using the corresponding ``write*Annotation``
-function. For example, to create a new tag annotation with value
-``tag_name``::
+function::
 
-    tagAnnotation = writeTagAnnotation(session, tag_name);
+    % Create a comment annotation
+    commentAnnotation = writeCommentAnnotation(session, 'comment');
+    % Create a double annotation
+    doubleAnnotation = writeDoubleAnnotation(session, .5);
+    % Create a map annotation
+    mapAnnotation = writeDoubleAnnotation(session, 'key', value);
+    % Create a tag annotation
+    tagAnnotation = writeTagAnnotation(session, 'tag name');
+    % Create a timestamp annotation
+    timestampAnnotation = writeTimestampAnnotation(session, now);
+    % Create a XML annotation
+    xmlAnnotation = writeXmlAnnotation(session, xmlString);
 
-To create a file annotations from the content of a ``local_file_path``::
+File annotations can also be created from the content of a
+:file:`local_file_path`::
 
     fileAnnotation = writeFileAnnotation(session, local_file_path);
+
+Each annotation creation function will use the context of the session group by
+default. To create the annotation in a different group, use the ``group``
+key/value pair::
+
+    commentAnnotation = writeCommentAnnotation(session, 'comment', 'group', groupId);
+    doubleAnnotation = writeDoubleAnnotation(session, .5, 'group', groupId);
+    mapAnnotation = writeDoubleAnnotation(session, 'key', value, 'group', groupId);
+    tagAnnotation = writeTagAnnotation(session, 'tag name', 'group', groupId);
+    timestampAnnotation = writeTimestampAnnotation(session, now, 'group', groupId);
+    xmlAnnotation = writeXmlAnnotation(session, xmlString, 'group', groupId);
+    fileAnnotation = writeFileAnnotation(session, local_file_path, 'group', groupId);
 
 Existing annotations can be linked to existing objects on the server using the
 :source:`linkAnnotation <components/tools/OmeroM/src/annotations/linkAnnotation.m>`

--- a/omero/developers/Matlab.txt
+++ b/omero/developers/Matlab.txt
@@ -651,7 +651,7 @@ File annotations can also be created from the content of a
 
     fileAnnotation = writeFileAnnotation(session, local_file_path);
 
-Each annotation creation function will use the context of the session group by
+Each annotation creation function uses the context of the session group by
 default. To create the annotation in a different group, use the ``group``
 key/value pair::
 

--- a/omero/developers/Matlab.txt
+++ b/omero/developers/Matlab.txt
@@ -696,19 +696,23 @@ using the :source:`createProject <components/tools/OmeroM/src/io/createProject.m
     newproject = createProject(session, 'project name');
     newdataset = createDataset(session, 'dataset name');
 
-When creating a dataset, it is possible to link it to an existing project
-using either the project object or its identifier::
-
-    % Create a new dataset linked to an existing project
-    newdataset = createDataset(session, 'dataset name', project);
-    newdataset = createDataset(session, 'dataset name', projectId);
-
 Writing projects/datasets in a different context than the session group can be
 achieved by passing the group identifier using the `group` parameter::
 
     % Create a new project and a linked dataset in the specified group
     newproject = createProject(session, 'project name', 'group', groupId);
-    newdataset = createDataset(session, 'dataset name', project, 'group', groupId);
+    newdataset = createDataset(session, 'dataset name', 'group', groupId);
+
+When creating a dataset, it is possible to link it to an existing project
+using either the project object or its identifier. In this case, the group
+context is determined by the parent project:
+
+    % Create two new projects in different groups
+    project1 = createProject(session, 'project name');
+    project2 = createProject(session, 'project name', 'group', groupId);
+    % Create new datasets linked to each project
+    dataset1 = createDataset(session, 'dataset name', project1);
+    dataset2 = createDataset(session, 'dataset name', project2.getId().getValue());
 
 -  **Screens/Plates**
 
@@ -719,19 +723,23 @@ using the :source:`createScreen <components/tools/OmeroM/src/io/createScreen.m>`
     newscreen = createScreen(session, 'screen name');
     newplate = createPlate(session, 'plate name');
 
-When creating a plate, it is possible to link it to an existing screen
-using either the screen object or its identifier::
-
-    % Create a new plate linked to an existing screen
-    newplate = createPlate(session, 'plate name', screen);
-    newplate = createPlate(session, 'plate name', screenId);
-
 Writing screens/plates in a different context than the session group can be
 achieved by passing the group identifier using the `group` parameter::
 
     % Create a new screen and a linked plate in the specified group
     newscreen = createScreen(session, 'screen name', 'group', groupId);
-    newplate = createPlate(session, 'plate name', screen, 'group', groupId);
+    newplate = createPlate(session, 'plate name', 'group', groupId);
+
+When creating a plate, it is possible to link it to an existing screen
+using either the screen object or its identifier. In this case, the group
+context is determined by the parent screen:
+
+    % Create two new projects in different groups
+    screen1 = createScreen(session, 'screen name');
+    screen2 = createScreen(session, 'screen name', 'group', groupId
+    % Create new datasets linked to each project
+    plate1 = createPlate(session, 'plate name', screen1);
+    plate2 = createPlate(session, 'plate name', screen2.getId().getValue());
 
 .. seealso::
   :source:`WriteData.m <examples/Training/matlab/WriteData.m>`

--- a/omero/developers/Matlab.txt
+++ b/omero/developers/Matlab.txt
@@ -638,7 +638,7 @@ function::
     % Create a double annotation
     doubleAnnotation = writeDoubleAnnotation(session, .5);
     % Create a map annotation
-    mapAnnotation = writeDoubleAnnotation(session, 'key', value);
+    mapAnnotation = writeMapAnnotation(session, 'key', value);
     % Create a tag annotation
     tagAnnotation = writeTagAnnotation(session, 'tag name');
     % Create a timestamp annotation
@@ -657,7 +657,7 @@ key/value pair::
 
     commentAnnotation = writeCommentAnnotation(session, 'comment', 'group', groupId);
     doubleAnnotation = writeDoubleAnnotation(session, .5, 'group', groupId);
-    mapAnnotation = writeDoubleAnnotation(session, 'key', value, 'group', groupId);
+    mapAnnotation = writeMapAnnotation(session, 'key', value, 'group', groupId);
     tagAnnotation = writeTagAnnotation(session, 'tag name', 'group', groupId);
     timestampAnnotation = writeTimestampAnnotation(session, now, 'group', groupId);
     xmlAnnotation = writeXmlAnnotation(session, xmlString, 'group', groupId);


### PR DESCRIPTION
This is the same as gh-1278 but rebased onto develop.

---

See https://trello.com/c/gSKqCAe2/49-omero-matlab-group-support

This PR:
- reviews the `writexxAnnotation` functions giving concrete examples for each existing annotation type
- adds example of annotation writing command in a different group
- documents the project/dataset/screen/plate creation functions with and without group support
