### PR TITLE
Fixing Ice & Django docs issues

### DIFF
--- a/omero/developers/Web/Deployment.txt
+++ b/omero/developers/Web/Deployment.txt
@@ -66,7 +66,7 @@ Using WSGI (Unix/Linux)
 -----------------------
 
 For convenience you may wish to run a web server under your local user account
-instead of using a system server for testing. Install Nginx
+instead of using a system server for testing. Install Nginx and Gunicorn
 (See :doc:`/sysadmins/unix/install-web`) but generate a configuration file
 using the following command:
 
@@ -74,7 +74,7 @@ using the following command:
 
     $ bin/omero web config nginx-development > nginx-development.conf
 
-Start nginx and the Gunicorn worker processes running one thread
+Start Nginx and the Gunicorn worker processes running one thread
 listening on 127.0.0.1:4080 that will autoreload on source change:
 
 ::

--- a/omero/sysadmins/limitations.txt
+++ b/omero/sysadmins/limitations.txt
@@ -26,6 +26,13 @@ correctly. OpenJDK and OracleJDK versions 6 and 7 are also supported.
 Windows OS issues
 -----------------
 
+Django 1.8 will not work on Windows
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+OMERO.web has been upgraded to use Django 1.8 but support for this on Windows
+is still upcoming and you must use Django 1.6 for now. We aim to add support
+for Django 1.8 in OMERO.web within the 5.2.x development line.
+
 .. _windows-database-encoding:
 
 Failure response on import for new databases

--- a/omero/sysadmins/limitations.txt
+++ b/omero/sysadmins/limitations.txt
@@ -26,12 +26,13 @@ correctly. OpenJDK and OracleJDK versions 6 and 7 are also supported.
 Windows OS issues
 -----------------
 
-Django 1.8 will not work on Windows
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Django 1.8 will not work with IIS on Windows
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-OMERO.web has been upgraded to use Django 1.8 but support for this on Windows
-is still upcoming and you must use Django 1.6 for now. We aim to add support
-for Django 1.8 in OMERO.web within the 5.2.x development line.
+OMERO.web has been upgraded to use Django 1.8 but support for deploying it
+using IIS on Windows is still upcoming and you must use Django 1.6 for now. We
+aim to add support for Django 1.8 in OMERO.web within the 5.2.x development
+line.
 
 .. _windows-database-encoding:
 

--- a/omero/sysadmins/unix/install-web.txt
+++ b/omero/sysadmins/unix/install-web.txt
@@ -32,19 +32,6 @@ Prerequisites
 
    -  `Matplotlib`_ should be available for your distribution
 
-   -  `Django 1.8`_ should be available for your distribution.
-
-      .. note:: For more details refer to
-          :djangodoc:`how to install Django 1.8 <topics/install/#install-the-django-code>`
-          or :djangodoc:`hot to upgrade Django to 1.8 <topics/install/#remove-any-old-versions-of-django>`.
-
-   .. note:: Since OMERO 5.2, the OMERO web framework no longer bundles
-       a copy of the Django package, instead manual installation of
-       the Django dependency is required. It is highly recommended to use
-       `Django 1.8`_ (LTS) which requires Python 2.7. For more information
-       see :ref:`python-requirements` on the
-       :doc:`/sysadmins/version-requirements` page.
-
 -  A WSGI capable web server
 
 

--- a/omero/sysadmins/unix/install-web/install-apache.txt
+++ b/omero/sysadmins/unix/install-web/install-apache.txt
@@ -6,6 +6,25 @@ OMERO.web Apache and mod_wsgi deployment (Unix/Linux)
 Apache 2.2+ with mod_wsgi configuration (Unix/Linux)
 ----------------------------------------------------
 
+.. note:: Since OMERO 5.2, the OMERO web framework no longer bundles
+      a copy of the Django package, instead manual installation of
+      the Django dependency is required. It is highly recommended to use
+      `Django 1.8`_ (LTS) which requires Python 2.7. For more information
+      see :ref:`python-requirements` on the
+      :doc:`/sysadmins/version-requirements` page.
+
+Install `Django 1.8`_ using package requirements file:
+
+::
+
+   $ pip install -r requirements-py27-apache.txt
+
+
+.. note:: For more details refer to
+          :djangodoc:`how to install Django 1.8 <topics/install/#install-the-django-code>`
+          or :djangodoc:`hot to upgrade Django to 1.8 <topics/install/#remove-any-old-versions-of-django>`.
+
+
 If you have installed Apache, OMERO can automatically generate a
 configuration file for your web server. The location of the file
 will depend on your system, please refer to your web server's manual.

--- a/omero/sysadmins/unix/install-web/install-apache.txt
+++ b/omero/sysadmins/unix/install-web/install-apache.txt
@@ -13,6 +13,8 @@ Apache 2.2+ with mod_wsgi configuration (Unix/Linux)
       see :ref:`python-requirements` on the
       :doc:`/sysadmins/version-requirements` page.
 
+If you have installed Apache, install `mod\_wsgi <http://www.modwsgi.org/>`_.
+
 Install `Django 1.8`_ using package requirements file:
 
 ::
