### PR TITLE
Updated OSX walkthrough

### DIFF
--- a/omero/sysadmins/unix/server-install-homebrew.txt
+++ b/omero/sysadmins/unix/server-install-homebrew.txt
@@ -230,7 +230,7 @@ Now connect to your OMERO.server using OMERO.insight or OMERO.web with the follo
 ::
 
     U: root
-    P: root_password
+    P: omero
 
 Stop OMERO.web::
 

--- a/omero/sysadmins/unix/server-install-homebrew.txt
+++ b/omero/sysadmins/unix/server-install-homebrew.txt
@@ -48,6 +48,8 @@ running::
 Requirements
 ------------
 
+See installation script :download:`step01_deps.sh <walkthrough/osx/step01_deps.sh>`
+
 .. _`Homebrew wiki`: https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Installation.md
 
 All the requirements for OMERO will be installed under :file:`/usr/local`. See also: Installation instructions on the `Homebrew wiki`_.
@@ -99,8 +101,6 @@ and older versions of Ice. To add these, run::
     $ brew tap homebrew/science
     $ brew tap ome/alt
 
-:download:`step01_deps.sh <walkthrough/osx/step01_deps.sh>`
-
 .. note::
 
     The Homebrew formulae used below provide Python bindings. As
@@ -111,6 +111,8 @@ and older versions of Ice. To add these, run::
 OMERO installation
 ------------------
 
+See installation script :download:`step02_omero.sh <walkthrough/osx/step02_omero.sh>`
+
 OMERO |release| server
 ^^^^^^^^^^^^^^^^^^^^^^
 
@@ -120,6 +122,9 @@ To install and deploy the |release| release of OMERO.server, run::
     $ brew install omero52 --with-nginx --with-cpp
     $ export PYTHONPATH=$(brew --prefix omero52)/lib/python
     $ export ICE_CONFIG=$(brew --prefix omero52)/etc/ice.config
+
+This will install the OMERO server to /usr/local/Cellar/omero, which means you'll find the
+log files in /usr/local/Cellar/omero/|release|/var/log. The binaries will be linked to /usr/local/bin.
 
 Install OMERO python dependencies::
 
@@ -157,8 +162,6 @@ Set up OMERO data directory::
     $ mkdir -p $OMERO_DATA_DIR
     $ omero config set omero.data.dir $OMERO_DATA_DIR
 
-:download:`step02_omero.sh <walkthrough/osx/step02_omero.sh>`
-
 
 Development server
 ^^^^^^^^^^^^^^^^^^
@@ -195,12 +198,12 @@ in the previous section.
 OMERO.web
 ^^^^^^^^^
 
+See installation script :download:`step03_nginx.sh <walkthrough/osx/step03_nginx.sh>`
+
 Basic setup for OMERO using nginx::
 
     $ export HTTPPORT=${HTTPPORT:-8080}
     $ omero web config nginx-development --http $HTTPPORT > $(brew --prefix omero52)/etc/nginx.conf
-
-:download:`step03_nginx.sh <walkthrough/osx/step03_nginx.sh>`
 
 For detailed instructions on how to deploy OMERO.web in a production environment such as Apache or
 Nginx please see :doc:`install-web`.
@@ -244,7 +247,7 @@ Stop OMERO::
 
     $ omero admin stop
 
-:download:`step04_test.sh <walkthrough/osx/step04_test.sh>`
+See example script for a basic functionality test: :download:`step04_test.sh <walkthrough/osx/step04_test.sh>`
 
 Common issues
 -------------

--- a/omero/sysadmins/unix/server-install-homebrew.txt
+++ b/omero/sysadmins/unix/server-install-homebrew.txt
@@ -189,6 +189,13 @@ able to build the server, i.e.
 
 .. include:: development-server
 
+Then change into the `dist` directory::
+
+    $ cd ~/code/projects/OMERO/dist
+
+and follow the steps for setting up the database and OMERO data directory like mentioned
+in the previous section.
+
 OMERO.web
 ^^^^^^^^^
 

