### PR TITLE
Removing out-of-date content & permissions fix

### DIFF
--- a/omero/sysadmins/limitations.txt
+++ b/omero/sysadmins/limitations.txt
@@ -133,8 +133,8 @@ the shared images by cutting the links.
 Changing group permissions
 --------------------------
 
-If you have data which has been linked by other users, you cannot make the
-group that data is in into a private group.
+If a group contains a projection made by one member from data owned by another
+user, you cannot make the group into a private group.
 
 File format support
 -------------------
@@ -169,7 +169,8 @@ Flex data in OMERO.tables
 
 If you are using the advanced configuration setting ``FlexReaderServerMaps``
 for importing Flex data split between multiple directories for use with
-:doc:`OMERO.tables </developers/analysis>`, you should not upgrade to 5.1.0.
+:doc:`OMERO.tables </developers/analysis>`, you should not upgrade beyond
+5.0.x. Neither the 5.1 line nor OMERO 5.2 support this functionality.
 
 LDAP
 ----

--- a/omero/sysadmins/limitations.txt
+++ b/omero/sysadmins/limitations.txt
@@ -76,32 +76,12 @@ Windows does not handle non-Latin characters well in the command prompt
 are not correctly formed. Therefore, we recommend you avoid them if at all
 possible.
 
-OMERO.web 'development server' does not work under Windows XP
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The development server included with OMERO.web does not work under
-Windows XP. This server is included to allow you to easily evaluate
-and develop the OMERO.web component. As it should not be used in a
-production environment, while an inconvenience, this should not stop
-the deployment of a production version of OMERO.web. See :forum:`OME forum
-topic <viewtopic.php?f=5&t=640>`.
-
 Binary delete
 ^^^^^^^^^^^^^
 
 On Windows servers not all binary files corresponding to a delete may
 be removed from the binary repository. See :ref:`DeleteBinaryData` for more
 details.
-
-Mac OS X issues
----------------
-
-C++ compilation problems on Mac OS X 10.6 (Snow Leopard)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Under certain circumstances building OmeroCpp can fail with "ld: symbol(s) not
-found". You can find further details, a potential solution and make any
-comments on your experience with the problem on :ticket:`3210`.
 
 Ubuntu issues
 -------------

--- a/omero/sysadmins/limitations.txt
+++ b/omero/sysadmins/limitations.txt
@@ -29,14 +29,6 @@ and OpenJDK 1.7.0_85).
 Windows OS issues
 -----------------
 
-Django 1.8 will not work with IIS on Windows
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-OMERO.web has been upgraded to use Django 1.8 but support for deploying it
-using IIS on Windows is still upcoming and you must use Django 1.6 for now. We
-aim to add support for Django 1.8 in OMERO.web within the 5.2.x development
-line.
-
 .. _windows-database-encoding:
 
 Failure response on import for new databases

--- a/omero/sysadmins/server-permissions.txt
+++ b/omero/sysadmins/server-permissions.txt
@@ -136,7 +136,7 @@ with data, with the following limitations:
 -  It is not possible to 'reduce' permissions to :term:`Private` if the group
    contains a projection made by one member from data owned by another user.
    In other circumstances, reducing permissions to private will warn of loss
-   of annotations etc as noted below, but will still be possible.
+   of annotations etc. as noted below, but will still be possible.
 -  Only :term:`Administrator` can promote a group to :term:`Read-write`
    permissions. **Make certain all the members understand that this allows
    anyone in the group to permanently delete any of the data before performing

--- a/omero/sysadmins/server-permissions.txt
+++ b/omero/sysadmins/server-permissions.txt
@@ -126,12 +126,6 @@ The various permission levels are:
     :help:`Help guide for sharing data <sharing-data.html>`
      Workflow guide covering the groups and permissions system
 
