### PR TITLE
Expand contributing documentation to include the Bio-Formats DEV jobs

### DIFF
--- a/common/conf.py
+++ b/common/conf.py
@@ -183,6 +183,7 @@ rst_epilog = """
 .. _Ice: https://zeroc.com
 .. _Jenkins: http://jenkins-ci.org
 .. _roadmap: https://trac.openmicroscopy.org/ome/roadmap
+.. _OME artifactory: http://artifacts.openmicroscopy.org
 .. _Open Microscopy Environment: http://www.openmicroscopy.org/site
 .. _Glencoe Software, Inc.: http://www.glencoesoftware.com/
 .. _Pillow: http://pillow.readthedocs.org

--- a/contributing/ci-bio-formats.txt
+++ b/contributing/ci-bio-formats.txt
@@ -496,15 +496,6 @@ Jenkins.
                 #. Runs automated tests against
                    :file:`/ome/data_repo/test_images_good`
 
-        :jenkinsjob:`BIOFORMATS-DEV-breaking-test_images_good-win`
-
-                This job runs automated tests against the test_images_good subset on
-                Windows
-
-                #. Checks out :bf_scc_branch:`develop/breaking/trigger`
-                #. Runs automated tests against
-                   :file:`\\\\squig.openmicroscopy.org.uk\\ome-data-repo\\test_images_good`
-
         :jenkinsjob:`BIOFORMATS-DEV-breaking-full-repository`
 
                 This job runs automated tests against the full repository on Linux

--- a/contributing/ci-bio-formats.txt
+++ b/contributing/ci-bio-formats.txt
@@ -65,10 +65,6 @@ All jobs are listed under the :jenkinsview:`Bio-Formats` view tab of Jenkins.
                 * :term:`BIOFORMATS-5.1-merge-openbytes-performance`
                 * :term:`BIOFORMATS-DEV-merge-openbytes-performance`
 
-        -       * Builds the breaking native C++ implementation for Bio-Formats
-                * :term:`BIOFORMATS-CPP-5.1-breaking`
-                *
-
         -       * Builds the latest native C++ implementation for Bio-Formats
                 * :term:`BIOFORMATS-CPP-5.1-latest`
                 *

--- a/contributing/ci-bio-formats.txt
+++ b/contributing/ci-bio-formats.txt
@@ -12,53 +12,58 @@ All jobs are listed under the :jenkinsview:`Bio-Formats` view tab of Jenkins.
 
         -       * Builds the latest Bio-Formats artifacts
                 * :term:`BIOFORMATS-5.1-latest`
-                *
+                * :term:`BIOFORMATS-DEV-latest`
 
         -       * Generates the latest generated-sources
                 * :term:`BIOFORMATS-5.1-latest-generated-sources`
-                *
+                * :term:`BIOFORMATS-DEV-latest-generated-sources`
 
         -       * Publishes the latest Bio-Formats to the OME artifactory
                 * :term:`BIOFORMATS-5.1-latest-maven`
-                *
+                * :term:`BIOFORMATS-DEV-latest-maven`
 
         -       * Runs the daily Bio-Formats merge jobs
                 * :term:`BIOFORMATS-5.1-merge-daily`
-                *
+                * :term:`BIOFORMATS-DEV-merge-daily`
 
         -       * Merges the PRs
                 * :term:`BIOFORMATS-5.1-merge-push`
-                *
+                * :term:`BIOFORMATS-DEV-merge-push`
 
         -       * Builds the merge Bio-Formats artifacts
-                * :term:`BIOFORMATS-5.1-merge-build`
-                *
+                * | :term:`BIOFORMATS-5.1-merge-build`
+                    :term:`BIOFORMATS-5.1-merge-build-win`
+                * | :term:`BIOFORMATS-DEV-merge-build`
+                    :term:`BIOFORMATS-DEV-merge-build-win`
+
+        -       * Publishes the merge Bio-Formats to the OME artifactory
+                * :term:`BIOFORMATS-5.1-merge-maven`
+                * :term:`BIOFORMATS-DEV-merge-maven`
 
         -       * Generates the merge  generated sources
                 * :term:`BIOFORMATS-5.1-merge-generated-sources`
-                *
+                * :term:`BIOFORMATS-DEV-merge-generated-sources`
 
         -       * Runs the MATLAB tests
                 * :term:`BIOFORMATS-5.1-merge-matlab`
-                *
+                * :term:`BIOFORMATS-DEV-merge-matlab`
 
         -       * Runs automated tests against the full repository on squig
                 * | :term:`BIOFORMATS-5.1-merge-full-repository`
                   | :term:`BIOFORMATS-5.1-merge-full-repository-win`
-                *
+                * :term:`BIOFORMATS-DEV-merge-full-repository`
 
         -       * Runs automated tests against test_images_good on squig
-                * | :term:`BIOFORMATS-5.1-merge-test_images_good`
-                  | :term:`BIOFORMATS-5.1-merge-test_images_good-win`
-                *
+                * :term:`BIOFORMATS-5.1-merge-test_images_good`
+                * :term:`BIOFORMATS-DEV-merge-test_images_good`
 
         -       * Runs automated tests against a subset of the data repository on squig
                 * :term:`BIOFORMATS-5.1-merge-repository-subset`
-                *
+                * :term:`BIOFORMATS-DEV-merge-repository-subset`
 
         -       * Runs openBytes performance test
                 * :term:`BIOFORMATS-5.1-merge-openbytes-performance`
-                *
+                * :term:`BIOFORMATS-DEV-merge-openbytes-performance`
 
         -       * Builds the breaking native C++ implementation for Bio-Formats
                 * :term:`BIOFORMATS-CPP-5.1-breaking`
@@ -104,39 +109,42 @@ All jobs are listed under the :jenkinsview:`Bio-Formats` view tab of Jenkins.
 5.1.x series
 ^^^^^^^^^^^^
 
-The branch for the 5.1.x series of Bio-Formats is develop.
+The branch for the 5.1.x series of Bio-Formats is dev_5_1.
 
 .. glossary::
 
         :jenkinsjob:`BIOFORMATS-5.1-latest`
 
-                This job builds the develop branch of Bio-Formats
+            This job builds the dev_5_1 branch of Bio-Formats
 
                 #. |buildBF|
                 #. |testBF|
+                #. Triggers downstream latest jobs
+
+            See :jenkinsjob:`the build graph <BIOFORMATS-5.1-latest/lastSuccessfulBuild/BuildGraph>`
 
         :jenkinsjob:`BIOFORMATS-5.1-latest-maven`
 
-                This job publishes the develop branch of Bio-Formats to the
-                OME artifactory at http://artifacts.openmicroscopy.org/
+            This job publishes the dev_5_1 branch of Bio-Formats to the
+            `OME artifactory`_
 
         :jenkinsjob:`BIOFORMATS-5.1-latest-generated-sources`
 
-                This job builds the generated sources of Bio-Formats for the develop
-                branch
+            This job builds the generated sources of Bio-Formats for the 
+            dev_5_1 branch
 
                 #. Builds the Java generated sources using ``ant clean ome-xml-src``
                 #. Builds the C++ generated sources using ``cmake .. && make gensrc``
                 #. Commits all the generated sources
                 #. Pushes the branch to 
-                   :bf_scc_branch:`develop/latest/generated_sources`. This branch
+                   :bf_scc_branch:`dev_5_1/latest/generated_sources`. This branch
                    can be used as the baseline for comparison with other generated
                    source jobs like :term:`BIOFORMATS-5.1-merge-generated-sources`
 
         :jenkinsjob:`BIOFORMATS-5.1-merge-daily`
 
                 This job runs the daily Bio-Formats jobs used for reviewing the PRs
-                opened against the develop branch of Bio-Formats by running basic unit
+                opened against the dev_5_1 branch of Bio-Formats by running basic unit
                 tests, checking for open file handles, and checking for regressions
                 across a representative subset of the data repository
 
@@ -151,31 +159,41 @@ The branch for the 5.1.x series of Bio-Formats is develop.
 
         :jenkinsjob:`BIOFORMATS-5.1-merge-push`
 
-                This job merges all the PRs opened against develop
+                This job merges all the PRs opened against dev_5_1
 
                 #. |merge|
-                #. Pushes the branch to :bf_scc_branch:`develop/merge/daily`
+                #. Pushes the branch to :bf_scc_branch:`dev_5_1/merge/daily`
 
         :jenkinsjob:`BIOFORMATS-5.1-merge-build`
 
                 This job builds the merge artifacts of Bio-Formats
 
-                #. Checks out :bf_scc_branch:`develop/merge/daily`
+                #. Checks out :bf_scc_branch:`dev_5_1/merge/daily`
                 #. |buildBF|
                 #. |fulltestBF|
                 #. Triggers :term:`BIOFORMATS-5.1-merge-matlab`
+
+        :jenkinsjob:`BIOFORMATS-5.1-merge-build-win`
+
+                This job builds the merge artifacts of Bio-Formats on Windows
+
+        :jenkinsjob:`BIOFORMATS-5.1-merge-maven`
+
+            This job builds and publishes the merge artifacts of the dev_5_1 
+            branch of Bio-Formats to the
+            `OME artifactory`_
 
         :jenkinsjob:`BIOFORMATS-5.1-merge-generated-sources`
 
                 This job builds the merge generated sources of Bio-Formats
 
-                #. Checks out :bf_scc_branch:`develop/merge/daily`
+                #. Checks out :bf_scc_branch:`dev_5_1/merge/daily`
                 #. Builds the Java generated sources using ``ant clean ome-xml-src``
                 #. Builds the C++ generated sources using ``cmake .. && make gensrc``
                 #. Commits all the generated sources and pushes to
-                   :bf_scc_branch:`develop/merge/generated_sources` branch
+                   :bf_scc_branch:`dev_5_1/merge/generated_sources` branch
                 #. Computes the diff with
-                   :bf_scc_branch:`develop/latest/generated_sources` and archives
+                   :bf_scc_branch:`dev_5_1/latest/generated_sources` and archives
                    the artifacts
 
         :jenkinsjob:`BIOFORMATS-5.1-merge-matlab`
@@ -191,14 +209,14 @@ The branch for the 5.1.x series of Bio-Formats is develop.
 
                 This job runs automated tests against the full repository on Linux
 
-                #. Checks out :bf_scc_branch:`develop/merge/daily`
+                #. Checks out :bf_scc_branch:`dev_5_1/merge/daily`
                 #. Runs automated tests against :file:`/ome/data_repo/from_skyking/`
 
         :jenkinsjob:`BIOFORMATS-5.1-merge-full-repository-win`
 
                 This job runs automated tests against the full repository on Windows
 
-                #. Checks out :bf_scc_branch:`develop/merge/daily`
+                #. Checks out :bf_scc_branch:`dev_5_1/merge/daily`
                 #. Runs automated tests against
                    :file:`\\\\squig.openmicroscopy.org.uk\\ome-data-repo\\from_skyking`
 
@@ -207,18 +225,9 @@ The branch for the 5.1.x series of Bio-Formats is develop.
                 This job runs automated tests against the test_images_good subset on
                 Linux
 
-                #. Checks out :bf_scc_branch:`develop/merge/daily`
+                #. Checks out :bf_scc_branch:`dev_5_1/merge/daily`
                 #. Runs automated tests against
                    :file:`/ome/data_repo/test_images_good`
-
-        :jenkinsjob:`BIOFORMATS-5.1-merge-test_images_good-win`
-
-                This job runs automated tests against the test_images_good subset on
-                Windows
-
-                #. Checks out :bf_scc_branch:`develop/merge/daily`
-                #. Runs automated tests against
-                   :file:`\\\\squig.openmicroscopy.org.uk\\ome-data-repo\\test_images_good`
 
         :jenkinsjob:`BIOFORMATS-5.1-merge-repository-subset`
 
@@ -234,7 +243,7 @@ The branch for the 5.1.x series of Bio-Formats is develop.
 
                 This job runs openBytes performance tests against directories on squig
 
-                #. Checks out the :bf_scc_branch:`develop/merge/daily`
+                #. Checks out the :bf_scc_branch:`dev_5_1/merge/daily`
                 #. Runs ``loci.tests.testng.OmeroOpenBytesTest`` and
                    ``loci.tests.testng.OpenBytesPerformanceTest`` tests against
                    directories specified by
@@ -282,6 +291,143 @@ The branch for the 5.1.x series of Bio-Formats is develop.
                 This job triggers the building of the merge native C++
                 implementation for Bio-Formats (all merge build jobs)
 
+5.2.x series
+^^^^^^^^^^^^
+
+The branch for the 5.2.x series of Bio-Formats is develop.
+
+.. glossary::
+
+        :jenkinsjob:`BIOFORMATS-DEV-latest`
+
+            This job builds the develop branch of Bio-Formats
+
+                #. |buildBF|
+                #. |testBF|
+                #. Triggers downstream latest jobs
+
+            See :jenkinsjob:`the build graph <BIOFORMATS-DEV-latest/lastSuccessfulBuild/BuildGraph>`
+
+        :jenkinsjob:`BIOFORMATS-DEV-latest-maven`
+
+            This job publishes the develop branch of Bio-Formats to the
+            `OME artifactory`_
+
+        :jenkinsjob:`BIOFORMATS-DEV-latest-generated-sources`
+
+            This job builds the generated sources of Bio-Formats for the 
+            develop branch
+
+                #. Builds the Java generated sources using ``ant clean ome-xml-src``
+                #. Builds the C++ generated sources using ``cmake .. && make gensrc``
+                #. Commits all the generated sources
+                #. Pushes the branch to 
+                   :bf_scc_branch:`develop/latest/generated_sources`. This branch
+                   can be used as the baseline for comparison with other generated
+                   source jobs like :term:`BIOFORMATS-DEV-merge-generated-sources`
+
+        :jenkinsjob:`BIOFORMATS-DEV-merge-daily`
+
+                This job runs the daily Bio-Formats jobs used for reviewing the PRs
+                opened against the develop branch of Bio-Formats by running basic unit
+                tests, checking for open file handles, and checking for regressions
+                across a representative subset of the data repository
+
+                #. Triggers :term:`BIOFORMATS-DEV-merge-push`
+                #. Triggers downstream merge projects
+
+                See :jenkinsjob:`the build graph <BIOFORMATS-DEV-merge-daily/lastSuccessfulBuild/BuildGraph>`
+
+        :jenkinsjob:`BIOFORMATS-DEV-merge-push`
+
+                This job merges all the PRs opened against develop
+
+                #. |merge|
+                #. Pushes the branch to :bf_scc_branch:`develop/merge/daily`
+
+        :jenkinsjob:`BIOFORMATS-DEV-merge-build`
+
+                This job builds the merge artifacts of Bio-Formats
+
+                #. Checks out :bf_scc_branch:`develop/merge/daily`
+                #. |buildBF|
+                #. |fulltestBF|
+                #. Triggers :term:`BIOFORMATS-DEV-merge-matlab`
+
+        :jenkinsjob:`BIOFORMATS-DEV-merge-build-win`
+
+                This job builds the merge artifacts of Bio-Formats on Windows
+
+        :jenkinsjob:`BIOFORMATS-DEV-merge-maven`
+
+            This job builds and publishes the merge artifacts of the develop 
+            branch of Bio-Formats to the `OME artifactory`_
+
+        :jenkinsjob:`BIOFORMATS-DEV-merge-generated-sources`
+
+                This job builds the merge generated sources of Bio-Formats
+
+                #. Checks out :bf_scc_branch:`develop/merge/daily`
+                #. Builds the Java generated sources using ``ant clean ome-xml-src``
+                #. Builds the C++ generated sources using ``cmake .. && make gensrc``
+                #. Commits all the generated sources and pushes to
+                   :bf_scc_branch:`develop/merge/generated_sources` branch
+                #. Computes the diff with
+                   :bf_scc_branch:`develop/latest/generated_sources` and archives
+                   the artifacts
+
+        :jenkinsjob:`BIOFORMATS-DEV-merge-matlab`
+
+                This job runs the MATLAB tests of Bio-Formats
+
+                #. Collects the MATLAB artifacts and unit tests from
+                   :term:`BIOFORMATS-DEV-merge-build`
+                #. Runs the MATLAB unit tests under
+                   :file:`components/bio-formats/test/matlab` and collect the results
+
+        :jenkinsjob:`BIOFORMATS-DEV-merge-full-repository`
+
+                This job runs automated tests against the full repository on Linux
+
+                #. Checks out :bf_scc_branch:`develop/merge/daily`
+                #. Runs automated tests against :file:`/ome/data_repo/from_skyking/`
+
+        :jenkinsjob:`BIOFORMATS-DEV-merge-full-repository-win`
+
+                This job runs automated tests against the full repository on Windows
+
+                #. Checks out :bf_scc_branch:`develop/merge/daily`
+                #. Runs automated tests against
+                   :file:`\\\\squig.openmicroscopy.org.uk\\ome-data-repo\\from_skyking`
+
+        :jenkinsjob:`BIOFORMATS-DEV-merge-test_images_good`
+
+                This job runs automated tests against the test_images_good subset on
+                Linux
+
+                #. Checks out :bf_scc_branch:`develop/merge/daily`
+                #. Runs automated tests against
+                   :file:`/ome/data_repo/test_images_good`
+
+        :jenkinsjob:`BIOFORMATS-DEV-merge-repository-subset`
+
+                This job runs automated tests against a subset of the data repository
+
+                #. |merge|
+                #. Runs automated tests against a subset of format directories under
+                   :file:`/ome/data_repo/from_skyking/`. The list of directories to
+                   test by setting a space-separated list of formats for the
+                   ``DEFAULT_FORMAT_LIST`` variable.
+
+        :jenkinsjob:`BIOFORMATS-DEV-merge-openbytes-performance`
+
+                This job runs openBytes performance tests against directories on squig
+
+                #. Checks out the :bf_scc_branch:`develop/merge/daily`
+                #. Runs ``loci.tests.testng.OmeroOpenBytesTest`` and
+                   ``loci.tests.testng.OpenBytesPerformanceTest`` tests against
+                   directories specified by
+                   :file:`BIOFORMATS-openbytes-performance.txt`
 
 .. _bf_breaking:
 

--- a/contributing/ci-bio-formats.txt
+++ b/contributing/ci-bio-formats.txt
@@ -111,7 +111,7 @@ The branch for the 5.1.x series of Bio-Formats is dev_5_1.
 
         :jenkinsjob:`BIOFORMATS-5.1-latest`
 
-            This job builds the dev_5_1 branch of Bio-Formats
+                This job builds the dev_5_1 branch of Bio-Formats
 
                 #. |buildBF|
                 #. |testBF|
@@ -126,8 +126,8 @@ The branch for the 5.1.x series of Bio-Formats is dev_5_1.
 
         :jenkinsjob:`BIOFORMATS-5.1-latest-generated-sources`
 
-            This job builds the generated sources of Bio-Formats for the 
-            dev_5_1 branch
+                This job builds the generated sources of Bio-Formats for the
+                dev_5_1 branch
 
                 #. Builds the Java generated sources using ``ant clean ome-xml-src``
                 #. Builds the C++ generated sources using ``cmake .. && make gensrc``
@@ -296,7 +296,7 @@ The branch for the 5.2.x series of Bio-Formats is develop.
 
         :jenkinsjob:`BIOFORMATS-DEV-latest`
 
-            This job builds the develop branch of Bio-Formats
+                This job builds the develop branch of Bio-Formats
 
                 #. |buildBF|
                 #. |testBF|
@@ -311,8 +311,8 @@ The branch for the 5.2.x series of Bio-Formats is develop.
 
         :jenkinsjob:`BIOFORMATS-DEV-latest-generated-sources`
 
-            This job builds the generated sources of Bio-Formats for the 
-            develop branch
+                This job builds the generated sources of Bio-Formats for the 
+                develop branch
 
                 #. Builds the Java generated sources using ``ant clean ome-xml-src``
                 #. Builds the C++ generated sources using ``cmake .. && make gensrc``

--- a/contributing/ci-bio-formats.txt
+++ b/contributing/ci-bio-formats.txt
@@ -440,45 +440,45 @@ breaking jobs are listed under the :jenkinsview:`Breaking` view tab of
 Jenkins.
 
 .. glossary::
-        :jenkinsjob:`BIOFORMATS-5.1-breaking-trigger`
+        :jenkinsjob:`BIOFORMATS-DEV-breaking-trigger`
 
                 This job runs the daily Bio-Formats jobs used for reviewing the PRs
                 opened against the develop branch of Bio-Formats by running basic unit
                 tests, checking for open file handles, and checking for regressions
                 across a representative subset of the data repository
 
-                #. Triggers :term:`BIOFORMATS-5.1-breaking-push`
+                #. Triggers :term:`BIOFORMATS-DEV-breaking-push`
                 #. Triggers downstream jobs
 
-                See :jenkinsjob:`the build graph <BIOFORMATS-5.1-breaking-trigger/lastSuccessfulBuild/BuildGraph>`
+                See :jenkinsjob:`the build graph <BIOFORMATS-DEV-breaking-trigger/lastSuccessfulBuild/BuildGraph>`
 
-        :jenkinsjob:`BIOFORMATS-5.1-breaking-push`
+        :jenkinsjob:`BIOFORMATS-DEV-breaking-push`
 
                 This job merges all the breaking PRs opened against develop
 
                 #. |merge| labeled as breaking
                 #. Pushes the branch to :bf_scc_branch:`develop/breaking/trigger`
 
-        :jenkinsjob:`BIOFORMATS-5.1-breaking-build`
+        :jenkinsjob:`BIOFORMATS-DEV-breaking-build`
 
                 This job builds the merge artifacts of Bio-Formats
 
                 #. Checks out :bf_scc_branch:`develop/breaking/trigger`
                 #. |buildBF|
                 #. |fulltestBF|
-                #. Triggers :term:`BIOFORMATS-5.1-breaking-matlab`
+                #. Triggers :term:`BIOFORMATS-DEV-breaking-matlab`
 
 
-        :jenkinsjob:`BIOFORMATS-5.1-breaking-matlab`
+        :jenkinsjob:`BIOFORMATS-DEV-breaking-matlab`
 
                 This job runs the MATLAB tests of Bio-Formats
 
                 #. Collects the MATLAB artifacts and unit tests from
-                   :term:`BIOFORMATS-5.1-breaking-build`
+                   :term:`BIOFORMATS-DEV-breaking-build`
                 #. Runs the MATLAB unit tests under
                    :file:`components/bio-formats/test/matlab` and collect the results
 
-        :jenkinsjob:`BIOFORMATS-5.1-breaking-generated-sources`
+        :jenkinsjob:`BIOFORMATS-DEV-breaking-generated-sources`
 
                 This job builds the breaking generated sources of Bio-Formats
 
@@ -491,7 +491,7 @@ Jenkins.
                    :bf_scc_branch:`develop/latest/generated_sources` and archives
                    the artifacts
 
-        :jenkinsjob:`BIOFORMATS-5.1-breaking-test_images_good`
+        :jenkinsjob:`BIOFORMATS-DEV-breaking-test_images_good`
 
                 This job runs automated tests against the test_images_good subset on
                 Linux
@@ -500,7 +500,7 @@ Jenkins.
                 #. Runs automated tests against
                    :file:`/ome/data_repo/test_images_good`
 
-        :jenkinsjob:`BIOFORMATS-5.1-breaking-test_images_good-win`
+        :jenkinsjob:`BIOFORMATS-DEV-breaking-test_images_good-win`
 
                 This job runs automated tests against the test_images_good subset on
                 Windows
@@ -509,14 +509,14 @@ Jenkins.
                 #. Runs automated tests against
                    :file:`\\\\squig.openmicroscopy.org.uk\\ome-data-repo\\test_images_good`
 
-        :jenkinsjob:`BIOFORMATS-5.1-breaking-full-repository`
+        :jenkinsjob:`BIOFORMATS-DEV-breaking-full-repository`
 
                 This job runs automated tests against the full repository on Linux
 
                 #. Checks out :bf_scc_branch:`develop/breaking/trigger`
                 #. Runs automated tests against :file:`/ome/data_repo/from_skyking/`
 
-        :jenkinsjob:`BIOFORMATS-5.1-breaking-repository-subset`
+        :jenkinsjob:`BIOFORMATS-DEV-breaking-repository-subset`
 
                 This job runs automated tests against a subset of the data repository
 
@@ -526,7 +526,3 @@ Jenkins.
                    test by setting a space-separated list of formats for the
                    ``DEFAULT_FORMAT_LIST`` variable.
 
-        :jenkinsjob:`BIOFORMATS-CPP-5.1-breaking`
-
-                This job is used to build the breaking native C++ implementation for
-                Bio-Formats

--- a/contributing/ci-docs.txt
+++ b/contributing/ci-docs.txt
@@ -17,16 +17,15 @@ tab of Jenkins.
 
 	-	* Builds the latest Bio-Formats documentation for publishing
 		* :term:`BIOFORMATS-5.1-latest-docs`
-		*
+		* :term:`BIOFORMATS-DEV-latest-docs`
 
 	-	* Builds the OMERO documentation for review
 		* :term:`OMERO-5.1-merge-docs`
 		* :term:`OMERO-DEV-merge-docs`
 
-
 	-	* Builds the Bio-Formats documentation for review
 		* :term:`BIOFORMATS-5.1-merge-docs`
-		*
+		* :term:`BIOFORMATS-DEV-merge-docs`
 
 	-	* Builds the auto-generated OMERO documentation
 		* :term:`OMERO-5.1-latest-docs-autogen`
@@ -38,11 +37,11 @@ tab of Jenkins.
 
 	-	* Builds the auto-generated Bio-Formats documentation
 		* :term:`BIOFORMATS-5.1-latest-docs-autogen`
-		*
+		* :term:`BIOFORMATS-DEV-latest-docs-autogen`
 
 	-	* Builds the auto-generated OMERO documentation for review
 		* :term:`BIOFORMATS-5.1-merge-docs-autogen`
-		*
+		* :term:`BIOFORMATS-DEV-merge-docs-autogen`
 
 
 The OME Model, OME help and OME Contributing documentation sets are
@@ -136,7 +135,7 @@ dev_5_1.
 
 	:jenkinsjob:`BIOFORMATS-5.1-latest-docs`
 
-		This job is used to build the develop branch of the Bio-Formats
+		This job is used to build the dev_5_1 branch of the Bio-Formats
 		documentation and publish the official documentation for the 5.1.x
 		release of Bio-Formats
 
@@ -159,7 +158,7 @@ dev_5_1.
 
 	:jenkinsjob:`BIOFORMATS-5.1-merge-docs`
 
-		This job is used to review the PRs opened against the develop branch
+		This job is used to review the PRs opened against the dev_5_1 branch
 		of the Bio-Formats documentation
 
 		#. |merge|
@@ -171,29 +170,28 @@ dev_5_1.
 	:jenkinsjob:`BIOFORMATS-5.1-latest-docs-autogen`
 
 		This job is used to build the latest auto-generated formats and
-		readers pages for the develop branch of the Bio-Formats documentation
+		readers pages for the dev_5_1 branch of the Bio-Formats documentation
 
 		#. Builds Bio-Formats using ``ant clean jars``
-		#. Runs the auto-generation using ``ant gen-format-pages gen-original-meta-support gen-meta-support gen-meta-support``
+		#. Runs the auto-generation using ``ant gen-format-pages gen-structure-table gen-meta-support gen-meta-support``
 		   from :file:`components/autogen`
 		#. Checks for file changes under :file:`docs/sphinx`
 		#. Pushes the auto-generated changes to
-		   :bf_scc_branch:`develop/latest/autogen`
-
+		   :bf_scc_branch:`dev_5_1/latest/autogen`
 
 
 	:jenkinsjob:`BIOFORMATS-5.1-merge-docs-autogen`
 
 		This job is used to build the merge auto-generated pages for the
-		develop branch of the Bio-Formats documentation
+		dev_5_1 branch of the Bio-Formats documentation
 
-		#. Checks out :bf_scc_branch:`develop/merge/daily`
+		#. Checks out :bf_scc_branch:`dev_5_1/merge/daily`
 		#. Builds Bio-Formats using ``ant clean jars``
-		#. Runs the auto-generation using ``ant gen-format-pages gen-original-meta-support gen-meta-support gen-meta-support``
+		#. Runs the auto-generation using ``ant gen-format-pages gen-structure-table gen-meta-support gen-meta-support``
 		   from :file:`components/autogen`
 		#. Checks for file changes under :file:`docs/sphinx`
 		#. Pushes the auto-generated changes to 
-		   :bf_scc_branch:`develop/merge/autogen`
+		   :bf_scc_branch:`dev_5_1/merge/autogen`
 
 	:jenkinsjob:`OMERO-5.1-latest-docs-autogen`
 
@@ -219,11 +217,10 @@ dev_5_1.
 		#. Pushes the auto-generated changes to
 		   :omedoc_scc_branch:`dev_5_1/merge/autogen`
 
-5.2.x series
-^^^^^^^^^^^^
+OMERO 5.2.x series
+^^^^^^^^^^^^^^^^^^
 
-The branch for the 5.2.x series of the OMERO/Bio-Formats documentation is
-develop.
+The branch for the 5.2.x series of the OMERO documentation is develop.
 
 .. glossary::
 
@@ -273,6 +270,63 @@ develop.
 		#. Runs the :file:`omero/autogen_docs` autogeneration script
 		#. Pushes the auto-generated changes to
 		   :omedoc_scc_branch:`develop/merge/autogen`
+
+Bio-Formats 5.2.x series
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The branch for the 5.2.x series of the Bio-Formats documentation is develop.
+
+.. glossary::
+
+	:jenkinsjob:`BIOFORMATS-DEV-latest-docs`
+
+		This job is used to build the develop branch of the Bio-Formats
+		documentation and publish the official documentation for the 5.2.x
+		release of Bio-Formats
+
+		#. |sphinxbuild|
+		#. |linkcheck|
+		#. If the build is promoted,
+			#. |ssh-doc| :file:`bf-5.2-release.tmp`
+			#. |deploy-doc| http://www.openmicroscopy.org/site/support/bio-formats5.2/
+
+	:jenkinsjob:`BIOFORMATS-DEV-merge-docs`
+
+		This job is used to review the PRs opened against the develop branch
+		of the Bio-Formats documentation
+
+		#. |merge|
+		#. |sphinxbuild|
+		#. |linkcheck|
+		#. |ssh-doc| :file:`bf-5.2-staging.tmp`
+		#. |deploy-doc| http://www.openmicroscopy.org/site/support/bio-formats5.2-staging/
+
+	:jenkinsjob:`BIOFORMATS-DEV-latest-docs-autogen`
+
+		This job is used to build the latest auto-generated formats and
+		readers pages for the develop branch of the Bio-Formats documentation
+
+		#. Builds Bio-Formats using ``ant clean jars``
+		#. Runs the auto-generation using ``ant gen-format-pages gen-structure-table gen-meta-support gen-meta-support``
+		   from :file:`components/autogen`
+		#. Checks for file changes under :file:`docs/sphinx`
+		#. Pushes the auto-generated changes to
+		   :bf_scc_branch:`develop/latest/autogen`
+
+
+	:jenkinsjob:`BIOFORMATS-DEV-merge-docs-autogen`
+
+		This job is used to build the merge auto-generated pages for the
+		develop branch of the Bio-Formats documentation
+
+		#. Checks out :bf_scc_branch:`develop/merge/daily`
+		#. Builds Bio-Formats using ``ant clean jars``
+		#. Runs the auto-generation using ``ant gen-format-pages gen-structure-table gen-meta-support gen-meta-support``
+		   from :file:`components/autogen`
+		#. Checks for file changes under :file:`docs/sphinx`
+		#. Pushes the auto-generated changes to 
+		   :bf_scc_branch:`develop/merge/autogen`
+
 
 OME Model and OME Contributing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/omero/developers/Java.txt
+++ b/omero/developers/Java.txt
@@ -14,10 +14,9 @@ Java bindings available on the classpath.
 
 The required :file:`.jar` files can be obtained in a number of ways:
 
-* manually from the OME
-  `Artifactory server <http://artifacts.openmicroscopy.org/artifactory>`_. All
-  available artifacts and their POM files can be browsed using the
-  `maven repository
+* manually from the `OME artifactory`_. All available artifacts and their POM
+  files can be browsed using the
+  `Maven repository
   <http://artifacts.openmicroscopy.org/artifactory/maven/>`_.
 * using the :file:`OMERO.java` ZIP file downloaded from the
   :downloads:`Java <#java>` section of the OMERO download page.

--- a/omero/developers/build-system.txt
+++ b/omero/developers/build-system.txt
@@ -147,14 +147,14 @@ resolves the following locations in order:
 #. the local dependency repository under :file:`lib/repository`
 #. the local Maven cache under :file:`~/.m2/repository`
 #. the `Maven central repository <http://central.sonatype.org>`_
-#. the `OME artifactory <http://artifacts.openmicroscopy.org>`_
+#. the `OME artifactory`_
 
 Bio-Formats dependencies are resolved using a specific
 :ivydoc:`chain resolver <resolver/chain.html>` called ``ome-resolver`` which
 resolves the following locations in order:
 
 #. the local Maven cache under :file:`~/.m2/repository`
-#. the `OME artifactory <http://artifacts.openmicroscopy.org>`_
+#. the `OME artifactory`_
 
 To define its dependencies, each component uses a top-level
 :ivydoc:`Ivy file <ivyfile.html>`, :file:`ivy.xml`, for the build and


### PR DESCRIPTION
These jobs will be active as soon as develop and dev_5_1 are split on the code
repository of Bio-Formats. This PR extends both the Bio-Formats and the
Documentation contributing tables/glossaries to list the new available jobs.
