### PR TITLE
Small text update

### DIFF
--- a/omero/developers/Web/Deployment.txt
+++ b/omero/developers/Web/Deployment.txt
@@ -11,8 +11,8 @@ external OMERO server. You can add the server to the
 You should enable :property:`omero.web.debug` and start a lightweight
 development Web server on your local machine.
 
-.. note:: Since OMERO 5.2, the web framework is no longer shipped with the
-    Django package and requires manual installation of the Django dependency.
+.. note:: Since OMERO 5.2, the OMERO web framework no longer bundles a copy
+    of Django package and requires manual installation of the Django dependency.
     It is highly recommended to use `Django 1.8`_ (LTS) which requires
     Python 2.7. For more information see :ref:`python-requirements` on the
     :doc:`/sysadmins/version-requirements` page.

--- a/omero/developers/Web/Deployment.txt
+++ b/omero/developers/Web/Deployment.txt
@@ -11,10 +11,11 @@ external OMERO server. You can add the server to the
 You should enable :property:`omero.web.debug` and start a lightweight
 development Web server on your local machine.
 
-.. note:: Since OMERO 5.2, the OMERO web framework no longer bundles a copy
-    of Django package and requires manual installation of the Django dependency.
-    It is highly recommended to use `Django 1.8`_ (LTS) which requires
-    Python 2.7. For more information see :ref:`python-requirements` on the
+.. note:: Since OMERO 5.2, the OMERO web framework no longer bundles
+    a copy of the Django package, instead manual installation of
+    the Django dependency is required. It is highly recommended to use
+    `Django 1.8`_ (LTS) which requires Python 2.7. For more information
+    see :ref:`python-requirements` on the
     :doc:`/sysadmins/version-requirements` page.
 
 Using the lightweight development server on Unix

--- a/omero/sysadmins/unix/install-web.txt
+++ b/omero/sysadmins/unix/install-web.txt
@@ -38,12 +38,12 @@ Prerequisites
           :djangodoc:`how to install Django 1.8 <topics/install/#install-the-django-code>`
           or :djangodoc:`hot to upgrade Django to 1.8 <topics/install/#remove-any-old-versions-of-django>`.
 
-   .. note:: Since OMERO 5.2, the OMERO web framework no longer bundles a copy
-       of Django package and requires manual installation of the Django
-       dependency. It is highly recommended to use `Django 1.8`_ (LTS) which
-       requires Python 2.7. For more information see :ref:`python-requirements`
-       on the :doc:`/sysadmins/version-requirements` page.
-
+   .. note:: Since OMERO 5.2, the OMERO web framework no longer bundles
+       a copy of the Django package, instead manual installation of
+       the Django dependency is required. It is highly recommended to use
+       `Django 1.8`_ (LTS) which requires Python 2.7. For more information
+       see :ref:`python-requirements` on the
+       :doc:`/sysadmins/version-requirements` page.
 
 -  A WSGI capable web server
 

--- a/omero/sysadmins/unix/install-web.txt
+++ b/omero/sysadmins/unix/install-web.txt
@@ -38,8 +38,8 @@ Prerequisites
           :djangodoc:`how to install Django 1.8 <topics/install/#install-the-django-code>`
           or :djangodoc:`hot to upgrade Django to 1.8 <topics/install/#remove-any-old-versions-of-django>`.
 
-   .. note:: Since OMERO 5.2, the web framework is no longer shipped with the
-       Django package and requires manual installation of the Django
+   .. note:: Since OMERO 5.2, the OMERO web framework no longer bundles a copy
+       of Django package and requires manual installation of the Django
        dependency. It is highly recommended to use `Django 1.8`_ (LTS) which
        requires Python 2.7. For more information see :ref:`python-requirements`
        on the :doc:`/sysadmins/version-requirements` page.

--- a/omero/sysadmins/whatsnew.txt
+++ b/omero/sysadmins/whatsnew.txt
@@ -13,9 +13,11 @@ What's new for OMERO 5.2 for sysadmins
   major release (currently planned to be 5.3). Most notably, we have dropped
   support for Java 1.6 and changed the Python dependencies.
 
-- OMERO.web is no longer shipped with Django package and requires manual installation
-  of Django dependency. For more information about Python and Django version see 
-  :ref:`python-requirements` on the :doc:`/sysadmins/unix/server-installation` page.
+- The OMERO web framework no longer bundles a copy of the Django package,
+  instead manual installation of the Django dependency is required. It is
+  highly recommended to use `Django 1.8`_ (LTS) which requires Python 2.7.
+  For more information see :ref:`python-requirements` on the
+  :doc:`/sysadmins/version-requirements` page.
 
 - FastCGI support was removed in OMERO 5.2 and OMERO.web can be deployed
   using WSGI :ref:`unix_omero_web_deployment`.

--- a/omero/sysadmins/windows/install-web.txt
+++ b/omero/sysadmins/windows/install-web.txt
@@ -36,8 +36,11 @@ Prerequisites
       .. note:: For more details refer to
           `install Django 1.6 on Windows <https://docs.djangoproject.com/en/1.6/howto/windows/>`_.
 
-   .. note:: For more information about Python 2.6 and `Django 1.6`_
-       see :ref:`python-requirements` of the
+   .. note:: Since OMERO 5.2, the OMERO web framework no longer bundles
+       a copy of the Django package, instead manual installation of
+       the Django dependency is required. It is highly recommended to use
+       `Django 1.6`_ on Windows. For more information
+       see :ref:`python-requirements` on the
        :doc:`/sysadmins/version-requirements` page.
 
 -  IIS or WSGI capable web server


### PR DESCRIPTION
updating text as @rleigh-dundee said in https://github.com/openmicroscopy/ome-documentation/pull/1305

> Reads ambiguously to me. "the web framework is no longer shipped with Django" means that Django no longer provides the web framework, when I think this means to say that "the OMERO web framework no longer bundles a copy of Django", which is the opposite way around.

cc: @jburel 
