### PR TITLE
Add superseded note to 5.1 docs

### DIFF
--- a/omero/conf.py
+++ b/omero/conf.py
@@ -45,6 +45,11 @@ else:
     previousversion = 'UNKNOWN'
     release = 'UNKNOWN'
 
+rst_prolog = """
+.. note:: **This documentation is for the superseded OMERO 5.1 line.** See the `latest
+    OMERO 5.2.x version <http://www.openmicroscopy.org/site/support/omero5.2/>`_ for the
+    most up-to-date documentation.
+"""
 
 rst_epilog += """
 .. |OmeroPy| replace:: :doc:`/developers/Python`


### PR DESCRIPTION
See https://trello.com/c/1VCpNEFp/195-google-shows-old-versions-as-recent
As an interim help, while we get the hang of getting Google to point at the new docs more quickly, I propose sticking a banner of the 5.1 docs to make it clear these aren't the most up to date ones any more.
