### PR TITLE
Fix installation link for MlabWrap

### DIFF
--- a/omero/developers/scripts/matlab-scripts.txt
+++ b/omero/developers/scripts/matlab-scripts.txt
@@ -7,8 +7,8 @@ Python package `Mlabwrap <http://mlabwrap.sourceforge.net>`_.
 Installing Mlabwrap
 -------------------
 
-To install MlabWrap follow the installation guide at
-`http://www.scipy.org/MlabWrap <http://www.scipy.org/MlabWrap>`_ and
+To install MlabWrap follow the
+`installation guide <http://mlabwrap.sourceforge.net/#installation>`_ and
 make sure that the paths are set for the environment variables:
 
 ::


### PR DESCRIPTION
This should fix the broken links reported from the linkcheck target of the OMERO documentation.