### PR TITLE
initial 5.2 updates & Java version changes

### DIFF
--- a/omero/developers/Python.txt
+++ b/omero/developers/Python.txt
@@ -143,7 +143,7 @@ Connect to OMERO
 
 ::
 
-        # New in OMERO 5
+        # Added in OMERO 5.0
         print "Admins:"
         for exp in conn.getAdministrators():
             print "   ID: %s %s Name: %s" % (
@@ -532,7 +532,7 @@ Write data
     project = conn.getObject("Project", projectId)
     project.linkAnnotation(tagAnn)
 
--  **New in OMERO 5.1: 'Map' annotations (list of key: value pairs)**
+-  **Added in OMERO 5.1: 'Map' annotations (list of key: value pairs)**
 
 ::
 
@@ -1143,7 +1143,7 @@ Create Image
 
     print 'Created new Image:%s Name:"%s"' % (i.getId(), i.getName())
 
--  **Set the pixel size using units (new in 5.1.0)**
+-  **Set the pixel size using units (added in 5.1.0)**
 
 
 Lengths are specified by value and a unit enumeration
@@ -1215,8 +1215,8 @@ Here we set the pixel size X and Y to be 9.8 Angstroms
     # When you are done, close the session to free up server resources.
     conn._closeSession()
 
-Filesets - New in OMERO 5
-^^^^^^^^^^^^^^^^^^^^^^^^^
+Filesets - added in OMERO 5.0
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 -  **Create a connection**
 

--- a/omero/developers/Server/ExtendingOmero.txt
+++ b/omero/developers/Server/ExtendingOmero.txt
@@ -34,10 +34,10 @@ point you back to this page for packaging and deploying your new code.
    password backend
 -  :doc:`/developers/Modules/Search/Bridges` - write Java Lucene parsers
    to extend search
--  :doc:`/sysadmins/mail` - server email sender (new for OMERO 5.1, no
+-  :doc:`/sysadmins/mail` - server email sender (added in OMERO 5.1, no
    developer documentation as yet)
 -  :property:`omero.policy.bean` - policy configuration point e.g. for setting
-   download restriction policy on users (new for OMERO 5.1, no developer
+   download restriction policy on users (added in OMERO 5.1, no developer
    documentation as yet)
 
 Extending the Model

--- a/omero/developers/Server/ObjectGraphs.txt
+++ b/omero/developers/Server/ObjectGraphs.txt
@@ -7,7 +7,7 @@ Model graph operations
   impact on related objects. For instance, deleting an image may entail
   deleting users' rendering settings for that image, also the links to
   any datasets that the image is in. Version 5.1.0 of the OMERO server
-  includes a new algorithm for determining which model objects to act
+  included a new algorithm for determining which model objects to act
   on. Clients should be :doc:`using the new 5.1 graph requests
   <GraphsMigration>` because the previous ones will be *removed* in
   OMERO 5.3. Understanding the details of the new implementation

--- a/omero/developers/whatsnew.txt
+++ b/omero/developers/whatsnew.txt
@@ -1,6 +1,12 @@
 What's new for OMERO 5.2 for developers
 =======================================
 
+- The :doc:`/sysadmins/version-requirements` section provides extensive
+  details about which operating systems and dependency versions we intend to
+  support for the life of 5.2 and the likely changes to these for the next
+  major release (currently planned to be 5.3). Most notably for development
+  purposes, we have dropped support for Java 1.6.
+
 The Java gateway has undergone a major overhaul [details to follow]
 
 Breaking changes
@@ -18,12 +24,15 @@ information.
 Graphs
 ^^^^^^
 
-The API's request operations :javadoc:`Chgrp
+The API's request operations :javadoc:`Chmod
+<slice2html/omero/cmd/Chmod.html>`, :javadoc:`Chgrp
 <slice2html/omero/cmd/Chgrp.html>`, :javadoc:`Chown
 <slice2html/omero/cmd/Chown.html>`, :javadoc:`Delete
 <slice2html/omero/cmd/Delete.html>`, and their superclass
-:javadoc:`GraphModify <slice2html/omero/cmd/GraphModify.html>`, are now
-deprecated and will be removed in 5.3. They are replaced by :javadoc:`Chgrp2
+:javadoc:`GraphModify <slice2html/omero/cmd/GraphModify.html>`, were
+deprecated in 5.1 and will be removed in 5.3. They are replaced by
+:javadoc:`Chmod2
+<slice2html/omero/cmd/Chmod2.html>`:javadoc:`Chgrp2
 <slice2html/omero/cmd/Chgrp2.html>`, :javadoc:`Chown2
 <slice2html/omero/cmd/Chown2.html>`, :javadoc:`Delete2
 <slice2html/omero/cmd/Delete2.html>`, and their superclass

--- a/omero/developers/whatsnew.txt
+++ b/omero/developers/whatsnew.txt
@@ -1,27 +1,7 @@
-What's new for OMERO 5.1 for developers
+What's new for OMERO 5.2 for developers
 =======================================
 
-- The :doc:`/sysadmins/version-requirements` section provides extensive
-  details about which operating systems and dependency versions we will be
-  supporting for the life of 5.1 and the likely changes to these for the next
-  major release (currently planned to be 5.2). Most notably for development
-  purposes, we are deprecating support for Java 1.6 and Python 2.6.
-- :doc:`Model/Units` introduces the new Units-types which are available
-  for use from :doc:`Model Objects <Model/EveryObject>` (note that this
-  documentation has been expanded since the release of 5.1.2 and is still a
-  work in progress).
-- Similarly, :doc:`Model/KeyValuePairs` introduces the new concept of a
-  "map" type, which consists of ordered lists of key-value pairs.
-- :doc:`Server/ObjectGraphs` explains how the new graph operations of
-  :javadoc:`omero::cmd <slice2html/omero/cmd.html>` are implemented.
-- Deprecated methods in IContainer and RenderingEngine have been removed, as
-  have the deprecated services IDelete and Gateway.
-- Pojos methods have been deprecated and replaced by corresponding units
-  methods.
-- OMERO 5.1 requires a Unicode-encoded (UTF8) database.
-- Since OMERO 5.1.3, the Bio-Formats submodule has been removed from the source
-  code and Bio-Formats is managed as another dependency using Ivy. See
-  :doc:`build-system` for more details.
+The Java gateway has undergone a major overhaul [details to follow]
 
 Breaking changes
 ----------------
@@ -29,15 +9,11 @@ Breaking changes
 OMERO.web
 ^^^^^^^^^
 
-There have been many updates to this client for 5.1. See the
-:ref:`web-breaking-changes` section on the :doc:`/sysadmins/whatsnew` page for
-further details.
+OMERO.web has undergone a major upgrade, updating jsTree to version 3 and
+using json for all tree loading to substantially improve performance.
 
-OMERO.web template and view writers need to use the ``@render_response()``
-decorator, see :ref:`render-response` for more details.
-
-The redundant ``-locked`` flag has been removed from data manager tree nodes
-e.g. ``dataset-locked`` is now simply ``dataset``.
+See the :pythondoc:`OMERO.web python docs <omeroweb/omeroweb.html>` for more
+information.
 
 Graphs
 ^^^^^^
@@ -47,51 +23,12 @@ The API's request operations :javadoc:`Chgrp
 <slice2html/omero/cmd/Chown.html>`, :javadoc:`Delete
 <slice2html/omero/cmd/Delete.html>`, and their superclass
 :javadoc:`GraphModify <slice2html/omero/cmd/GraphModify.html>`, are now
-deprecated. They are replaced by :javadoc:`Chgrp2
+deprecated and will be removed in 5.3. They are replaced by :javadoc:`Chgrp2
 <slice2html/omero/cmd/Chgrp2.html>`, :javadoc:`Chown2
 <slice2html/omero/cmd/Chown2.html>`, :javadoc:`Delete2
 <slice2html/omero/cmd/Delete2.html>`, and their superclass
-:javadoc:`GraphModify2 <slice2html/omero/cmd/GraphModify2.html>`. To
-allow each deprecated request to be implemented by its corresponding
-replacement, a partial API compatibility layer is included in OMERO 5.1
-and is activated by default through the new configuration property
-:property:`omero.graphs.wrap`. If the new request implementations
-introduce regressions, setting that property to ``false`` will
-reactivate the implementations from OMERO 5.0. However, the
-configuration property :property:`omero.graphs.wrap` will be *removed*
-in OMERO 5.2 and :javadoc:`Chgrp <slice2html/omero/cmd/Chgrp.html>`,
-:javadoc:`Chown <slice2html/omero/cmd/Chown.html>`, :javadoc:`Delete
-<slice2html/omero/cmd/Delete.html>`, and :javadoc:`GraphModify
-<slice2html/omero/cmd/GraphModify.html>`, will be *removed* in OMERO
-5.3. OMERO 5.1 users should thus be :doc:`using the new 5.1 graph
-requests <Server/GraphsMigration>` so that problems may be detected and
-corrected before the deprecated features are removed.
-
-Tables
-^^^^^^
-
-OMERO.tables attribute names beginning with `__` are reserved for internal
-use, see :doc:`Tables`.
-
-ImportContainer
-^^^^^^^^^^^^^^^
-
-Changes to ImportContainer will break any listeners implemented by external
-developers.
-
-Units
-^^^^^
-
-A number of Objects formerly of numerical type are now unit quantities. As a
-result, code working with these types will no longer compile and queries of
-these types will now return different values. For example, as explained in
-:ref:`querying-units`, to return the floating point number using::
-
-   select planeInfo.exposureTime from PlaneInfo planeInfo ...
-
-you now need to add ``.value`` as follows::
-
-   select planeInfo.exposureTime.value from PlaneInfo planeInfo ...
-
-and you also need the enum to go along with it.
+:javadoc:`GraphModify2 <slice2html/omero/cmd/GraphModify2.html>`.
+OMERO developers who have not migrated yet should refer to
+:doc:`Server/GraphsMigration` and take action before the deprecated features
+are removed.
 

--- a/omero/index.txt
+++ b/omero/index.txt
@@ -35,12 +35,12 @@ Additional online resources can be found at:
   now managed by the main OME team, providing the latest released version of
   OMERO for you to try out (barring a short lag time for upgrading).
 
-OMERO version *5.1* uses the :schema_plone:`January 2015 release
+OMERO version *5.2* uses the :schema_plone:`January 2015 release
 <Documentation/Generated/OME-2015-01/ome.html>` of the :model_doc:`OME Data
 Model <>`. The :doc:`users/history` page details the development of OMERO
 functionality over time.
 
-A summary of breaking changes and new features for version 5.1 can be found on
+A summary of breaking changes and new features for version 5.2 can be found on
 the pages below:
 
 - :doc:`What's new for OMERO users<users/whatsnew>`

--- a/omero/sysadmins/whatsnew.txt
+++ b/omero/sysadmins/whatsnew.txt
@@ -1,88 +1,13 @@
-What's new for OMERO 5.1 for sysadmins
+What's new for OMERO 5.2 for sysadmins
 ======================================
 
-- The :doc:`version-requirements` section provides extensive details about
-  which operating systems and dependency versions we will be supporting for
-  the life of 5.1 and the likely changes to these for the next major release
-  (currently planned to be 5.2).
+- OMERO clients are no longer distributed as Java Web Start applications. This
+  decision is discussed at length in our `Java Web Start blog post <http://blog.openmicroscopy.org/tech-issues/future-plans/2015/09/23/java-web-start/>`_.
+  We recognize that this will be problematic for some institutional users and
+  are working to expand the functionality of OMERO.web to mitigate this as far
+  as possible.
 
-- A new configuration property :property:`omero.graphs.wrap` allows
-  switching back to the old server code for moving and deleting data. If
-  a regression with the new code requires changing this setting, ensure
-  that a bug is filed with the OME team so it can be fixed before this
-  configuration property is *removed* in OMERO 5.2.
-
-- The server download policy can now be configured to restrict users' ability
-  to download the original data e.g. by user or by data type. This is one of
-  the features we have introduced to help support using OMERO for data
-  publication. More information about how to configure your server for this
-  purpose is available in the updated :ref:`index-public-data` section.
-
-- OMERO usernames can now be made :ref:`case insensitive <case-sensitivity>`.
-
-Database
---------
-
-- OMERO 5.1 requires Postgres 9.2 or later, the OMERO database upgrade script
-  will not run on older versions.
-
-- OMERO 5.1 requires a Unicode-encoded (UTF8) database, the
-  :doc:`server-upgrade` page has been updated to reflect this.
-
-
-.. _web-breaking-changes:
-
-OMERO.web
----------
-
-- OMERO.web now defaults to being mounted at the root on all webservers with
-  the exception of IIS (Windows production deployment) where it continues to
-  be mounted on ``/omero``. Static files continue to be served from
-  ``/static``. :ref:`Both prefixes can be customized
-  <customizing_your_omero_web_installation_unix>` (including on IIS) but note
-  the configuration property :property:`omero.web.force_script_name` has
-  changed to :property:`omero.web.prefix`.
-
-- :ref:`Apache 2.4 with mod_proxy_fcgi <apache24_configuration>` is now
-  supported.
-
-- OMERO.web FastCGI processes default to listening on 127.0.0.1 instead of
-  all network interfaces. This improves security, see
-  :ref:`customizing_your_omero_web_installation_unix` if you need to listen
-  on another interface.
-
-- If OMERO.web is disabled the generated Nginx and Apache configurations
-  automatically display a maintenance page.
-
-- The semantics of the command for generating the Nginx configuration has
-  been modified as described below:
-
-  .. list-table::
-    :header-rows: 1
-
-    * - Version
-      - 5.0.x command
-      - 5.1.x command
-    * - System configuration
-      - ``omero web config nginx --system``
-      - ``omero web config nginx``
-    * - User configuration
-      - ``omero web config nginx``
-      - ``omero web config nginx-development``
-
-OMERO.mail
-----------
-
-A new :doc:`additional feature <advanced-install>` has been added. :doc:`mail`
-allows you to configure the server to email users, for example to alert group
-owners to broken links in OMERO.web.
-
-OMERO permissions system
-------------------------
-
-Read-Write groups are now (as of OMERO version 5.1.2) supported in the
-clients. This group type essentially allows all members to act as if they
-co-own the data except for the ability to move it between groups. Existing
-groups can be promoted to this permissions level via your usual OMERO admin
-tool. See :doc:`server-permissions` for more details.
+- The configuration property :property:`omero.graphs.wrap` which allowed
+  switching back to the old server code for moving and deleting data has now
+  been removed. You must migrate to using the new request operations.
 

--- a/omero/sysadmins/whatsnew.txt
+++ b/omero/sysadmins/whatsnew.txt
@@ -7,6 +7,12 @@ What's new for OMERO 5.2 for sysadmins
   are working to expand the functionality of OMERO.web to mitigate this as far
   as possible.
 
+- The :doc:`version-requirements` section provides extensive
+  details about which operating systems and dependency versions we intend to
+  support for the life of 5.2 and the likely changes to these for the next
+  major release (currently planned to be 5.3). Most notably, we have dropped
+  support for Java 1.6.
+
 - The configuration property :property:`omero.graphs.wrap` which allowed
   switching back to the old server code for moving and deleting data has now
   been removed. You must migrate to using the new request operations.

--- a/omero/users/clients-overview.txt
+++ b/omero/users/clients-overview.txt
@@ -16,10 +16,10 @@ installations worldwide, OMERO has been shown to be relatively easy to install
 and get running.
 
 OMERO.insight and OMERO.importer are desktop applications written in Java
-and require Java 1.6 (or higher) to be installed on the user's computer
+and require Java 1.7 (or higher) to be installed on the user's computer
 (automatically installed on most up-to-date OS X and Windows XP systems).
 
-Our **NEW** user assistance :help:`help website<>` provides a series of 
+Our user assistance :help:`help website<>` provides a series of 
 workflow-based guides to performing common actions in the client applications, 
 such as importing and viewing data, exporting images and using the measuring 
 tool. 

--- a/omero/users/demo-server.txt
+++ b/omero/users/demo-server.txt
@@ -23,7 +23,7 @@ Once you have these, follow the instructions below:
 Getting started with your demo account
 ======================================
 
-To log on and try the demo server you have three options:
+To log on and try the demo server you have two options:
 
 1. :ref:`OMEROinsight`
 
@@ -34,7 +34,7 @@ the demo server is upgraded (we will email you to inform you).
 
 2. :ref:`OMEROweb`
 
-The web client does not allow you to import data or use the measurement tools.
+The web client does not allow you to import data or create new ROIs.
 
 |
 

--- a/omero/users/index.txt
+++ b/omero/users/index.txt
@@ -16,7 +16,7 @@ several Java client applications, as well as Python and C++ bindings
 and a Django-based web application.
 
 The OMERO clients are cross-platform. To run on your computer they require
-Java 1.6 or higher to be installed. This can easily be installed from
+Java 1.7 or higher to be installed. This can easily be installed from
 http://java.com/en if it is not already included in your OS. The OMERO.insight
 client gets all of its information from a remote OMERO.server — the location
 of which is specified at login. Since this connection utilises a standard
@@ -52,7 +52,7 @@ Additional resources
 
 -   :omero_plone:`About OMERO <>` introduces OMERO for new users, while
     the :omero_plone:`Features List <feature-list>` provides an overview
-    of the platform features with those that are new for OMERO 5.1
+    of the platform features with those that are new for OMERO 5.2
     highlighted.
 
 -   Workflow-based user assistance guides are provided on our

--- a/omero/users/whatsnew.txt
+++ b/omero/users/whatsnew.txt
@@ -1,25 +1,9 @@
-What's new for OMERO 5.1 for users
+What's new for OMERO 5.2 for users
 ==================================
 
-Updates and new features for OMERO 5.1 include:
+Updates and new features for OMERO 5.2 include:
 
-- support for units throughout the Data Model allowing for example, pixel
-  sizes for electron microscopy to be stored in nanometers rather than being
-  set as micrometers
-- new, searchable key-value pair annotations for adding experimental metadata
-- improved performance for moving and deleting data
-- improved performance for many file formats, including much faster import for
-  HCS data and new supported formats via Bio-Formats (now over 140)
-- improvements in rendering settings workflow to make it more transparent and
-  also to align the functionality between OMERO.insight and OMERO.web
-- improved functionality of the OMERO ImageJ plugin allowing you to import
-  images to OMERO from ImageJ (both modified e.g. cropped and unmodified) and
-  also save ROIs and overlays from ImageJ into OMERO without having to
-  re-import if your image is already stored in OMERO
-
-See the updated user guides for :help:`managing data <managing-data.html>`,
-:help:`viewing data <viewing-data.html>` and
-:help:`using ImageJ with OMERO <imagej.html>` for further information.
-
-OMERO 5.1.2 introduced support for Read-Write groups - see the updated
-:help:`sharing data <sharing-data.html>` guide for details.
+-  improved support for screen data
+-  improved support for attaching analytical results
+-  significant improvement in client performance including for loading data
+   and drag and drop actions


### PR DESCRIPTION
See https://trello.com/c/esod316Q/75-document-dropping-java-1-6 and https://trello.com/c/wSW2lRBp/76-what-s-new-for-5-2-pages-version-history

Summarises 5.2 changes (details still to add for devs / OMERO.web), updates hardcoded version numbers and references to Java 1.6 as minimum requirement.

N.B. have made a separate card for version requirements page, won't tackle that on this PR.

--no-rebase
