### PR TITLE
Fix Python packaging URL

### DIFF
--- a/contributing/tools-maintenance.txt
+++ b/contributing/tools-maintenance.txt
@@ -41,5 +41,5 @@ Finally, the signed tag needs to be pushed to the source code repository::
 
 .. seealso::
 
-  https://packaging.python.org/en/latest/distributing.html#uploading-your-project-to-pypi
+  http://python-packaging-user-guide.readthedocs.org/en/latest/distributing/#uploading-your-project-to-pypi
      Instructions about uploading a project to PyPi


### PR DESCRIPTION
This commit should turn https://ci.openmicroscopy.org/view/Docs/job/CONTRIBUTING-merge-docs/ green
