### PR TITLE
bump model doc reference to new 5.2 OMERO

### DIFF
--- a/formats/conf.py
+++ b/formats/conf.py
@@ -44,7 +44,7 @@ model_extlinks = {
     # API
     'javadoc' : (downloads_root + '/latest/bio-formats5.1/api/%s', ''),
     # Doc links
-    'omero_doc' : (oo_site_root + '/support/omero5.1/%s', ''),
+    'omero_doc' : (oo_site_root + '/support/omero5.2/%s', ''),
     'bf_doc' : (oo_site_root + '/support/bio-formats5.1/%s', ''),
     # Downloads
     'bf_downloads' : (downloads_root + '/latest/bio-formats5.1/%s', ''),

--- a/formats/conf.py
+++ b/formats/conf.py
@@ -42,12 +42,12 @@ model_extlinks = {
     'sourcedir' : (bf_github_root + 'tree/'+ branch + '/%s', ''),
     'omero_source' : (omero_github_root + 'blob/'+ branch + '/%s', ''),
     # API
-    'javadoc' : (downloads_root + '/latest/bio-formats5.1/api/%s', ''),
+    'javadoc' : (downloads_root + '/latest/bio-formats/api/%s', ''),
     # Doc links
-    'omero_doc' : (oo_site_root + '/support/omero5.2/%s', ''),
-    'bf_doc' : (oo_site_root + '/support/bio-formats5.1/%s', ''),
+    'omero_doc' : (oo_site_root + '/support/omero/%s', ''),
+    'bf_doc' : (oo_site_root + '/support/bio-formats/%s', ''),
     # Downloads
-    'bf_downloads' : (downloads_root + '/latest/bio-formats5.1/%s', ''),
+    'bf_downloads' : (downloads_root + '/latest/bio-formats/%s', ''),
     }
 extlinks.update(model_extlinks)
 

--- a/omero/themes/globalomerotoc.html
+++ b/omero/themes/globalomerotoc.html
@@ -1,5 +1,5 @@
 <h3><a href="{{ pathto(master_doc) }}">{{ _('OMERO') }}</a></h3>
 {{ toctree()}}
-<a href="http://downloads.openmicroscopy.org/latest/omero5.1/">{{ _('Downloads') }}</a></br>
+<a href="http://downloads.openmicroscopy.org/latest/omero5.2/">{{ _('Downloads') }}</a></br>
 <a href="//www.openmicroscopy.org/site/products/omero/feature-list">{{ _('Feature List') }}</a></br>
 <a href="//www.openmicroscopy.org/site/about/licensing-attribution">{{ _('Licensing') }}</a>

--- a/omero/themes/globalomerotoc.html
+++ b/omero/themes/globalomerotoc.html
@@ -1,5 +1,5 @@
 <h3><a href="{{ pathto(master_doc) }}">{{ _('OMERO') }}</a></h3>
 {{ toctree()}}
-<a href="http://downloads.openmicroscopy.org/latest/omero5.2/">{{ _('Downloads') }}</a></br>
+<a href="http://downloads.openmicroscopy.org/latest/omero/">{{ _('Downloads') }}</a></br>
 <a href="//www.openmicroscopy.org/site/products/omero/feature-list">{{ _('Feature List') }}</a></br>
 <a href="//www.openmicroscopy.org/site/about/licensing-attribution">{{ _('Licensing') }}</a>


### PR DESCRIPTION
Effects https://trello.com/c/lUQDSthL/81-update-model-docs-to-point-at-omero-5-2-docs.

--no-rebase