--- a/omero/sysadmins/unix/server-install-homebrew.txt
+++ b/omero/sysadmins/unix/server-install-homebrew.txt
@@ -123,7 +123,7 @@ To install and deploy the |release| release of OMERO.server, run::
     $ export PYTHONPATH=$(brew --prefix omero52)/lib/python
     $ export ICE_CONFIG=$(brew --prefix omero52)/etc/ice.config
 
-This will install the OMERO server to /usr/local/Cellar/omero, which means you'll find the
+This will install the OMERO server to /usr/local/Cellar/omero, which means you will find the
 log files in /usr/local/Cellar/omero/|release|/var/log. The binaries will be linked to /usr/local/bin.
 
 Install OMERO python dependencies::

--- a/omero/sysadmins/unix/server-install-homebrew.txt
+++ b/omero/sysadmins/unix/server-install-homebrew.txt
@@ -56,10 +56,13 @@ Requirements
 
 All the requirements for OMERO will be installed under :file:`/usr/local`. See also: Installation instructions on the `Homebrew wiki`_.
 
-::
+Install homebrew::
 
     $ export PATH=/usr/local/bin:$PATH
     $ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+
+Update homebrew and run 'brew doctor' to fix potential issues beforehand::
+
     $ brew update
     $ brew doctor
 
@@ -95,7 +98,7 @@ The installation of OMERO via Homebrew depends upon two alternate
 repositories containing extra formulae:
 https://github.com/Homebrew/homebrew-science for the HDF5 formula and
 https://github.com/ome/homebrew-alt for all the OME-provided formulae
-and older versions of Ice.  To add these, run::
+and older versions of Ice. To add these, run::
 
     $ brew tap homebrew/science
     $ brew tap ome/alt
@@ -152,7 +155,7 @@ Create and run script to initialize the OMERO database::
     $ psql -h localhost -U db_user omero_database < $PSQL_SCRIPT_NAME
     $ rm $PSQL_SCRIPT_NAME
 
-Setup OMERO data directory::
+Set up OMERO data directory::
 
     $ export OMERO_DATA_DIR=${OMERO_DATA_DIR:-/var/OMERO.data}
     $ mkdir -p $OMERO_DATA_DIR
@@ -260,7 +263,7 @@ any previous OMERO installation artifacts from your system.
 
 Database
 ^^^^^^^^
-Check to make sure the database has been created.
+Check to make sure the database has been created and 'UTF8' encoding is used
 
 ::
 

--- a/omero/sysadmins/unix/server-install-homebrew.txt
+++ b/omero/sysadmins/unix/server-install-homebrew.txt
@@ -7,11 +7,7 @@ OMERO.server Mac OS X installation walk-through with Homebrew
     This walk-through demonstrates how to install OMERO on a clean Mac
     OS X system (10.9 or later) using Homebrew.  Note that this
     demonstrates how to install OMERO.server *from the source code*
-    via Homebrew, in addition to all its prerequisites. **The default
-    instructions for UNIX platforms in the**
-    :doc:`server-installation` **guide are all you need to install the
-    prerequisites with Homebrew and then install the server zip from
-    the downloads page or build from source.**
+    via Homebrew, in addition to all its prerequisites. 
 
 These instructions are implemented in a series of `automated scripts
 <https://github.com/ome/omero-install/tree/develop/osx>`_ which
@@ -193,7 +189,7 @@ Then change into the `dist` directory::
 
     $ cd ~/code/projects/OMERO/dist
 
-and follow the steps for setting up the database and OMERO data directory like mentioned
+and follow the steps for setting up the database and OMERO data directory as mentioned
 in the previous section.
 
 OMERO.web

--- a/omero/sysadmins/unix/server-install-homebrew.txt
+++ b/omero/sysadmins/unix/server-install-homebrew.txt
@@ -234,7 +234,7 @@ Now connect to your OMERO.server using OMERO.insight or OMERO.web with the follo
 
 Stop OMERO.web::
 