-    :snapshot:`OMERO.insight Permissions update in OMERO 4.4 <movies/omero-4-4/mov/InsightMultiGroups-4.4.mov>`
-     Movie describing the permissions update under OMERO.insight in OMERO 4.4
-
-    :snapshot:`Web Permissions update in OMERO 4.4 <movies/omero-4-4/mov/WebMultiGroups-4.4.mov>`
-     Movie describing the permissions update under Web in OMERO 4.4
-
 Changing group permissions
 --------------------------
 
@@ -139,12 +133,10 @@ It is possible for the :term:`Group owner` or server :term:`Administrator` to
 change the permissions level on a group after it has been created and filled
 with data, with the following limitations:
 
--  It is not possible to 'reduce' permissions to :term:`Private`. Once links
-   have been created in the database under :term:`Read-only` or
-   :term:`Read-annotate` permissions, these cannot be severed. However, it is
-   possible to 'promote' a :term:`Private` group to be more permissive
--  It is possible to toggle permissions of a group between :term:`Read-only`
-   and :term:`Read-annotate` groups.
+-  It is not possible to 'reduce' permissions to :term:`Private` if the group
+   contains a projection made by one member from data owned by another user.
+   In other circumstances, reducing permissions to private will warn of loss
+   of annotations etc as noted below, but will still be possible.
 -  Only :term:`Administrator` can promote a group to :term:`Read-write`
    permissions. **Make certain all the members understand that this allows
    anyone in the group to permanently delete any of the data before performing
@@ -154,6 +146,7 @@ with data, with the following limitations:
     permission level. If a user has annotated other users' data and
     the group is downgraded, any links to annotations that are not
     permitted by the new permissions level will be lost.
+
 
 Permissions on your and other users' data
 -----------------------------------------

--- a/omero/sysadmins/server-permissions.txt
+++ b/omero/sysadmins/server-permissions.txt
@@ -45,15 +45,6 @@ permission level for that group. See the :help:`Help guide for managing groups
 <sharing-data.html#owner>` for more information about how to administrate them
 in OMERO.
 
-.. seealso::
-
-    :snapshot:`OMERO.insight Admin update in OMERO 4.4 <movies/omero-4-4/mov/InsightAdmin-4.4.mov>`
-        Movie describing the administration tools update under OMERO.insight for OMERO 4.4
-
-    :snapshot:`OMERO.web Admin update in OMERO 4.4 <movies/omero-4-4/mov/WebAdmin-4.4.mov>`
-        Movie describing the administration tools update under OMERO.web for OMERO 4.4
-
-
 Group permission levels
 -----------------------
 

--- a/omero/sysadmins/system-requirements.txt
+++ b/omero/sysadmins/system-requirements.txt
@@ -128,6 +128,6 @@ OMERO.py       Required for some functionality          Required Required
 OMERO.cpp      Required for some functionality                   Required
 ============== =============================== ======== ======== ======== ==========
 
-For full details on which versions of these are supported for 5.1.x and how we
-intend to update these going forward, see the :doc:`version-requirements`
-section.
+For full details on which versions of these are supported for OMERO |version|
+and how we intend to update these going forward, see the
+:doc:`version-requirements` section.

--- a/omero/sysadmins/whatsnew.txt
+++ b/omero/sysadmins/whatsnew.txt
@@ -15,9 +15,7 @@ What's new for OMERO 5.2 for sysadmins
 
 - The OMERO web framework no longer bundles a copy of the Django package,
   instead manual installation of the Django dependency is required. It is
-  highly recommended to use `Django 1.8`_ (LTS) which requires Python 2.7
-  (unless you are using IIS on Windows, in which case you will need to use
-  Django 1.6).
+  highly recommended to use `Django 1.8`_ (LTS) which requires Python 2.7.
   For more information see :ref:`python-requirements` on the
   :doc:`/sysadmins/version-requirements` page.
 


### PR DESCRIPTION
Removes limitations relating to OS we don't support any more anyway, 4.4 movies which are now hopelessly out-of-date (and replaced by help site content) and one remaining hardcoded reference to 5.1.x that had been missed previously.
