### PR TITLE
Fix CI intro

### DIFF
--- a/contributing/ci-introduction.txt
+++ b/contributing/ci-introduction.txt
@@ -62,21 +62,21 @@ Multiple labels are used in the PR reviewing process:
 Job names
 ^^^^^^^^^
 
-All core OME jobs are named after the following conventions
-``COMPONENT-VERSION-TYPE-DESCRIPTION`` where:
+All core OME job names take the form
+``COMPONENT-VERSION-TYPE-DESCRIPTION``, where:
 
-- ``COMPONENT`` describes to core OME component, e.g. OMERO or BIOFORMATS.
-- ``VERSION`` describes to the MINOR.MINOR version, e.g. 5.0 or 5.1.
-- ``TYPE`` describes the source of the job and can be:
+- ``COMPONENT`` is the core OME component, e.g. OMERO or BIOFORMATS.
+- ``VERSION`` is the MAJOR.MINOR version, e.g. 5.0 or 5.1.
+- ``TYPE`` represents the source of the job and can take the following values:
 
-  * the ``latest`` jobs build from the tip of the development branch, e.g.
-    `origin/dev_5_0`,
-  * the ``merge`` jobs build from the tip of the development branch with all
-    PRs merged using :ref:`scc merge` with the `org` default filter set,
-  * the ``breaking`` jobs build from the tip of the development branch with
-    all PRs labeled as ``breaking`` merged using :ref:`scc merge`,
-  * the ``release`` jobs build from and optionally create a tag at the tip of
+  * ``latest``: build from the tip of the development branch, e.g.
+    `origin/dev_5_0`;
+  * ``merge``: build from the tip of the development branch with all
+    PRs merged using :ref:`scc merge` with the `org` default filter set;
+  * ``breaking``: build from the tip of the development branch with
+    all PRs labeled as ``breaking`` merged using :ref:`scc merge`;
+  * ``release``: build from and optionally create a tag at the tip of
     a development branch, e.g. `v5.0.1-rc4`.
 
-- ``DESCRIPTION`` describes describing the function of the job via a couple of
-  keywords separated by dashes.
+- ``DESCRIPTION`` describes the job via a set of dash-separated
+  keywords, e.g. `docs-autogen`.

--- a/contributing/ci-introduction.txt
+++ b/contributing/ci-introduction.txt
@@ -65,17 +65,18 @@ Job names
 All core OME job names take the form
 ``COMPONENT-VERSION-TYPE-DESCRIPTION``, where:
 
-- ``COMPONENT`` is the core OME component, e.g. OMERO or BIOFORMATS.
-- ``VERSION`` is the MAJOR.MINOR version, e.g. 5.0 or 5.1.
+- ``COMPONENT`` refers to the core OME component, e.g. `OMERO` for
+  OMERO or `BIOFORMATS` for Bio-Formats.
+- ``VERSION`` is the MAJOR.MINOR version, e.g. `5.0` or `5.1`.
 - ``TYPE`` represents the source of the job and can take the following values:
 
-  * ``latest``: build from the tip of the development branch, e.g.
+  * `latest`: build from the tip of the development branch, e.g.
     `origin/dev_5_0`;
-  * ``merge``: build from the tip of the development branch with all
+  * `merge`: build from the tip of the development branch with all
     PRs merged using :ref:`scc merge` with the `org` default filter set;
-  * ``breaking``: build from the tip of the development branch with
-    all PRs labeled as ``breaking`` merged using :ref:`scc merge`;
-  * ``release``: build from and optionally create a tag at the tip of
+  * `breaking`: build from the tip of the development branch with
+    all PRs labeled as `breaking` merged using :ref:`scc merge`;
+  * `release`: build from and optionally create a tag at the tip of
     a development branch, e.g. `v5.0.1-rc4`.
 
 - ``DESCRIPTION`` describes the job via a set of dash-separated


### PR DESCRIPTION
Fixes the "job names" section in `contributing/ci-introduction.txt`