-    $ nginx -c $(bin/brew --prefix omero52)/etc/nginx.conf -s stop
+    $ nginx -c $(brew --prefix omero52)/etc/nginx.conf -s stop
     $ omero web stop
 
 Stop OMERO::

--- a/omero/sysadmins/unix/server-install-homebrew.txt
+++ b/omero/sysadmins/unix/server-install-homebrew.txt
@@ -14,7 +14,7 @@ OMERO.server Mac OS X installation walk-through with Homebrew
     the downloads page or build from source.**
 
 These instructions are implemented in a series of `automated scripts
-<https://github.com/ome/omero-install/tree/master/homebrew>`_ which
+<https://github.com/ome/omero-install/tree/develop/osx>`_ which
 install OMERO via Homebrew from a fresh configuration.
 
 Prerequisites
@@ -49,37 +49,29 @@ running::
     $ javac -version
     javac 1.8.0_31
 
-Homebrew
-^^^^^^^^
+Requirements
+------------
 
 .. _`Homebrew wiki`: https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Installation.md
 
-Follow the installation instructions on the `Homebrew wiki`_. All the
-requirements for OMERO will be installed under :file:`/usr/local`.
+All the requirements for OMERO will be installed under :file:`/usr/local`. See also: Installation instructions on the `Homebrew wiki`_.
 
 ::
 
+    $ export PATH=/usr/local/bin:$PATH
     $ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-    $ brew install git
+    $ brew update
+    $ brew doctor
 
-The installation of OMERO via Homebrew depends upon two alternate
-repositories containing extra formulae:
-https://github.com/Homebrew/homebrew-science for the HDF5 formula and
-https://github.com/ome/homebrew-alt for all the OME-provided formulae
-and older versions of Ice.  To add these, run::
+Install git if not already present::
 
-    $ brew tap homebrew/science
-    $ brew tap ome/alt
+    $ brew list | grep "\bgit\b" || brew install git
 
-Lastly, make sure :file:`/usr/local/bin` is before :file:`/usr/bin` in
-your :envvar:`PATH`.  For example, add the following to
-:file:`~/.profile` and then start a new shell for the change to take
-effect::
+Install PostgreSQL database server::
 
-    export PATH=/usr/local/bin:/usr/local/sbin:$PATH
-
-Python 2.7
-^^^^^^^^^^
+    $ export LANG=${LANG:-en_US.UTF-8}
+    $ export LANGUAGE=${LANGUAGE:-en_US:en}
+    $ brew install postgres
 
 .. _`Homebrew and Python`: https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Homebrew-and-Python.md
 
@@ -92,16 +84,23 @@ the OMERO installation using the Homebrew Python.
 
 To install the Python provided by Homebrew::
 
-	$ brew install python
+    $ brew install python
 
 Check that Python is working and is version 2.7::
 
     $ /usr/local/bin/python --version
     Python 2.7.9
 
-To create isolated Python environemnt you can set up and use `virtual
-environments <http://www.virtualenv.org/en/latest/>`_ to install the OMERO
-Python dependencies (see :ref:`python_dependencies`).
+The installation of OMERO via Homebrew depends upon two alternate
+repositories containing extra formulae:
+https://github.com/Homebrew/homebrew-science for the HDF5 formula and
+https://github.com/ome/homebrew-alt for all the OME-provided formulae
+and older versions of Ice.  To add these, run::
+
+    $ brew tap homebrew/science
+    $ brew tap ome/alt
+
+:download:`step01_deps.sh <walkthrough/osx/step01_deps.sh>`
 
 .. note::
 
@@ -113,23 +112,53 @@ Python dependencies (see :ref:`python_dependencies`).
 OMERO installation
 ------------------
 
-OMERO |release|
-^^^^^^^^^^^^^^^
+OMERO |release| server
+^^^^^^^^^^^^^^^^^^^^^^
 
 To install and deploy the |release| release of OMERO.server, run::
 
