### PR TITLE
Include specification samples

### DIFF
--- a/formats/specifications/compliant-hcs.txt
+++ b/formats/specifications/compliant-hcs.txt
@@ -16,67 +16,7 @@ This sample structure is based on Sample One in the
 OME Compliant File Specification 
 (see :doc:`index`):
 
-::
-
-    <?xml version="1.0" encoding="UTF-8"?>
-    <OME:OME xmlns:ROI="http://www.openmicroscopy.org/Schemas/ROI/2015-01"
-        xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2015-01"
-        xmlns:BIN="http://www.openmicroscopy.org/Schemas/BinaryFile/2015-01"
-        xmlns:SPW="http://www.openmicroscopy.org/Schemas/SPW/2015-01"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2015-01
-                            http://www.openmicroscopy.org/Schemas/OME/2015-01/ome.xsd">
-
-        <SPW:Plate 
-            ID="Plate:1" 
-            Name="Control Plate" 
-            ColumnNamingConvention="letter" 
-            RowNamingConvention="number" 
-            Columns="12" 
-            Rows="8"
-            >
-            <SPW:Description></SPW:Description>
-
-            <!-- repeat SPW:Well for # of wells in the plate that contain images -->
-            <SPW:Well ID="Well:1" Column="0" Row="0">
-                <!-- repeat SPW:WellSample for # of images taken in the well -->
-                <SPW:WellSample ID="WellSample:1" Index="0">
-                    <!-- 
-                            if there is an image associated with this SPW:WellSample
-                            it is linked using an SPW:ImageRef
-                        -->
-                    <OME:ImageRef ID="Image:0"/>
-                </SPW:WellSample>
-            </SPW:Well>
-        </SPW:Plate>
-        <!-- plus one more Plate for each Plate in this set -->
-
-        <!-- SPW:Screen is not required -->
-
-        <!-- The OME:Image element follows the structure for the OME Compliant File Specification -->
-        <OME:Image ID="Image:0" Name="Series 1">
-            <OME:AcquisitionDate>2008-02-06T13:43:19</OME:AcquisitionDate>
-            <OME:Description>An example OME compliant file, based on Olympus.oib</OME:Description>
-            <OME:Pixels DimensionOrder="XYCZT" ID="Pixels:0" 
-                PhysicalSizeX="0.207" PhysicalSizeY="0.207" 
-                SizeC="3" SizeT="16" SizeX="1024" SizeY="1024" SizeZ="1"
-                TimeIncrement="120.1302" Type="uint16">
-                <OME:Channel EmissionWavelength="523" ExcitationWavelength="488" ID="Channel:0:0"
-                    IlluminationType="Epifluorescence" Name="CH1" SamplesPerPixel="1"
-                    PinholeSize="103.5" AcquisitionMode="LaserScanningConfocalMicroscopy"/>
-                <OME:Channel EmissionWavelength="578" ExcitationWavelength="561" ID="Channel:0:1"
-                    IlluminationType="Epifluorescence" Name="CH3" SamplesPerPixel="1"
-                    PinholeSize="127.24" AcquisitionMode="LaserScanningConfocalMicroscopy"/>
-                <OME:Channel ExcitationWavelength="488" ID="Channel:0:2" 
-                    IlluminationType="Transmitted"
-                    ContrastMethod="DIC" Name="TD1" SamplesPerPixel="1"  
-                    AcquisitionMode="LaserScanningConfocalMicroscopy"/>
-                <BIN:BinData BigEndian="false" Length="0"/>
-            </OME:Pixels>
-        </OME:Image>
-    </OME:OME>
-
-    The data in this sample is nonsense.
+.. literalinclude:: hcs.ome
 
 Alternative valid forms:
 

