### PR TITLE
CI docs tidying

### DIFF
--- a/contributing/ci-docs.txt
+++ b/contributing/ci-docs.txt
@@ -72,7 +72,9 @@ independent of the current OMERO/Bio-Formats version.
 	-	* Publish OME help documentation
 		* :term:`OME-help-release`
 
-Since OMERO.figure came under the management of the wider OME team, there are also builds to manage its GitHub pages website, which operate the same way as the help builds.
+Since OMERO.figure came under the management of the wider OME team, there are
+also builds to manage its GitHub pages website, which operate the same way as
+the help builds.
 
 .. list-table::
 	:header-rows: 1

--- a/contributing/ci-docs.txt
+++ b/contributing/ci-docs.txt
@@ -379,7 +379,7 @@ The repository for OMERO.figure is https://github.com/ome/figure.
 
 	:jenkinsjob:`FIGURE-help-release`
 
-		This job is used to deploy the OME help documentation
+		This job is used to deploy the Figure gh-pages website
 
 		#. Opens a Pull Request from
 		   https://github.com/ome/figure/tree/gh-pages-staging

--- a/contributing/ci-release.txt
+++ b/contributing/ci-release.txt
@@ -442,10 +442,10 @@ Other release jobs
         #. Download the :envvar:`RELEASE` artifacts from
            https://github.com/ome/figure
         #. Copy the OMERO.figure source zip over SSH to
-           :file:`/ome/apache_repo/public/figure/RELEASE`
-        #. Merge PRs opened against `dev_5_0`
+           :file:`/ome/www/downloads.openmicroscopy.org/figure/RELEASE`
+        #. Merge PRs opened against `develop`
         #. Build the OMERO.figure downloads pages using :command:`make figure`
         #. Copy the OMERO.figure downloads page over SSH to
-           :file:`/ome/apache_repo/public/figure/RELEASE`
+           :file:`/ome/www/downloads.openmicroscopy.org/figure/RELEASE`
 
 Documentation release jobs are documented on :doc:`ci-docs`.

--- a/contributing/ci-release.txt
+++ b/contributing/ci-release.txt
@@ -428,3 +428,24 @@ clients of the deployment jobs described above:
         #. Triggers :term:`BIOFORMATS-CPP-5.1-release`
         #. Triggers :term:`BIOFORMATS-CPP-5.1-release-superbuild`
         #. Triggers :term:`BIOFORMATS-CPP-5.1-release-win-superbuild`
+
+
+Other release jobs
+^^^^^^^^^^^^^^^^^^
+
+.. glossary::
+
+    :jenkinsjob:`FIGURE-release-downloads`
+
+        This job is used to build the OMERO.figure downloads page
+
+        #. Download the :envvar:`RELEASE` artifacts from
+           https://github.com/ome/figure
+        #. Copy the OMERO.figure source zip over SSH to
+           :file:`/ome/apache_repo/public/figure/RELEASE`
+        #. Merge PRs opened against `dev_5_0`
+        #. Build the OMERO.figure downloads pages using :command:`make figure`
+        #. Copy the OMERO.figure downloads page over SSH to
+           :file:`/ome/apache_repo/public/figure/RELEASE`
+
+Documentation release jobs are documented on :doc:`ci-docs`.


### PR DESCRIPTION
see #1294 and https://trello.com/c/96Gal8J4/368-tidy-contributing-docs

Replaces Figure downloads build - now on the release page rather than the consortium page my previous PR removed it from.

Release builds page will want 5.0 refs removed too, can add to this PR if needed or hold off until we are ready to add the 5.2 builds, I defer to @sbesson on that.
