### PR TITLE
Fixing mis-formatted link

### DIFF
--- a/omero/developers/whatsnew.txt
+++ b/omero/developers/whatsnew.txt
@@ -18,7 +18,7 @@ OMERO.web has undergone a major upgrade, updating jsTree to version 3.0.8 and
 using json for all tree loading to substantially improve performance.
 
 If you have web code that directly works with the jsTree, you will need to
-update it according to the `jsTree docs <https://www.jstree.com/>`.
+update it according to the `jsTree docs <https://www.jstree.com/>`_.
 
 A number of new URLs are available in webclient, with the /api/ prefix that
 provide json data for the jsTree. However, these may soon be moved to a


### PR DESCRIPTION
Just spotted this which got missed during review. Staged at https://www.openmicroscopy.org/site/support/omero5.2-staging/developers/whatsnew.html