--- a/formats/specifications/hcs.ome
+++ b/formats/specifications/hcs.ome
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OME:OME xmlns:ROI="http://www.openmicroscopy.org/Schemas/ROI/2015-01"
+    xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2015-01"
+    xmlns:BIN="http://www.openmicroscopy.org/Schemas/BinaryFile/2015-01"
+    xmlns:SPW="http://www.openmicroscopy.org/Schemas/SPW/2015-01"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2015-01
+                        http://www.openmicroscopy.org/Schemas/OME/2015-01/ome.xsd">
+
+    <SPW:Plate 
+        ID="Plate:1" 
+        Name="Control Plate" 
+        ColumnNamingConvention="letter" 
+        RowNamingConvention="number" 
+        Columns="12" 
+        Rows="8"
+        >
+        <SPW:Description></SPW:Description>
+
+        <!-- repeat SPW:Well for # of wells in the plate that contain images -->
+        <SPW:Well ID="Well:1" Column="0" Row="0">
+            <!-- repeat SPW:WellSample for # of images taken in the well -->
+            <SPW:WellSample ID="WellSample:1" Index="0">
+                <!-- 
+                        if there is an image associated with this SPW:WellSample
+                        it is linked using an SPW:ImageRef
+                    -->
+                <OME:ImageRef ID="Image:0"/>
+            </SPW:WellSample>
+        </SPW:Well>
+    </SPW:Plate>
+    <!-- plus one more Plate for each Plate in this set -->
+
+    <!-- SPW:Screen is not required -->
+
+    <!-- The OME:Image element follows the structure for the OME Compliant File Specification -->
+    <OME:Image ID="Image:0" Name="Series 1">
+        <OME:AcquisitionDate>2008-02-06T13:43:19</OME:AcquisitionDate>
+        <OME:Description>An example OME compliant file, based on Olympus.oib</OME:Description>
+        <OME:Pixels DimensionOrder="XYCZT" ID="Pixels:0" 
+            PhysicalSizeX="0.207" PhysicalSizeY="0.207" 
+            SizeC="3" SizeT="16" SizeX="1024" SizeY="1024" SizeZ="1"
+            TimeIncrement="120.1302" Type="uint16">
+            <OME:Channel EmissionWavelength="523" ExcitationWavelength="488" ID="Channel:0:0"
+                IlluminationType="Epifluorescence" Name="CH1" SamplesPerPixel="1"
+                PinholeSize="103.5" AcquisitionMode="LaserScanningConfocalMicroscopy"/>
+            <OME:Channel EmissionWavelength="578" ExcitationWavelength="561" ID="Channel:0:1"
+                IlluminationType="Epifluorescence" Name="CH3" SamplesPerPixel="1"
+                PinholeSize="127.24" AcquisitionMode="LaserScanningConfocalMicroscopy"/>
+            <OME:Channel ExcitationWavelength="488" ID="Channel:0:2" 
+                IlluminationType="Transmitted"
+                ContrastMethod="DIC" Name="TD1" SamplesPerPixel="1"  
+                AcquisitionMode="LaserScanningConfocalMicroscopy"/>
+            <BIN:BinData BigEndian="false" Length="0"/>
+        </OME:Pixels>
+    </OME:Image>
+</OME:OME>

--- a/formats/specifications/index.txt
+++ b/formats/specifications/index.txt
@@ -30,122 +30,13 @@ attributes were then manually added to the files to make them compliant.
 
 Sample structure one:
 
