### PR TITLE
Document Homebrew jobs split

### DIFF
--- a/contributing/ci-bio-formats.txt
+++ b/contributing/ci-bio-formats.txt
@@ -65,6 +65,11 @@ All jobs are listed under the :jenkinsview:`Bio-Formats` view tab of Jenkins.
                 * :term:`BIOFORMATS-5.1-merge-openbytes-performance`
                 * :term:`BIOFORMATS-DEV-merge-openbytes-performance`
 
+
+        -       * Installs Bio-Formats using Homebrew
+                * :term:`BIOFORMATS-5.1-merge-homebrew`
+                *
+
         -       * Builds the latest native C++ implementation for Bio-Formats
                 * :term:`BIOFORMATS-CPP-5.1-latest`
                 *
@@ -79,10 +84,6 @@ All jobs are listed under the :jenkinsview:`Bio-Formats` view tab of Jenkins.
 
         -       * Builds the merge native C++ implementation for Bio-Formats
                 * :term:`BIOFORMATS-CPP-5.1-merge`
-                *
-
-        -       * Builds the merge native C++ implementation for Bio-Formats (MacOS X homebrew build)
-                * :term:`BIOFORMATS-CPP-5.1-merge-homebrew`
                 *
 
         -       * Builds the merge native C++ implementation for Bio-Formats (Unix superbuild)
@@ -244,6 +245,10 @@ The branch for the 5.1.x series of Bio-Formats is dev_5_1.
                    ``loci.tests.testng.OpenBytesPerformanceTest`` tests against
                    directories specified by
                    :file:`BIOFORMATS-openbytes-performance.txt`
+
+        :jenkinsjob:`BIOFORMATS-5.1-merge-homebrew`
+
+                This job builds Bio-Formats Java using MacOS X Homebrew
 
         :jenkinsjob:`BIOFORMATS-CPP-5.1-latest`
 

--- a/contributing/ci-bio-formats.txt
+++ b/contributing/ci-bio-formats.txt
@@ -268,11 +268,6 @@ The branch for the 5.1.x series of Bio-Formats is dev_5_1.
 
                 This job builds the merge native C++ implementation for Bio-Formats
 
-        :jenkinsjob:`BIOFORMATS-CPP-5.1-merge-homebrew`
-
-                This job builds the merge native C++ implementation
-                for Bio-Formats (MacOS X homebrew build)
-
         :jenkinsjob:`BIOFORMATS-CPP-5.1-merge-superbuild`
 
                 This job builds the merge native C++ implementation

--- a/contributing/ci-omero.txt
+++ b/contributing/ci-omero.txt
@@ -81,7 +81,7 @@ OMERO jobs
         *
 
     -   * Installs OMERO using Homebrew
-        * :term:`OME-5.1-merge-homebrew`
+        * :term:`OMERO-5.1-merge-homebrew`
         *
         *
 
@@ -337,7 +337,7 @@ under the :jenkinsview:`5.1` view tab of Jenkins.
         #. Builds OMERO.server and starts it
         #. Runs the robot framework tests and collect the results
 
-    :jenkinsjob:`OME-5.1-merge-homebrew`
+    :jenkinsjob:`OMERO-5.1-merge-homebrew`
 
         This job tests the installation of OMERO 5.1 using Homebrew
 


### PR DESCRIPTION
With decoupling, a single OME Homebrew job for Bio-Formats and OMERO does not
scale. This PR documents the job split.

/cc @mtbc 