@@ -25,13 +27,11 @@ Install `Django 1.8`_ using package requirements file:
           or :djangodoc:`hot to upgrade Django to 1.8 <topics/install/#remove-any-old-versions-of-django>`.
 
 
-If you have installed Apache, OMERO can automatically generate a
+OMERO can automatically generate a
 configuration file for your web server. The location of the file
 will depend on your system, please refer to your web server's manual.
 See :ref:`customizing_your_omero_web_installation_unix`
 for additional customization options.
-
-Install `mod\_wsgi <http://www.modwsgi.org/>`_.
 
 Set the following:
 

--- a/omero/sysadmins/unix/install-web/install-apache.txt
+++ b/omero/sysadmins/unix/install-web/install-apache.txt
@@ -17,7 +17,7 @@ Install `Django 1.8`_ using package requirements file:
 
 ::
 
-   $ pip install -r requirements-py27-apache.txt
+   $ pip install -r share/web/requirements-py27-apache.txt
 
 
 .. note:: For more details refer to

--- a/omero/sysadmins/unix/install-web/install-nginx.txt
+++ b/omero/sysadmins/unix/install-web/install-nginx.txt
@@ -6,6 +6,25 @@ OMERO.web Nginx and Gunicorn deployment (Unix/Linux)
 Nginx Gunicorn configuration (Unix/Linux)
 -----------------------------------------
 
+.. note:: Since OMERO 5.2, the OMERO web framework no longer bundles
+      a copy of the Django package, instead manual installation of
+      the Django dependency is required. It is highly recommended to use
+      `Django 1.8`_ (LTS) which requires Python 2.7. For more information
+      see :ref:`python-requirements` on the
+      :doc:`/sysadmins/version-requirements` page.
+
+Install `Django 1.8`_ using package requirements file:
+
+::
+
+   $ pip install -r requirements-py27-nginx.txt
+
+
+.. note:: For more details refer to
+          :djangodoc:`how to install Django 1.8 <topics/install/#install-the-django-code>`
+          or :djangodoc:`hot to upgrade Django to 1.8 <topics/install/#remove-any-old-versions-of-django>`.
+
+
 If you have installed Nginx, OMERO can automatically generate a
 configuration file for your web server. The location of the file
 will depend on your system, please refer to your web server's manual.

--- a/omero/sysadmins/unix/install-web/install-nginx.txt
+++ b/omero/sysadmins/unix/install-web/install-nginx.txt
@@ -13,7 +13,8 @@ Nginx Gunicorn configuration (Unix/Linux)
       see :ref:`python-requirements` on the
       :doc:`/sysadmins/version-requirements` page.
 
-Install `Django 1.8`_ using package requirements file:
+Install `Django 1.8`_ and `Gunicorn <http://docs.gunicorn.org/>`_ using
+package requirements file:
 
 ::
 

--- a/omero/sysadmins/unix/install-web/install-nginx.txt
+++ b/omero/sysadmins/unix/install-web/install-nginx.txt
@@ -17,7 +17,7 @@ Install `Django 1.8`_ using package requirements file:
 
 ::
 
-   $ pip install -r requirements-py27-nginx.txt
+   $ pip install -r share/web/requirements-py27-nginx.txt
 
 
 .. note:: For more details refer to

--- a/omero/sysadmins/version-requirements.txt
+++ b/omero/sysadmins/version-requirements.txt
@@ -146,7 +146,7 @@ The planned changes for 5.2 depend upon our support of
 
 * Ice
 
-  * [5.2] 3.4 dropped, 3.5 supported, 3.6 not supported
+  * [5.2] 3.4 dropped, 3.5 recommended, 3.6 not supported
   * [5.3] 3.4 dropped, 3.5 deprecated, 3.6 recommended
   * Rationale: 3.4 is no longer supported by ZeroC with 3.5 being
     current. By the release of 5.3, Ice 3.6 will have been out for
@@ -886,7 +886,9 @@ installable with ``pip`` using any Python version.
 The supported version of the Django module used by OMERO.web (1.8)
 requires Python 2.7. The older version (1.6) will work with Python
 2.6 but lacks security support, and is consequently not recommended
-for production use.
+for production use. However, if you are using Windows, Django 1.8 support is
+still upcoming and you must use 1.6 for now. We aim to add support for Django
+1.8 in OMERO.web within the 5.2.x development line.
 
 GCC
 ---
@@ -1199,7 +1201,7 @@ Ice
       - Upstream support
       - OMERO 5.1
       - OMERO 5.2
-      - OMERO 5.2
+      - OMERO 5.3
       - Details
     * - 3.3
       - from May 2008
@@ -1221,7 +1223,7 @@ Ice
       - from Mar 2013
       - to Oct 2013
       - Recommended
-      - Deprecated
+      - Recommended
       - Deprecated
       - :zerocforum:`Ice 3.5 <announcements/6093-ice-3-5-0-released>`
         :zerocforum:`Ice 3.5.1 <announcements/6283-ice-3-5-1-released>`

