### PR TITLE
Cross-referencing key-value pairs/map annotation docs

### DIFF
--- a/formats/developers/index.txt
+++ b/formats/developers/index.txt
@@ -60,8 +60,8 @@ Support for additional dimensions is also covered:
 
 -  :doc:`6D, 7D and 8D Storage <6d-7d-and-8d-storage>`
 
-The new 'key-value pairs' Map Annotations introduced in the
-:doc:`/schemas/january-2015` are a type of Structured Annotation. Further
+Map Annotations, storing 'key-value pairs', are a type of Structured
+Annotation which were introduced in the :doc:`/schemas/january-2015`. Further
 information is available in the :omero_doc:`OMERO developer documentation on
 Key-value pairs <developers/Model/KeyValuePairs.html>`.
 

--- a/formats/developers/index.txt
+++ b/formats/developers/index.txt
@@ -60,6 +60,11 @@ Support for additional dimensions is also covered:
 
 -  :doc:`6D, 7D and 8D Storage <6d-7d-and-8d-storage>`
 
+The new 'key-value pairs' Map Annotations introduced in the
+:doc:`/schemas/january-2015` are a type of Structured Annotation. Further
+information is available in the :omero_doc:`OMERO developer documentation on
+Key-value pairs <developers/Model/KeyValuePairs.html>`.
+
 Legacy solutions for tiled images and Single (or Selective) Plane Illumination
 Microscopy (also known as Light Sheet Microscopy) are detailed in the
 following sections for reference but **both these methods have been superseded

--- a/formats/developers/structured-annotations.txt
+++ b/formats/developers/structured-annotations.txt
@@ -13,8 +13,8 @@ For more information on SAs from an OMERO-centric perspective, see the
 :omero_doc:`OMERO page on structured
 annotations <developers/Model/StructuredAnnotations.html>`.
 
-The new 'key-value pairs' Map Annotations introduced in the
-:doc:`/schemas/january-2015` are a type of Structured Annotation. Further
+Map Annotations, storing 'key-value pairs', are a type of Structured
+Annotation which were introduced in the :doc:`/schemas/january-2015`. Further
 information is available in the :omero_doc:`OMERO developer documentation on
 Key-value pairs <developers/Model/KeyValuePairs.html>`.
 

--- a/formats/developers/structured-annotations.txt
+++ b/formats/developers/structured-annotations.txt
@@ -13,6 +13,11 @@ For more information on SAs from an OMERO-centric perspective, see the
 :omero_doc:`OMERO page on structured
 annotations <developers/Model/StructuredAnnotations.html>`.
 
+The new 'key-value pairs' Map Annotations introduced in the
+:doc:`/schemas/january-2015` are a type of Structured Annotation. Further
+information is available in the :omero_doc:`OMERO developer documentation on
+Key-value pairs <developers/Model/KeyValuePairs.html>`.
+
 The structure of the SA used in the schema is shown below,
 along with all the possible attachment points in the model.
 

--- a/formats/schemas/january-2015.txt
+++ b/formats/schemas/january-2015.txt
@@ -121,7 +121,7 @@ OME
     | ``UnitsElectricPotential``
     | ``UnitsPower``
     | ``UnitsFrequency``
-- Added a new ``GenericExcitationSource`` to light source types. This using a
+- Added a new ``GenericExcitationSource`` to light source types. This uses a
   ``Map`` of key-value pairs to store metadata for a light source that cannot
   be expressed as one of the other types.
 

--- a/formats/schemas/january-2015.txt
+++ b/formats/schemas/january-2015.txt
@@ -107,7 +107,7 @@ OME
     | ``Filter: CutOutTolerance``
     | ``Laser: Wavelength``
     | ``LightSourceSettings: Wavelength``
-- Added a general ``Map`` to ``ImagingEnvironment`` to store key/value pairs
+- Added a general ``Map`` to ``ImagingEnvironment`` to store key-value pairs
 - Added a new core type ``NonNegativeFloat``
 - Added a new core element ``Map`` and associated complex type ``MapPairs``.
   This in turn contains a collection of ``M`` elements that store a mapped
@@ -122,7 +122,7 @@ OME
     | ``UnitsPower``
     | ``UnitsFrequency``
 - Added a new ``GenericExcitationSource`` to light source types. This using a
-  ``Map`` of key/value pairs to store metadata for a light source that cannot
+  ``Map`` of key-value pairs to store metadata for a light source that cannot
   be expressed as one of the other types.
 
 OMERO
@@ -143,7 +143,7 @@ SA
 ^^
 
 - Added a new ``MapAnnotation`` type. This makes use of the new
-  ``Map`` element from ``ome.xsd`` to store a collection of key/value pairs.
+  ``Map`` element from ``ome.xsd`` to store a collection of key-value pairs.
 
 SPW
 ^^^


### PR DESCRIPTION
Finding the docs for map annotations is a bit of a nightmare at the moment as Jason noticed - no mention of them in the Model docs where you might expect and because they are described as key value pairs in the OMERO docs, searching isn't very helpful either. This should hopefully redress that for now (next schema these annotations will probably change anyway (shouldn't be text annotations) and we should aim to add docs then).

See https://www.openmicroscopy.org/site/support/ome-model-staging/ for review and also try the search box on the sphinx pages.
