### PR TITLE
Jstree3 docs 5 2

### DIFF
--- a/omero/developers/Web/WebGateway.txt
+++ b/omero/developers/Web/WebGateway.txt
@@ -14,7 +14,7 @@ Web services
 
 This list of URLs below may be incomplete or out of date. For a complete
 list of URLs, see the :pythondoc:`latest
-API <omeroweb/omeroweb.html#module-omeroweb.urls>`
+API <omeroweb/omeroweb.webgateway.html#module-omeroweb.webgateway.urls>`
 and try the URLs out for yourself!
 
 The HTTP request will need to include login details for creating or using a

--- a/omero/developers/whatsnew.txt
+++ b/omero/developers/whatsnew.txt
@@ -17,10 +17,10 @@ OMERO.web
 OMERO.web has undergone a major upgrade, updating jsTree to version 3.0.8 and
 using json for all tree loading to substantially improve performance.
 
-If you have web code that directly works with the jsTree, you'll need to
+If you have web code that directly works with the jsTree, you will need to
 update it according to the `jsTree docs <https://www.jstree.com/>`.
 
-A number of new urls are available in webclient, with the /api/ prefix that
+A number of new URLs are available in webclient, with the /api/ prefix that
 provide json data for the jsTree. However, these may soon be moved to a
 different Django app and should not yet be considered stable.
 

--- a/omero/developers/whatsnew.txt
+++ b/omero/developers/whatsnew.txt
@@ -14,11 +14,16 @@ Breaking changes
 OMERO.web
 ^^^^^^^^^
 
-OMERO.web has undergone a major upgrade, updating jsTree to version 3 and
+OMERO.web has undergone a major upgrade, updating jsTree to version 3.0.8 and
 using json for all tree loading to substantially improve performance.
 
-See the :pythondoc:`OMERO.web python docs <omeroweb/omeroweb.html>` for more
-information.
+If you have web code that directly works with the jsTree, you'll need to
+update it according to the `jsTree docs <https://www.jstree.com/>`.
+
+A number of new urls are available in webclient, with the /api/ prefix that
+provide json data for the jsTree. However, these may soon be moved to a
+different Django app and should not yet be considered stable.
+
 
 Graphs
 ^^^^^^


### PR DESCRIPTION
Updates the whatsnew page with a little more info on jsTree3 and new /api/ json urls.
Kinda vague since we haven't discussed this in detail yet.

I've removed the links to python web docs since I really don't find this useful. E.g. webclient urls.py doesn't list the webclient urls.
