### PR TITLE
Contributing CI docs tidying

### DIFF
--- a/contributing/ci-consortium.txt
+++ b/contributing/ci-consortium.txt
@@ -20,10 +20,6 @@ Jenkins.
 		  | :term:`FLIMfit-release-win`
 		  | :term:`FLIMfit-release-downloads`
 
-	-	* OMERO.figure
-		*
-		* :term:`FIGURE-release-downloads`
-
 	-	* OMERO.mtools
 		*
 		* :term:`MTOOLS-release-downloads`
@@ -101,24 +97,6 @@ https://github.com/openmicroscopy/Imperial-FLIMfit
 		#. Build the FLIMfit downloads pages using :command:`make flimfit`
 		#. Copy the FLIMfit downloads page over SSH to
 		   :file:`/ome/apache_repo/public/flimfit/RELEASE`
-
-OMERO.figure
-^^^^^^^^^^^^
-
-.. glossary::
-
-	:jenkinsjob:`FIGURE-release-downloads`
-
-		This job is used to build the OMERO.figure downloads page
-
-		#. Download the :envvar:`RELEASE` artifacts from
-		   https://github.com/will-moore/figure
-		#. Copy the OMERO.figure source zip over SSH to
-		   :file:`/ome/apache_repo/public/figure/RELEASE`
-		#. Merge PRs opened against `dev_5_0`
-		#. Build the OMERO.figure downloads pages using :command:`make figure`
-		#. Copy the OMERO.figure downloads page over SSH to
-		   :file:`/ome/apache_repo/public/figure/RELEASE`
 
 OMERO.mtools
 ^^^^^^^^^^^^

--- a/contributing/ci-consortium.txt
+++ b/contributing/ci-consortium.txt
@@ -44,7 +44,7 @@ https://github.com/openmicroscopy/Imperial-FLIMfit
 	:jenkinsjob:`FLIMfit-latest-mac`
 
 		This job is used to build the latest Mac OS X compiled version of
-		FLIMfit with OMERO 4.4 or 5.0
+		FLIMfit with OMERO 5.1
 
 		#. Polls the repo for SCM change
 		#. Checks out the `master` branch of FLIMfit
@@ -54,7 +54,7 @@ https://github.com/openmicroscopy/Imperial-FLIMfit
 	:jenkinsjob:`FLIMfit-latest-win`
 
 		This job is used to build the latest Windows compiled version of
-		FLIMfit with OMERO 4.4 or 5.0
+		FLIMfit with OMERO 5.1
 
 		#. Checks out the `master` branch of FLIMfit
 		#. Build FLIMfit using :file:`compile.m`
@@ -72,7 +72,7 @@ https://github.com/openmicroscopy/Imperial-FLIMfit
 	:jenkinsjob:`FLIMfit-release-mac`
 
 		This job is used to build the release Mac OS X compiled version of
-		FLIMfit with OMERO 4.4 or 5.0
+		FLIMfit with OMERO 5.1
 
 		#. Build FLIMfit using :file:`compile.m`
 		#. Copy the FLIMfit artifacts over SSH to
@@ -81,7 +81,7 @@ https://github.com/openmicroscopy/Imperial-FLIMfit
 	:jenkinsjob:`FLIMfit-release-win`
 
 		This job is used to build the release Windows compiled version of
-		FLIMfit with OMERO 4.4 or 5.0
+		FLIMfit with OMERO 5.1
 
 		#. Build FLIMfit using :file:`compile.m`
 
@@ -89,9 +89,9 @@ https://github.com/openmicroscopy/Imperial-FLIMfit
 
 		This job is used to build the FLIMfit downloads page
 
-		#. Checks out the `dev_5_0` branch of
+		#. Checks out the `develop` branch of
 		   https://github.com/openmicroscopy/ome-release
-		#. Merge PRs opened against `dev_5_0`
+		#. Merge PRs opened against `develop`
 		#. Copy the FLIMfit Windows artifacts over SSH to
 		   :file:`/ome/apache_repo/public/flimfit/RELEASE`
 		#. Build the FLIMfit downloads pages using :command:`make flimfit`
@@ -107,7 +107,7 @@ OMERO.mtools
 
 		This job is used to build the OMERO.mtools downloads page
 