-::
-
-    <?xml version="1.0" encoding="UTF-8"?>
-    <OME:OME xmlns:ROI="http://www.openmicroscopy.org/Schemas/ROI/2015-01"
-        xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2015-01"
-        xmlns:BIN="http://www.openmicroscopy.org/Schemas/BinaryFile/2015-01"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2015-01
-                            http://www.openmicroscopy.org/Schemas/OME/2015-01/ome.xsd">
-    
-        <OME:Image ID="Image:0" Name="Series 1">
-            <OME:AcquisitionDate>2008-02-06T13:43:19</OME:AcquisitionDate>
-            <OME:Description>An example OME compliant file, based on Olympus.oib</OME:Description>
-            <OME:Pixels DimensionOrder="XYCZT" ID="Pixels:0" 
-                PhysicalSizeX="0.207" PhysicalSizeY="0.207"
-                SizeC="3" SizeT="16" SizeX="1024" SizeY="1024" SizeZ="1"
-                TimeIncrement="120.1302" Type="uint16">
-                <OME:Channel EmissionWavelength="523" ExcitationWavelength="488" ID="Channel:0:0"
-                    IlluminationType="Epifluorescence" Name="CH1" SamplesPerPixel="1"
-                    PinholeSize="103.5" AcquisitionMode="LaserScanningConfocalMicroscopy"/>
-                <OME:Channel EmissionWavelength="578" ExcitationWavelength="561" ID="Channel:0:1"
-                    IlluminationType="Epifluorescence" Name="CH3" SamplesPerPixel="1"
-                    PinholeSize="127.24" AcquisitionMode="LaserScanningConfocalMicroscopy"/>
-                <OME:Channel ExcitationWavelength="488" ID="Channel:0:2"
-                    IlluminationType="Transmitted"
-                    ContrastMethod="DIC" Name="TD1" SamplesPerPixel="1"  
-                    AcquisitionMode="LaserScanningConfocalMicroscopy"/>
-                <BIN:BinData BigEndian="false" Length="0"/>
-            </OME:Pixels>
-        </OME:Image>
-    
-    </OME:OME>
+.. literalinclude:: sample-one.ome
 
 Sample structure two:
 
-::
+.. literalinclude:: sample-two.ome
 
