### PR TITLE
webclient api clarification

### DIFF
--- a/omero/developers/Web.txt
+++ b/omero/developers/Web.txt
@@ -47,6 +47,12 @@ folders named 'web....'. These include webgateway, as
 discussed above, as well as released tools (webadmin, webclient) and
 other apps in development:
 
+.. note::
+    Although it is possible to access functionality from any installed app,
+    only webgateway should be considered as a stable public API. URLs and methods
+    within other web apps are purely designed to provide internal functionality for
+    the app itself and may change in minor releases.
+
 .. glossary::
     webclient
         Main web client for viewing images, annotating etc. More

--- a/omero/developers/Web.txt
+++ b/omero/developers/Web.txt
@@ -47,12 +47,6 @@ folders named 'web....'. These include webgateway, as
 discussed above, as well as released tools (webadmin, webclient) and
 other apps in development:
 
-.. note::
-    Although it is possible to access functionality from any installed app,
-    only webgateway should be considered as a stable public API. URLs and methods
-    within other web apps are purely designed to provide internal functionality for
-    the app itself and may change in minor releases.
-
 .. glossary::
     webclient
         Main web client for viewing images, annotating etc. More
@@ -64,6 +58,12 @@ other apps in development:
     webgateway
         A web services interface, providing rendered images and
         data. See :doc:`/developers/Web/WebGateway`.
+
+.. note::
+    Although it is possible to access functionality from any installed app,
+    **ONLY webgateway** should be considered as a stable public API. URLs and methods
+    within other web apps are purely designed to provide internal functionality for
+    the app itself and may change in minor releases.
 
 Additional apps can be easily added to your OMERO.web deployment.
 One example is the `webtest app <https://github.com/openmicroscopy/webtest/>`_

--- a/omero/developers/Web.txt
+++ b/omero/developers/Web.txt
@@ -63,7 +63,7 @@ other apps in development:
     Although it is possible to access functionality from any installed app,
     **ONLY webgateway** should be considered as a stable public API. URLs and methods
     within other web apps are purely designed to provide internal functionality for
-    the app itself and may change in minor releases.
+    the app itself and may change in minor releases without warning.
 
 Additional apps can be easily added to your OMERO.web deployment.
 One example is the `webtest app <https://github.com/openmicroscopy/webtest/>`_


### PR DESCRIPTION
This adds a note to the web developer docs to warn that all apps other than webgateway should not be considered as usable APIs.