-    $ brew install omero
+    $ export PATH=/usr/local/bin:$PATH
+    $ brew install omero52 --with-nginx --with-cpp
+    $ export PYTHONPATH=$(brew --prefix omero52)/lib/python
+    $ export ICE_CONFIG=$(brew --prefix omero52)/etc/ice.config
 
-This should install OMERO along with most of the non-Python
-requirements.
+Install OMERO python dependencies::
 
-Additional installation options can be listed using the ``info``
-command::
+    $ pip install -r $(brew --prefix omero52)/share/web/requirements-py27-nginx.txt
+    $ cd /usr/local
+    $ bash bin/omero_python_deps
 
-    $ brew info omero
+Start database server::
 
-The default version of Ice installed by the OMERO formula is currently
-Ice 3.5.
+    $ pg_ctl -D /usr/local/var/postgres -l /usr/local/var/postgres/server.log -w start
+
+Create database and user::
+
+    $ createuser -w -D -R -S db_user
+    $ createdb -E UTF8 -O db_user omero_database
+    $ psql -h localhost -U db_user -l
+
+Set database parameters in OMERO::
+
+    $ omero config set omero.db.name omero_database
+    $ omero config set omero.db.user db_user
+    $ omero config set omero.db.pass db_password
+
+Create and run script to initialize the OMERO database::
+
+    $ export ROOT_PASSWORD=${ROOT_PASSWORD:-omero}
+    $ export PSQL_SCRIPT_NAME=${PSQL_SCRIPT_NAME:-OMERO.sql}
+    $ omero db script --password $ROOT_PASSWORD -f $PSQL_SCRIPT_NAME
+    $ psql -h localhost -U db_user omero_database < $PSQL_SCRIPT_NAME
+    $ rm $PSQL_SCRIPT_NAME
+
+Setup OMERO data directory::
+
+    $ export OMERO_DATA_DIR=${OMERO_DATA_DIR:-/var/OMERO.data}
+    $ mkdir -p $OMERO_DATA_DIR
+    $ omero config set omero.data.dir $OMERO_DATA_DIR
+
+:download:`step02_omero.sh <walkthrough/osx/step02_omero.sh>`
 
 
 Development server
@@ -157,151 +186,18 @@ able to build the server, i.e.
 
 .. include:: development-server
 