--- a/omero/sysadmins/version-requirements.txt
+++ b/omero/sysadmins/version-requirements.txt
@@ -886,9 +886,9 @@ installable with ``pip`` using any Python version.
 The supported version of the Django module used by OMERO.web (1.8)
 requires Python 2.7. The older version (1.6) will work with Python
 2.6 but lacks security support, and is consequently not recommended
-for production use. However, if you are using Windows, Django 1.8 support is
-still upcoming and you must use 1.6 for now. We aim to add support for Django
-1.8 in OMERO.web within the 5.2.x development line.
+for production use. However, if you are using IIS on Windows, Django 1.8
+support is still upcoming and you must use 1.6 for now. We aim to add support
+for Django 1.8 in OMERO.web within the 5.2.x development line.
 
 GCC
 ---

--- a/omero/sysadmins/whatsnew.txt
+++ b/omero/sysadmins/whatsnew.txt
@@ -15,7 +15,9 @@ What's new for OMERO 5.2 for sysadmins
 
 - The OMERO web framework no longer bundles a copy of the Django package,
   instead manual installation of the Django dependency is required. It is
-  highly recommended to use `Django 1.8`_ (LTS) which requires Python 2.7.
+  highly recommended to use `Django 1.8`_ (LTS) which requires Python 2.7
+  (unless you are using IIS on Windows, in which case you will need to use
+  Django 1.6).
   For more information see :ref:`python-requirements` on the
   :doc:`/sysadmins/version-requirements` page.
 

--- a/omero/sysadmins/windows/install-web.txt
+++ b/omero/sysadmins/windows/install-web.txt
@@ -31,18 +31,6 @@ Prerequisites
 
    -  `Matplotlib`_ should be available for your distribution
 
-   -  `Django 1.6`_ should be available for your distribution.
-
-      .. note:: For more details refer to
-          `install Django 1.6 on Windows <https://docs.djangoproject.com/en/1.6/howto/windows/>`_.
-
-   .. note:: Since OMERO 5.2, the OMERO web framework no longer bundles
-       a copy of the Django package, instead manual installation of
-       the Django dependency is required. It is highly recommended to use
-       `Django 1.6`_ on Windows. For more information
-       see :ref:`python-requirements` on the
-       :doc:`/sysadmins/version-requirements` page.
-
 -  IIS or WSGI capable web server
 
 

--- a/omero/sysadmins/windows/install-web/install-iis.txt
+++ b/omero/sysadmins/windows/install-web/install-iis.txt
@@ -6,6 +6,15 @@ OMERO.web IIS deployment (Windows)
 IIS configuration (Windows)
 ---------------------------
 
+Install `Django 1.6`_ using package requirements file:
+
+::
+
+   $ pip install -r requirements-py26-iis.txt
+
+.. note:: For more details refer to `how to install Django 1.6 <https://docs.djangoproject.com/en/1.6/intro/install/#install-django>`_.
+
+
 Once you have IIS installed on your system, a straightforward set of
 steps is required to get the `ISAPI
 WSGI <http://code.google.com/p/isapi-wsgi/>`_ handler for OMERO.web

--- a/omero/sysadmins/windows/install-web/install-iis.txt
+++ b/omero/sysadmins/windows/install-web/install-iis.txt
@@ -17,7 +17,7 @@ Install `Django 1.6`_ using package requirements file:
 
 ::
 
-   $ pip install -r requirements-py26-iis.txt
+   $ pip install -r share/web/requirements-py26-iis.txt
 
 .. note:: For more details refer to `Django 1.6 installation on Windows <https://docs.djangoproject.com/en/1.6/howto/windows/>`_.
 

--- a/omero/sysadmins/windows/install-web/install-iis.txt
+++ b/omero/sysadmins/windows/install-web/install-iis.txt
@@ -12,7 +12,7 @@ Install `Django 1.6`_ using package requirements file:
 
    $ pip install -r requirements-py26-iis.txt
 
-.. note:: For more details refer to `how to install Django 1.6 <https://docs.djangoproject.com/en/1.6/intro/install/#install-django>`_.
+.. note:: For more details refer to `Django 1.6 installation on Windows <https://docs.djangoproject.com/en/1.6/howto/windows/>`_.
 
 
 Once you have IIS installed on your system, a straightforward set of

--- a/omero/sysadmins/windows/install-web/install-iis.txt
+++ b/omero/sysadmins/windows/install-web/install-iis.txt
@@ -6,6 +6,13 @@ OMERO.web IIS deployment (Windows)
 IIS configuration (Windows)
 ---------------------------
 
+.. note:: Since OMERO 5.2, the OMERO web framework no longer bundles
+       a copy of the Django package, instead manual installation of
+       the Django dependency is required. It is highly recommended to use
+       `Django 1.6`_ on Windows. For more information
+       see :ref:`python-requirements` on the
+       :doc:`/sysadmins/version-requirements` page.
+
 Install `Django 1.6`_ using package requirements file:
 
 ::


### PR DESCRIPTION
This fixes up some remaining issues I noticed on the requirements page, fixes https://trello.com/c/QvS3yU4h/95-blocker-revert-requirement-changes with regard to Ice 3.4 and clarifies the Django issues for Windows (see #1322).
