### PR TITLE
removing system python from mac os x walkt through

### DIFF
--- a/omero/sysadmins/unix/server-install-homebrew.txt
+++ b/omero/sysadmins/unix/server-install-homebrew.txt
@@ -68,7 +68,6 @@ https://github.com/Homebrew/homebrew-science for the HDF5 formula and
 https://github.com/ome/homebrew-alt for all the OME-provided formulae
 and older versions of Ice.  To add these, run::
 
-    $ brew tap homebrew/python
     $ brew tap homebrew/science
     $ brew tap ome/alt
 

--- a/omero/sysadmins/unix/server-install-homebrew.txt
+++ b/omero/sysadmins/unix/server-install-homebrew.txt
@@ -5,7 +5,7 @@ OMERO.server Mac OS X installation walk-through with Homebrew
 .. topic:: Overview
 
     This walk-through demonstrates how to install OMERO on a clean Mac
-    OS X system (10.8 or later) using Homebrew.  Note that this
+    OS X system (10.9 or later) using Homebrew.  Note that this
     demonstrates how to install OMERO.server *from the source code*
     via Homebrew, in addition to all its prerequisites. **The default
     instructions for UNIX platforms in the**
@@ -68,6 +68,7 @@ https://github.com/Homebrew/homebrew-science for the HDF5 formula and
 https://github.com/ome/homebrew-alt for all the OME-provided formulae
 and older versions of Ice.  To add these, run::
 
+    $ brew tap homebrew/python
     $ brew tap homebrew/science
     $ brew tap ome/alt
 
@@ -83,9 +84,8 @@ Python 2.7
 
 .. _`Homebrew and Python`: https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Homebrew-and-Python.md
 
-You can install OMERO using either the Python 2.7 provided by
-Homebrew, or the system-wide Python 2.7 provided by MacOS X. Homebrew
-Python is recommended since it makes using Homebrew-provided modules
+You should install OMERO using Python 2.7 provided by
+Homebrew since it makes using Homebrew-provided modules
 simpler, for example the Ice python bindings needed by OMERO. For a
 more thorough description of the Homebrew solution, see the `Homebrew
 and Python`_ page. Note that the automated script linked above tests
@@ -100,20 +100,7 @@ Check that Python is working and is version 2.7::
     $ /usr/local/bin/python --version
     Python 2.7.9
 
-If using system Python, add the following to :file:`~/.profile` and
-then start a new shell for the change to take effect::
-
-    export PYTHONPATH=$(brew --prefix omero)/lib/python
-
-If using Homebrew Python, this will be on the default module path.
-
-.. note::
-
-    If you have a local :file:`.bash_profile` file, it will override
-    your :file:`.profile` configuration file.
-
-
-Independently of the chosen Python, you can set up and use `virtual
+To create isolated Python environemnt you can set up and use `virtual
 environments <http://www.virtualenv.org/en/latest/>`_ to install the OMERO
 Python dependencies (see :ref:`python_dependencies`).
 

--- a/omero/sysadmins/unix/server-installation.txt
+++ b/omero/sysadmins/unix/server-installation.txt
@@ -71,10 +71,6 @@ Fedora and Scientific Linux.
 
   where *package* is the package name to install.
 
-* For homebrew you need to enable the "python" and "science" taps::
-
-    $ brew tap homebrew/python
-    $ brew tap homebrew/science
 
 .. _server-requirements:
 


### PR DESCRIPTION
This PR update Mac OS X walkthrough
- removes system python support
- clean up