-Additional OMERO requirements
------------------------------
-
-PostgreSQL
-^^^^^^^^^^
-
-Install PostgreSQL::
-
-    $ brew install postgresql
-    $ postgres --version
-    postgres (PostgreSQL) 9.4.1
-
-.. _python_dependencies:
-
-Python dependencies
-^^^^^^^^^^^^^^^^^^^
-
-The Python dependencies can be installed in the system-wide Python
-:file:`site-packages`, in the Homebrew Python :file:`site-packages` or
-within a virtual environment. If you are using the system-wide Python
-:file:`site-packages`, you may need to use :program:`sudo` to install
-the dependencies. If you are using a virtual environment, activate it
-before calling the Python dependencies installation script.
-
-If you installed OMERO using Homebrew, execute the ``omero_python_deps``
-script::
-
-    $ omero_python_deps
-
-If you use a development server, execute the ``python_deps.sh`` script under
-:file:`docs/install`::
-
-    $ cd ~/code/projects/OMERO
-    $ docs/install/python_deps.sh
-
-If you encounter problems with the installation script, please take a look at
-:ref:`install_homebrew_common_issues`.
-
-Configuration
--------------
-
-Database creation
-^^^^^^^^^^^^^^^^^
-
-#. Create a new database cluster::
-
-    $ initdb -E UTF8 /usr/local/var/postgres
-
-#. Start the PostgreSQL server.
-
-   If you wish to use ``brew services`` to start postgresql, you will
-   first need to install it, then start the service::
-
-    $ brew tap gapple/services
-    $ brew services start postgresql
-
-   Alternatively, to start by hand::
-
-    $ pg_ctl -D /usr/local/var/postgres/ -l /usr/local/var/postgres/server.log start
-
-   It is also possible to configure :program:`launchd` to start
-   PostgreSQL at boot
-
-#. Create a user and database::
-
-    $ createuser -P -D -R -S db_user
-    Enter password for new role:       # enter db_password
-    Enter it again:                    # enter db_password
-    $ createdb -E UTF8 -O db_user omero_database
-
-   Note ``db_user`` and ``db_password`` should be replaced with a
-   username and password of your choice.  Record these for future use.
-
-#. Check to make sure the database has been created.
-
-::
-
-    $ psql -h localhost -U db_user -l
-
-This command should give similar output to the following::
-
-                            List of databases
-
-       Name         | Owner   | Encoding |  Collation  |    Ctype    | Access privileges
-    ----------------+---------+----------+-------------+-------------+-------------------
-     omero_database | db_user | UTF8     | en_GB.UTF-8 | en_GB.UTF-8 |
-     postgres       | ome     | UTF8     | en_GB.UTF-8 | en_GB.UTF-8 |
-     template0      | ome     | UTF8     | en_GB.UTF-8 | en_GB.UTF-8 | =c/ome           +
-                    |         |          |             |             | ome=CTc/ome
-     template1      | ome     | UTF8     | en_GB.UTF-8 | en_GB.UTF-8 | =c/ome           +
-                    |         |          |             |             | ome=CTc/ome
-    (4 rows)
-
-OMERO.server
-^^^^^^^^^^^^
-
-Now configure OMERO.server to connect to the newly-created database::
-
-    $ omero config set omero.db.name omero_database
-    $ omero config set omero.db.user db_user
-    $ omero config set omero.db.pass db_password
-
-And then, generate the database schema::
-
-    $ omero db script --password secretpassword
-
-You should see output similar to this:
-
-.. literalinclude:: /downloads/cli/db-script-example.txt
-
-Then run the SQL commands in the generated schema file to create the
-database:
-
-.. parsed-literal::
-
-    $ psql -h localhost -U db_user omero_database < |current_dbver|.sql
-
-Now create a location to store OMERO data, for example::
-
-    $ mkdir -p ~/var/OMERO.data
-
-and configure OMERO.server to use this location::
-
-    $ omero config set omero.data.dir ~/var/OMERO.data
-
-The OMERO.server configuration settings can be inspected using::
-
-    $ omero config get
-
-Next, start the OMERO.server::
-
-    $ omero admin start
-
-Now connect to your OMERO.server using OMERO.insight with the following credentials:
-
-::
-
-    U: root
-    P: root_password
-
 OMERO.web
 ^^^^^^^^^
 
-In order to deploy OMERO.web in a production environment such as Apache or
-Nginx please follow the instructions under :doc:`install-web`.
+Basic setup for OMERO using nginx::
+
+    $ export HTTPPORT=${HTTPPORT:-8080}
+    $ omero web config nginx-development --http $HTTPPORT > $(brew --prefix omero52)/etc/nginx.conf
+
+:download:`step03_nginx.sh <walkthrough/osx/step03_nginx.sh>`
+
+For detailed instructions on how to deploy OMERO.web in a production environment such as Apache or
+Nginx please see :doc:`install-web`.
 
 .. note::
     The internal Django webserver can be used for evaluation and development.
@@ -309,6 +205,40 @@ Nginx please follow the instructions under :doc:`install-web`.
     :doc:`/developers/Web/Deployment`.
 
 .. _install_homebrew_common_issues:
+
+Startup/Shutdown
+^^^^^^^^^^^^^^^^
+
+If necessary start PostgreSQL database server::
+
+    $ pg_ctl -D /usr/local/var/postgres -l /usr/local/var/postgres/server.log -w start
+
+Start OMERO::
+
+    $ omero admin start
+
+Start OMERO.web::
+
+    $ omero web start
+    $ nginx -c $(brew --prefix omero52)/etc/nginx.conf
+
+Now connect to your OMERO.server using OMERO.insight or OMERO.web with the following credentials:
+
+::
+
+    U: root
+    P: root_password
+
+Stop OMERO.web::
+
+    $ nginx -c $(bin/brew --prefix omero52)/etc/nginx.conf -s stop
+    $ omero web stop
+
+Stop OMERO::
+
+    $ omero admin stop
+
+:download:`step04_test.sh <walkthrough/osx/step04_test.sh>`
 
 Common issues
 -------------