-    <?xml version="1.0" encoding="UTF-8"?>
-    <OME:OME xmlns:ROI="http://www.openmicroscopy.org/Schemas/ROI/2015-01"
-        xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2015-01"
-        xmlns:BIN="http://www.openmicroscopy.org/Schemas/BinaryFile/2015-01"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2015-01
-                            http://www.openmicroscopy.org/Schemas/OME/2015-01/ome.xsd">
-    
-        <OME:Instrument ID="Instrument:0">
-            <OME:Detector ID="Detector:0:0" Model="COOLSNAP_HQ / ICX285" Type="CCD"/>
-            <OME:Objective ID="Objective:10002" Immersion="Oil" LensNA="1.4" Manufacturer="Olympus"
-                NominalMagnification="100"/>
-        </OME:Instrument>
-        <OME:Image ID="Image:1" Name="example_R3D_D3D.dv">
-            <OME:AcquisitionDate>2005-01-28T13:50:08</OME:AcquisitionDate>
-            <OME:Description>An example OME compliant file, 
-                based on a wide-field microscope image</OME:Description>
-            <OME:ObjectiveSettings ID="Objective:10002" Medium="Oil" RefractiveIndex="1.52" 
-                CorrectionCollar="7"/>
-            <OME:Pixels DimensionOrder="XYCZT" ID="Pixels:1" PhysicalSizeX="0.06631"
-                PhysicalSizeY="0.06631" PhysicalSizeZ="0.2" 
-                SizeC="3" SizeT="1" SizeX="480" SizeY="480" SizeZ="5"
-                Type="int16">
-                <OME:Channel EmissionWavelength="457" ExcitationWavelength="360" ID="Channel:1:0"
-                    NDFilter="0.5" Name="DAPI" SamplesPerPixel="1" Fluor="DAPI"
-                    IlluminationType="Epifluorescence" ContrastMethod="Fluorescence"
-                    AcquisitionMode="WideField" Color="65535">
-                    <OME:DetectorSettings Binning="1x1" Gain="0.5" ID="Detector:0:0" 
-                        ReadOutRate="10.0"/>
-                </OME:Channel>
-                <OME:Channel EmissionWavelength="528" ExcitationWavelength="490" ID="Channel:1:1"
-                    NDFilter="0.0" Name="FITC" SamplesPerPixel="1" Fluor="GFP"
-                    IlluminationType="Epifluorescence" ContrastMethod="Fluorescence"
-                    AcquisitionMode="WideField" Color="16711935">
-                    <OME:DetectorSettings Binning="1x1" Gain="0.5" ID="Detector:0:0" 
-                        ReadOutRate="10.0"/>
-                </OME:Channel>
-                <OME:Channel EmissionWavelength="617" ExcitationWavelength="555" ID="Channel:1:2"
-                    NDFilter="0.0" Name="RD-TR-PE" SamplesPerPixel="1" Fluor="TRITC"
-                    IlluminationType="Epifluorescence" ContrastMethod="Fluorescence"
-                    AcquisitionMode="WideField" Color="-16776961">
-                    <OME:DetectorSettings Binning="1x1" Gain="0.5" ID="Detector:0:0"
-                        ReadOutRate="10.0"/>
-                </OME:Channel>
-                <BIN:BinData BigEndian="false" Length="0"/>
-                <OME:Plane DeltaT="0.0" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46"
-                    PositionZ="-21.496" TheC="0" TheT="0" TheZ="0"/>
-                <OME:Plane DeltaT="0.294" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46"
-                    PositionZ="-21.696" TheC="0" TheT="0" TheZ="1"/>
-                <OME:Plane DeltaT="0.587" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46"
-                    PositionZ="-21.896" TheC="0" TheT="0" TheZ="2"/>
-                <OME:Plane DeltaT="0.881" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46"
-                    PositionZ="-22.096" TheC="0" TheT="0" TheZ="3"/>
-                <OME:Plane DeltaT="1.174" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46"
-                    PositionZ="-22.296" TheC="0" TheT="0" TheZ="4"/>
-                <OME:Plane DeltaT="9.625" ExposureTime="0.3" PositionX="3316.37" PositionY="-646.46"
-                    PositionZ="-21.496" TheC="1" TheT="0" TheZ="0"/>
-                <OME:Plane DeltaT="10.12" ExposureTime="0.3" PositionX="3316.37" PositionY="-646.46"
-                    PositionZ="-21.696" TheC="1" TheT="0" TheZ="1"/>
-                <OME:Plane DeltaT="10.613" ExposureTime="0.3" PositionX="3316.37" PositionY="-646.46"
-                    PositionZ="-21.896" TheC="1" TheT="0" TheZ="2"/>
-                <OME:Plane DeltaT="11.106" ExposureTime="0.3" PositionX="3316.37" PositionY="-646.46"
-                    PositionZ="-22.096" TheC="1" TheT="0" TheZ="3"/>
-                <OME:Plane DeltaT="11.599" ExposureTime="0.3" PositionX="3316.37" PositionY="-646.46"
-                    PositionZ="-22.296" TheC="1" TheT="0" TheZ="4"/>
-                <OME:Plane DeltaT="25.447" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46"
-                    PositionZ="-21.496" TheC="2" TheT="0" TheZ="0"/>
-                <OME:Plane DeltaT="25.739" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46"
-                    PositionZ="-21.696" TheC="2" TheT="0" TheZ="1"/>
-                <OME:Plane DeltaT="26.033" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46"
-                    PositionZ="-21.896" TheC="2" TheT="0" TheZ="2"/>
-                <OME:Plane DeltaT="26.326" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46"
-                    PositionZ="-22.096" TheC="2" TheT="0" TheZ="3"/>
-                <OME:Plane DeltaT="26.619" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46"
-                    PositionZ="-22.296" TheC="2" TheT="0" TheZ="4"/>
-            </OME:Pixels>
-        </OME:Image>        
-    </OME:OME>
-
+.. note::
     The data (BinData element content) in these sample was removed for
     reasons of length.
 

--- a/formats/specifications/minimum-specification.ome
+++ b/formats/specifications/minimum-specification.ome
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ome:OME xmlns:bf="http://www.openmicroscopy.org/Schemas/BinaryFile/2015-01"
+    xmlns:ome="http://www.openmicroscopy.org/Schemas/OME/2015-01"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2015-01
+                        http://www.openmicroscopy.org/Schemas/OME/2015-01/ome.xsd">
+    <ome:Image ID="Image:1" Name="Name92">
+        <ome:AcquisitionDate>2009-03-16T15:41:51.0Z</ome:AcquisitionDate>
+        <ome:Pixels 
+            ID="Pixels:1" 
+            DimensionOrder="XYZCT" 
+            Type="int8" 
+            SizeX="2" 
+            SizeY="2" 
+            SizeZ="2"
+            SizeC="2" 
+            SizeT="2">
+            <bf:BinData 
+                BigEndian="false" 
+                Compression="none" 
+                Length="12"
+                >ZGVmYXVsdA==</bf:BinData>
+        </ome:Pixels>
+    </ome:Image>
+</ome:OME>

