### PR TITLE
Openjdk8 on limitations page

### DIFF
--- a/omero/sysadmins/limitations.txt
+++ b/omero/sysadmins/limitations.txt
@@ -21,8 +21,10 @@ for `OpenJDK
 <https://bugs.launchpad.net/ubuntu/+source/openjdk-8/+bug/1421501>`__. See
 :ticket:`12612` and `this ome-users thread <http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-November/005723.html>`__
 for more information. OracleJDK8 is also supported, but the earliest releases
-have had problems. The latest OpenJDK8 or OracleJDK8 should work correctly.
-OpenJDK and OracleJDK version 7 are also supported.
+have had problems. The latest OpenJDK8 or OracleJDK8 should work correctly (we
+have checked both OpenJDK 1.8.0_45-internal and OracleJDK 1.8.0_66). OpenJDK
+and OracleJDK version 7 are also supported (we have tested java version
+1.7.0_80).
 
 Windows OS issues
 -----------------

--- a/omero/sysadmins/limitations.txt
+++ b/omero/sysadmins/limitations.txt
@@ -18,7 +18,10 @@ the current Ubuntu build of 8u40) have broken JPEG support, reported
 for `OpenJDK
 <http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=1393>`__ and
 `Ubuntu
-<https://bugs.launchpad.net/ubuntu/+source/openjdk-8/+bug/1421501>`__.
+<https://bugs.launchpad.net/ubuntu/+source/openjdk-8/+bug/1421501>`__. See
+:ticket:`ticket 12612` and
+:mailinglist:`this ome-users thread <ome-users/2015-November/005723.html>` for
+more information.
 OracleJDK8 is also supported, but the earliest releases have had
 problems.  The latest OpenJDK8 or OracleJDK8 should work
 correctly. OpenJDK and OracleJDK versions 6 and 7 are also supported.

--- a/omero/sysadmins/limitations.txt
+++ b/omero/sysadmins/limitations.txt
@@ -23,8 +23,8 @@ for `OpenJDK
 for more information. OracleJDK8 is also supported, but the earliest releases
 have had problems. The latest OpenJDK8 or OracleJDK8 should work correctly (we
 have checked both OpenJDK 1.8.0_45-internal and OracleJDK 1.8.0_66). OpenJDK
-and OracleJDK version 7 are also supported (we have tested java version
-1.7.0_80).
+and OracleJDK version 7 are also supported (we have tested OracleJDK 1.7.0_80
+and OpenJDK 1.7.0_85).
 
 Windows OS issues
 -----------------

--- a/omero/sysadmins/limitations.txt
+++ b/omero/sysadmins/limitations.txt
@@ -19,12 +19,10 @@ for `OpenJDK
 <http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=1393>`__ and
 `Ubuntu
 <https://bugs.launchpad.net/ubuntu/+source/openjdk-8/+bug/1421501>`__. See
-:ticket:`ticket 12612` and
-:mailinglist:`this ome-users thread <ome-users/2015-November/005723.html>` for
-more information.
-OracleJDK8 is also supported, but the earliest releases have had
-problems.  The latest OpenJDK8 or OracleJDK8 should work
-correctly. OpenJDK and OracleJDK versions 6 and 7 are also supported.
+:ticket:`12612` and `this ome-users thread <http://lists.openmicroscopy.org.uk/pipermail/ome-users/2015-November/005723.html>`__
+for more information. OracleJDK8 is also supported, but the earliest releases
+have had problems. The latest OpenJDK8 or OracleJDK8 should work correctly.
+OpenJDK and OracleJDK version 7 are also supported.
 
 Windows OS issues
 -----------------


### PR DESCRIPTION
Replaces #1330 - adds Trac and mailing list links and removes reference to jdk 6 which we don't support any more.