@@ -327,6 +257,28 @@ Also, please check the Homebrew `Bug Fixing Checklist
 Below is a non-exhaustive list of errors/warnings specific to the OMERO
 installation. Some if not all of them could possibly be avoided by removing
 any previous OMERO installation artifacts from your system.
+
+Database
+^^^^^^^^
+Check to make sure the database has been created.
+
+::
+
+    $ psql -h localhost -U db_user -l
+
+This command should give similar output to the following::
+
+                            List of databases
+
+       Name         | Owner   | Encoding |  Collation  |    Ctype    | Access privileges
+    ----------------+---------+----------+-------------+-------------+-------------------
+     omero_database | db_user | UTF8     | en_GB.UTF-8 | en_GB.UTF-8 |
+     postgres       | ome     | UTF8     | en_GB.UTF-8 | en_GB.UTF-8 |
+     template0      | ome     | UTF8     | en_GB.UTF-8 | en_GB.UTF-8 | =c/ome           +
+                    |         |          |             |             | ome=CTc/ome
+     template1      | ome     | UTF8     | en_GB.UTF-8 | en_GB.UTF-8 | =c/ome           +
+                    |         |          |             |             | ome=CTc/ome
+    (4 rows)
 
 Macports/Fink
 ^^^^^^^^^^^^^

--- a/omero/sysadmins/unix/walkthrough/osx/step01_deps.sh
+++ b/omero/sysadmins/unix/walkthrough/osx/step01_deps.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Installs OMERO requirements
+
+set -e
+set -u
+set -x
+
+export PATH=/usr/local/bin:$PATH
+export LANG=${LANG:-en_US.UTF-8}
+export LANGUAGE=${LANGUAGE:-en_US:en}
+
+# Test whether this script is run in a job environment
+JOB_NAME=${JOB_NAME:-}
+if [[ -n $JOB_NAME ]]; then
+    DEFAULT_TESTING_MODE=true
+else
+    DEFAULT_TESTING_MODE=false
+fi
+TESTING_MODE=${TESTING_MODE:-$DEFAULT_TESTING_MODE}
+
+###################################################################
+# Homebrew installation
+###################################################################
+
+# Install Homebrew in /usr/local
+ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+
+# Update Homebrew
+brew update
+
+# Run brew doctor
+brew doctor
+
+# Install git if not already installed
+brew list | grep "\bgit\b" || brew install git
+
+# Install PostgreSQL
+brew install postgres
+
+###################################################################
+# Python pip installation
+###################################################################
+
+# Install Homebrew python
+# Alternately, the system Python can be used but installing Python
+# dependencies may require sudo
+brew install python
+
+# Tap ome-alt library
+if [ "$TESTING_MODE" = true ]; then
+    brew tap --full ome/alt || echo "Already tapped"
+
+    # Install scc tools
+    pip install -U scc || echo "scc installed"
+
+    # Merge homebrew-alt PRs
+    cd /usr/local/Library/Taps/ome/homebrew-alt
+    scc merge master
+
+    # Repair formula symlinks after merge
+    brew tap --repair
+else
+    brew tap ome/alt || echo "Already tapped"
+fi
+
+# Tap homebrew-science library (HDF5)
+brew tap homebrew/science || echo "Already tapped"

--- a/omero/sysadmins/unix/walkthrough/osx/step02_omero.sh
+++ b/omero/sysadmins/unix/walkthrough/osx/step02_omero.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Main OMERO installation script
+
+set -e
+set -u
+set -x
+
+export PATH=/usr/local/bin:$PATH
+export OMERO_DATA_DIR=${OMERO_DATA_DIR:-/tmp/var/OMERO.data}
+export PSQL_SCRIPT_NAME=${PSQL_SCRIPT_NAME:-OMERO.sql}
+export ROOT_PASSWORD=${ROOT_PASSWORD:-omero}
+export ICE=${ICE:-3.5}
+export HTTPPORT=${HTTPPORT:-8080}
+export LANG=${LANG:-en_US.UTF-8}
+export LANGUAGE=${LANGUAGE:-en_US:en}
+
+###################################################################
+# OMERO installation
+###################################################################
+
+# Install OMERO
+OMERO_PYTHONPATH=$(brew --prefix omero52)/lib/python
+brew install omero52 --with-nginx --with-cpp
+export PYTHONPATH=$OMERO_PYTHONPATH
+VERBOSE=1 brew test omero52
+
+# Install OMERO Python dependencies
+pip install -r $(brew --prefix omero52)/share/web/requirements-py27-nginx.txt
+cd /usr/local
+bash bin/omero_python_deps
+
+# Set additional environment variables
+export ICE_CONFIG=$(brew --prefix omero52)/etc/ice.config
+
+# Start PostgreSQL
+pg_ctl -D /usr/local/var/postgres -l /usr/local/var/postgres/server.log -w start
+
+# Create user and database
+createuser -w -D -R -S db_user
+createdb -E UTF8 -O db_user omero_database
+psql -h localhost -U db_user -l
+
+# Set database
+omero config set omero.db.name omero_database
+omero config set omero.db.user db_user
+omero config set omero.db.pass db_password
+
+# Run DB script
+omero db script --password $ROOT_PASSWORD -f $PSQL_SCRIPT_NAME
+psql -h localhost -U db_user omero_database < $PSQL_SCRIPT_NAME
+rm $PSQL_SCRIPT_NAME
+
+# Stop PostgreSQL
+pg_ctl -D /usr/local/var/postgres -m fast stop
+
+# Set up the data directory
+if [ -d "$OMERO_DATA_DIR" ]; then
+    rm -rf $OMERO_DATA_DIR
+fi
+mkdir -p $OMERO_DATA_DIR
+omero config set omero.data.dir $OMERO_DATA_DIR
+

--- a/omero/sysadmins/unix/walkthrough/osx/step03_nginx.sh
+++ b/omero/sysadmins/unix/walkthrough/osx/step03_nginx.sh
@@ -7,8 +7,8 @@ set -x
 
 export PATH=/usr/local/bin:$PATH
 export HTTPPORT=${HTTPPORT:-8080}
-export ICE_CONFIG=$(bin/brew --prefix omero52)/etc/ice.config
-export PYTHONPATH=$(bin/brew --prefix omero52)/lib/python
+export ICE_CONFIG=$(brew --prefix omero52)/etc/ice.config
+export PYTHONPATH=$(brew --prefix omero52)/lib/python
 
 # Setup nginx
 omero web config nginx-development --http $HTTPPORT > $(brew --prefix omero52)/etc/nginx.conf

--- a/omero/sysadmins/unix/walkthrough/osx/step03_nginx.sh
+++ b/omero/sysadmins/unix/walkthrough/osx/step03_nginx.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Setup OMERO.web using nginx
+
+set -e
+set -u
+set -x
+
+export PATH=/usr/local/bin:$PATH
+export HTTPPORT=${HTTPPORT:-8080}
+export ICE_CONFIG=$(bin/brew --prefix omero52)/etc/ice.config
+export PYTHONPATH=$(bin/brew --prefix omero52)/lib/python
+
+# Setup nginx
+omero web config nginx-development --http $HTTPPORT > $(brew --prefix omero52)/etc/nginx.conf

--- a/omero/sysadmins/unix/walkthrough/osx/step04_test.sh
+++ b/omero/sysadmins/unix/walkthrough/osx/step04_test.sh
@@ -29,7 +29,6 @@ omero version | grep -v UNKNOWN
 omero login -s localhost -u root -w $ROOT_PASSWORD
 touch test.fake
 omero import test.fake
-rm test.fake
 
 # Test simple Web connection
 brew install wget

--- a/omero/sysadmins/unix/walkthrough/osx/step04_test.sh
+++ b/omero/sysadmins/unix/walkthrough/osx/step04_test.sh
@@ -9,8 +9,6 @@ set -x
 export PATH=/usr/local/bin:$PATH
 export HTTPPORT=${HTTPPORT:-8080}
 export ROOT_PASSWORD=${ROOT_PASSWORD:-omero}
-export ICE_CONFIG=$(bin/brew --prefix omero52)/etc/ice.config
-export PYTHONPATH=$(bin/brew --prefix omero52)/lib/python
 
 # Start PostgreSQL
 pg_ctl -D /usr/local/var/postgres -l /usr/local/var/postgres/server.log -w start
@@ -29,6 +27,7 @@ omero version | grep -v UNKNOWN
 omero login -s localhost -u root -w $ROOT_PASSWORD
 touch test.fake
 omero import test.fake
+omero logout
 
 # Test simple Web connection
 brew install wget
@@ -40,7 +39,7 @@ resp=$(wget --keep-session-cookies --load-cookies cookies.txt --post-data $post_
 echo "$resp"
 
 # Stop OMERO.web
-nginx -c $(bin/brew --prefix omero52)/etc/nginx.conf -s stop
+nginx -c $(brew --prefix omero52)/etc/nginx.conf -s stop
 omero web stop
 
 # Stop the server

--- a/omero/sysadmins/unix/walkthrough/osx/step04_test.sh
+++ b/omero/sysadmins/unix/walkthrough/osx/step04_test.sh
@@ -1,0 +1,51 @@
+
+#!/usr/bin/env bash
+# Start up server, perform some simple test, shutdown again.
+
+set -e
+set -u
+set -x
+
+export PATH=/usr/local/bin:$PATH
+export HTTPPORT=${HTTPPORT:-8080}
+export ROOT_PASSWORD=${ROOT_PASSWORD:-omero}
+export ICE_CONFIG=$(bin/brew --prefix omero52)/etc/ice.config
+export PYTHONPATH=$(bin/brew --prefix omero52)/lib/python
+
+# Start PostgreSQL
+pg_ctl -D /usr/local/var/postgres -l /usr/local/var/postgres/server.log -w start
+
+# Start the server
+omero admin start
+
+# Start OMERO.web
+omero web start
+nginx -c $(brew --prefix omero52)/etc/nginx.conf
+
+# Check OMERO version
+omero version | grep -v UNKNOWN
+
+# Test simple fake import
+omero login -s localhost -u root -w $ROOT_PASSWORD
+touch test.fake
+omero import test.fake
+rm test.fake
+
+# Test simple Web connection
+brew install wget
+sleep 30
+wget --keep-session-cookies --save-cookies cookies.txt http://localhost:$HTTPPORT/webclient/login/ -O csrf_index.html
+csrf=$(cat csrf_index.html | grep "name=\'csrfmiddlewaretoken\'"  | sed "s/.* value=\'\(.*\)\'.*/\1/")
+post_data="username=root&password=$ROOT_PASSWORD&csrfmiddlewaretoken=$csrf&server=1&noredirect=1"
+resp=$(wget --keep-session-cookies --load-cookies cookies.txt --post-data $post_data http://localhost:$HTTPPORT/webclient/login/)
+echo "$resp"
+
+# Stop OMERO.web
+nginx -c $(bin/brew --prefix omero52)/etc/nginx.conf -s stop
+omero web stop
+
+# Stop the server
+omero admin stop
+
+# Stop PostgreSQL
+pg_ctl -D /usr/local/var/postgres -m fast stop


### PR DESCRIPTION
Updates the OSX walkthrough using the latest installation scripts from https://github.com/ome/omero-install/pull/61 (should roughly follow linux walkthrough #1338 )

Deployed on staging: https://www.openmicroscopy.org/site/support/omero5.2-staging/sysadmins/unix/server-install-homebrew.html