--- a/formats/specifications/minimum.txt
+++ b/formats/specifications/minimum.txt
@@ -9,34 +9,7 @@ A minimum specification OME file has been defined. This is best viewed
 as being the minimum required for the display of an image. A sample of
 the structure is:
 
-::
-
-    <?xml version="1.0" encoding="UTF-8"?>
-    <OME xmlns:bf="http://www.openmicroscopy.org/Schemas/BinaryFile/2015-01"
-        xmlns="http://www.openmicroscopy.org/Schemas/OME/2015-01"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2015-01
-                            http://www.openmicroscopy.org/Schemas/OME/2015-01/ome.xsd">
-        <Image ID="Image:1" Name="Name92">
-            <AcquisitionDate>2009-03-16T15:41:51.0Z</AcquisitionDate>
-            <Pixels 
-                ID="Pixels:1" 
-                DimensionOrder="XYZCT" 
-                Type="int8" 
-                SizeX="2" 
-                SizeY="2" 
-                SizeZ="2"
-                SizeC="2" 
-                SizeT="2">
-                <bf:BinData 
-                    BigEndian="false" 
-                    Compression="none" 
-                    Length="12"
-                    >ZGVmYXVsdA==</bf:BinData>
-            </Pixels>
-        </Image>
-    </OME>
-    The data in this sample is nonsense.
+.. literalinclude:: minimum-specification.ome
 
 Alternative valid forms:
 

--- a/formats/specifications/minimum.txt
+++ b/formats/specifications/minimum.txt
@@ -12,14 +12,14 @@ the structure is:
 ::
 
     <?xml version="1.0" encoding="UTF-8"?>
-    <ome:OME xmlns:bf="http://www.openmicroscopy.org/Schemas/BinaryFile/2015-01"
-        xmlns:ome="http://www.openmicroscopy.org/Schemas/OME/2015-01"
+    <OME xmlns:bf="http://www.openmicroscopy.org/Schemas/BinaryFile/2015-01"
+        xmlns="http://www.openmicroscopy.org/Schemas/OME/2015-01"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2015-01
                             http://www.openmicroscopy.org/Schemas/OME/2015-01/ome.xsd">
-        <ome:Image ID="Image:1" Name="Name92">
-            <ome:AcquisitionDate>2009-03-16T15:41:51.0Z</ome:AcquisitionDate>
-            <ome:Pixels 
+        <Image ID="Image:1" Name="Name92">
+            <AcquisitionDate>2009-03-16T15:41:51.0Z</AcquisitionDate>
+            <Pixels 
                 ID="Pixels:1" 
                 DimensionOrder="XYZCT" 
                 Type="int8" 
@@ -33,9 +33,9 @@ the structure is:
                     Compression="none" 
                     Length="12"
                     >ZGVmYXVsdA==</bf:BinData>
-            </ome:Pixels>
-        </ome:Image>
-    </ome:OME>
+            </Pixels>
+        </Image>
+    </OME>
     The data in this sample is nonsense.
 
 Alternative valid forms:

--- a/formats/specifications/sample-one.ome
+++ b/formats/specifications/sample-one.ome
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OME:OME xmlns:ROI="http://www.openmicroscopy.org/Schemas/ROI/2015-01"
+    xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2015-01"
+    xmlns:BIN="http://www.openmicroscopy.org/Schemas/BinaryFile/2015-01"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2015-01
+                        http://www.openmicroscopy.org/Schemas/OME/2015-01/ome.xsd">
+
+    <OME:Image ID="Image:0" Name="Series 1">
+        <OME:AcquisitionDate>2008-02-06T13:43:19</OME:AcquisitionDate>
+        <OME:Description>An example OME compliant file, based on Olympus.oib</OME:Description>
+        <OME:Pixels DimensionOrder="XYCZT" ID="Pixels:0" 
+            PhysicalSizeX="0.207" PhysicalSizeY="0.207"
+            SizeC="3" SizeT="16" SizeX="1024" SizeY="1024" SizeZ="1"
+            TimeIncrement="120.1302" Type="uint16">
+            <OME:Channel EmissionWavelength="523" ExcitationWavelength="488" ID="Channel:0:0"
+                IlluminationType="Epifluorescence" Name="CH1" SamplesPerPixel="1"
+                PinholeSize="103.5" AcquisitionMode="LaserScanningConfocalMicroscopy"/>
+            <OME:Channel EmissionWavelength="578" ExcitationWavelength="561" ID="Channel:0:1"
+                IlluminationType="Epifluorescence" Name="CH3" SamplesPerPixel="1"
+                PinholeSize="127.24" AcquisitionMode="LaserScanningConfocalMicroscopy"/>
+            <OME:Channel ExcitationWavelength="488" ID="Channel:0:2"
+                IlluminationType="Transmitted"
+                ContrastMethod="DIC" Name="TD1" SamplesPerPixel="1"  
+                AcquisitionMode="LaserScanningConfocalMicroscopy"/>
+            <BIN:BinData BigEndian="false" Length="0"/>
+        </OME:Pixels>
+    </OME:Image>
+
+</OME:OME>

