### PR TITLE
Migrate to Travis Docker container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,18 @@
 language: python
 
-python:
-  - "2.6"
+# This (sudo: false) is needed to "run on container-based infrastructure" on
+# which cache: is available
+# http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+sudo: false
+
+# http://docs.travis-ci.com/user/caching/
+cache: pip
+
 
 env:
-  - SPHINXOPTS="-W" CLASSPATH="/usr/share/java/ant-contrib.jar"
+  - SPHINXOPTS="-W"
 
 before_install:
-  - sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ trusty main universe"
-  - travis_retry sudo apt-get update
-  - travis_retry sudo apt-get -y install ant ant-contrib ant-optional
-  - travis_retry sudo apt-get -y install texlive-latex-base texlive-latex-recommended texlive-xetex
-  - travis_retry sudo apt-get -y install texlive-latex-extra texlive-fonts-recommended fonts-texgyre
-  - sudo fc-cache -rsfv
-  - fc-list
-  - sudo pip install scc Sphinx==1.2.3
-  - git config --global github.token 3bc7fc530b01081559eb911f59ccfec7f4fb2592
-  - git config --global user.email snoopycrimecop@gmail.com
-  - git config --global user.name 'Snoopy Crime Cop'
-  - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
-  - scc travis-merge
+  - pip install --user Sphinx==1.2.3
 
-script: "make html pdf clean"
+script: make clean html

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ env:
   - SPHINXOPTS="-W"
 
 before_install:
-  - pip install --user Sphinx==1.2.3
+  - pip install Sphinx==1.2.3
 
 script: make clean html


### PR DESCRIPTION
This PR  migrates the Travis build to using Docker containers in order to speed up build times as well as the queuing for the organization.

Like https://github.com/openmicroscopy/bioformats/pull/1968, one caveat of this PR is that it drops the `pdf` target of the top-level build command. This target is however tested by the various Jenkins doc jobs.