-		#. Merge PRs opened against `dev_5_0`
+		#. Merge PRs opened against `develop`
 		#. Build the OMERO.mtools downloads pages using :command:`make mtools`
 		#. Copy the OMERO.mtools downloads page over SSH to
 		   :file:`/ome/apache_repo/public/mtools/RELEASE`
@@ -125,7 +125,7 @@ OMERO.webtagging
 		   https://github.com/dpwrussell/webtagging
 		#. Copy the OMERO.webtagging source zip over SSH to
 		   :file:`/ome/apache_repo/public/webtagging/RELEASE`
-		#. Merge PRs opened against `dev_5_0`
+		#. Merge PRs opened against `develop`
 		#. Build the OMERO.webtagging downloads pages using
 		   :command:`make webtagging`
 		#. Copy the OMERO.webtagging downloads page over SSH to
@@ -158,9 +158,9 @@ u-track
 
 		This job is used to build the u-track downloads page
 
-		#. Checks out the `dev_5_0` branch of
+		#. Checks out the `develop` branch of
 		   https://github.com/openmicroscopy/ome-release
-		#. Merge PRs opened against `dev_5_0`
+		#. Merge PRs opened against `develop`
 		#. Build the u-track downloads pages using :command:`make u-track`
 		#. Copy the u-track downloads page over SSH to
 		   :file:`/ome/apache_repo/public/u-track/RELEASE`

--- a/contributing/ci-introduction.txt
+++ b/contributing/ci-introduction.txt
@@ -29,28 +29,23 @@ Most of the OME code is split between four repositories: openmicroscopy.git_,
 bioformats.git_, scripts.git_, ome-documentation.git_. Each repository
 contains several development branches associated with development series:
 
-* The "dev_5_0" branch contains work on the 5.0.x series.
-* The "dev_5_1" branch contains work on the 5.1.x series.
-* The "develop" branch contains work on the 5.2.x series.
+* The "dev_5_y" branch(es) containing work on the current 5.y.x series.
+* The "develop" branch containing work on the next major release series.
 
-Note that only two branches are maintained simultaneously. With this workflow,
-it is possible to have a point release immediately, while still working on
-more major releases by ensuring that (nearly) all commits that are applied to
-dev_5_0 are applied to develop in order to prevent regressions.
+Note that only two branches are usually maintained simultaneously. With this
+workflow, it is possible to have a point release immediately, while still
+working on more major releases by ensuring that (nearly) all commits that are
+applied to dev_5_y are applied to develop in order to prevent regressions.
 
 Labels
 ^^^^^^
 
 Labels are applied to PRs on GitHub under the “Issues” tab of each repository.
 
-The 5.0.x series consists of PRs labeled with “dev_5_0”, which is also
-the name of the branch which they will be merged into.
-
-The 5.1.x series consists of PRs labeled with “dev_5_1”, which is also
-the name of the branch which they will be merged into.
-
-The 5.2.x series consists of PRs labeled with “develop”, which is also
-the name of the branch which they will be merged into.
+Each release series consists of PRs labeled according to the release version,
+which also matches the name of the branch they will be merged into e.g. 5.1.x
+series PRs will be labelled as "dev_5_1" and be merged into the dev_5_1
+branch.
 
 Multiple labels are used in the PR reviewing process:
 

--- a/contributing/ci-introduction.txt
+++ b/contributing/ci-introduction.txt
@@ -44,7 +44,7 @@ Labels are applied to PRs on GitHub under the “Issues” tab of each repositor
 
 Each release series consists of PRs labeled according to the release version,
 which also matches the name of the branch they will be merged into e.g. 5.1.x
-series PRs will be labelled as "dev_5_1" and be merged into the dev_5_1
+series PRs will be labeled as "dev_5_1" and be merged into the dev_5_1
 branch.
 
 Multiple labels are used in the PR reviewing process:


### PR DESCRIPTION
Removes Figure from consortium page and tidies intro page to make it version neutral so we don't have to keep updating it.

N.B. merge job is still waiting on Roger updating the C++ jobs on the release builds page so isn't expected to be made green by this PR.

--no-rebase