--- a/formats/specifications/sample-two.ome
+++ b/formats/specifications/sample-two.ome
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OME:OME xmlns:ROI="http://www.openmicroscopy.org/Schemas/ROI/2015-01"
+    xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2015-01"
+    xmlns:BIN="http://www.openmicroscopy.org/Schemas/BinaryFile/2015-01"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2015-01
+                        http://www.openmicroscopy.org/Schemas/OME/2015-01/ome.xsd">
+
+    <OME:Instrument ID="Instrument:0">
+        <OME:Detector ID="Detector:0:0" Model="COOLSNAP_HQ / ICX285" Type="CCD"/>
+        <OME:Objective ID="Objective:10002" Immersion="Oil" LensNA="1.4" Manufacturer="Olympus"
+            NominalMagnification="100"/>
+    </OME:Instrument>
+    <OME:Image ID="Image:1" Name="example_R3D_D3D.dv">
+        <OME:AcquisitionDate>2005-01-28T13:50:08</OME:AcquisitionDate>
+        <OME:Description>An example OME compliant file, 
+            based on a wide-field microscope image</OME:Description>
+        <OME:ObjectiveSettings ID="Objective:10002" Medium="Oil" RefractiveIndex="1.52" 
+            CorrectionCollar="7"/>
+        <OME:Pixels DimensionOrder="XYCZT" ID="Pixels:1" PhysicalSizeX="0.06631"
+            PhysicalSizeY="0.06631" PhysicalSizeZ="0.2" 
+            SizeC="3" SizeT="1" SizeX="480" SizeY="480" SizeZ="5"
+            Type="int16">
+            <OME:Channel EmissionWavelength="457" ExcitationWavelength="360" ID="Channel:1:0"
+                NDFilter="0.5" Name="DAPI" SamplesPerPixel="1" Fluor="DAPI"
+                IlluminationType="Epifluorescence" ContrastMethod="Fluorescence"
+                AcquisitionMode="WideField" Color="65535">
+                <OME:DetectorSettings Binning="1x1" Gain="0.5" ID="Detector:0:0" 
+                    ReadOutRate="10.0"/>
+            </OME:Channel>
+            <OME:Channel EmissionWavelength="528" ExcitationWavelength="490" ID="Channel:1:1"
+                NDFilter="0.0" Name="FITC" SamplesPerPixel="1" Fluor="GFP"
+                IlluminationType="Epifluorescence" ContrastMethod="Fluorescence"
+                AcquisitionMode="WideField" Color="16711935">
+                <OME:DetectorSettings Binning="1x1" Gain="0.5" ID="Detector:0:0" 
+                    ReadOutRate="10.0"/>
+            </OME:Channel>
+            <OME:Channel EmissionWavelength="617" ExcitationWavelength="555" ID="Channel:1:2"
+                NDFilter="0.0" Name="RD-TR-PE" SamplesPerPixel="1" Fluor="TRITC"
+                IlluminationType="Epifluorescence" ContrastMethod="Fluorescence"
+                AcquisitionMode="WideField" Color="-16776961">
+                <OME:DetectorSettings Binning="1x1" Gain="0.5" ID="Detector:0:0"
+                    ReadOutRate="10.0"/>
+            </OME:Channel>
+            <BIN:BinData BigEndian="false" Length="0"/>
+            <OME:Plane DeltaT="0.0" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46"
+                PositionZ="-21.496" TheC="0" TheT="0" TheZ="0"/>
+            <OME:Plane DeltaT="0.294" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46"
+                PositionZ="-21.696" TheC="0" TheT="0" TheZ="1"/>
+            <OME:Plane DeltaT="0.587" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46"
+                PositionZ="-21.896" TheC="0" TheT="0" TheZ="2"/>
+            <OME:Plane DeltaT="0.881" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46"
+                PositionZ="-22.096" TheC="0" TheT="0" TheZ="3"/>
+            <OME:Plane DeltaT="1.174" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46"
+                PositionZ="-22.296" TheC="0" TheT="0" TheZ="4"/>
+            <OME:Plane DeltaT="9.625" ExposureTime="0.3" PositionX="3316.37" PositionY="-646.46"
+                PositionZ="-21.496" TheC="1" TheT="0" TheZ="0"/>
+            <OME:Plane DeltaT="10.12" ExposureTime="0.3" PositionX="3316.37" PositionY="-646.46"
+                PositionZ="-21.696" TheC="1" TheT="0" TheZ="1"/>
+            <OME:Plane DeltaT="10.613" ExposureTime="0.3" PositionX="3316.37" PositionY="-646.46"
+                PositionZ="-21.896" TheC="1" TheT="0" TheZ="2"/>
+            <OME:Plane DeltaT="11.106" ExposureTime="0.3" PositionX="3316.37" PositionY="-646.46"
+                PositionZ="-22.096" TheC="1" TheT="0" TheZ="3"/>
+            <OME:Plane DeltaT="11.599" ExposureTime="0.3" PositionX="3316.37" PositionY="-646.46"
+                PositionZ="-22.296" TheC="1" TheT="0" TheZ="4"/>
+            <OME:Plane DeltaT="25.447" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46"
+                PositionZ="-21.496" TheC="2" TheT="0" TheZ="0"/>
+            <OME:Plane DeltaT="25.739" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46"
+                PositionZ="-21.696" TheC="2" TheT="0" TheZ="1"/>
+            <OME:Plane DeltaT="26.033" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46"
+                PositionZ="-21.896" TheC="2" TheT="0" TheZ="2"/>
+            <OME:Plane DeltaT="26.326" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46"
+                PositionZ="-22.096" TheC="2" TheT="0" TheZ="3"/>
+            <OME:Plane DeltaT="26.619" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46"
+                PositionZ="-22.296" TheC="2" TheT="0" TheZ="4"/>
+        </OME:Pixels>
+    </OME:Image>        
+</OME:OME>


### PR DESCRIPTION
As reported in https://github.com/openmicroscopy/bioformats/pull/2068#issuecomment-155421039, the minimal specification on our formats documentation does not pass xmlvalid. This PR modifies the specifications to include external OME-XML files via `literalinclude`. These OME-XML samples can be tested like the rest our [samples](https://www.openmicroscopy.org/Schemas/Samples/2015-01/). /cc @rleigh-dundee @mtbc @joshmoore @melissalinkert 
