### PR TITLE
Fix out-of-date postgres minimum version refs

### DIFF
--- a/omero/sysadmins/unix/server-postgresql.txt
+++ b/omero/sysadmins/unix/server-postgresql.txt
@@ -9,8 +9,8 @@ version and that it is installed and configured correctly.
 Ensuring you have a valid PostgreSQL version
 --------------------------------------------
 
-For OMERO |version|, PostgreSQL version 9.2 or later is required; version 9.3
-or later is recommended. Make sure you are using a
+For OMERO |version|, PostgreSQL version 9.3 or later is required; version 9.4
+is recommended. Make sure you are using a
 `supported version <http://www.postgresql.org/support/versioning/>`_.
 
 You can check which version of PostgreSQL you have installed with any of

--- a/omero/sysadmins/unix/server-postgresql.txt
+++ b/omero/sysadmins/unix/server-postgresql.txt
@@ -19,11 +19,11 @@ the following commands:
 ::
 
        $ createuser -V
-       createuser (PostgreSQL) 9.3.4
+       createuser (PostgreSQL) 9.4.1
        $ psql -V
-       psql (PostgreSQL) 9.3.4
+       psql (PostgreSQL) 9.4.1
        $ createdb -V
-       createdb (PostgreSQL) 9.3q.4
+       createdb (PostgreSQL) 9.4.1
 
 If your existing PostgreSQL installation is version 9.3 or earlier, it
 is recommended that you upgrade to a more up-to-date version.  Before

--- a/omero/sysadmins/unix/server-postgresql.txt
+++ b/omero/sysadmins/unix/server-postgresql.txt
@@ -25,7 +25,7 @@ the following commands:
        $ createdb -V
        createdb (PostgreSQL) 9.3q.4
 
-If your existing PostgreSQL installation is version 9.2 or earlier, it
+If your existing PostgreSQL installation is version 9.3 or earlier, it
 is recommended that you upgrade to a more up-to-date version.  Before
 upgrading, stop the OMERO server and then perform a full dump of the
 database using :program:`pg_dump`.  See the :ref:`server_backup`

--- a/omero/sysadmins/windows/server-installation.txt
+++ b/omero/sysadmins/windows/server-installation.txt
@@ -113,11 +113,11 @@ the latest release number and A and B stand for the Python version, for example
 
 .. _windows_additional_libraries:
 
-PostgreSQL (9.2 or higher)
+PostgreSQL (9.3 or higher)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 PostgreSQL has to be installed and configured to accept TCP connections.
-PostgreSQL 9.1 and earlier are not supported. 9.3 or later is recommended.
+PostgreSQL 9.2 and earlier are not supported. 9.3 or later is recommended.
 
 The *One click installer* can be found on the `PostgreSQL Windows
 download page <http://www.postgresql.org/download/windows>`_.

--- a/omero/sysadmins/windows/server-postgresql.txt
+++ b/omero/sysadmins/windows/server-postgresql.txt
@@ -12,8 +12,8 @@ For Windows-specific installation instructions, first see
 Ensuring you have a valid PostgreSQL version
 --------------------------------------------
 
-For OMERO |version|, PostgreSQL version 9.2 or later is required; version 9.3
-or later is recommended. Make sure you are using a `supported version <http://www.postgresql.org/support/versioning/>`_.
+For OMERO |version|, PostgreSQL version 9.3 or later is required; version 9.4
+is recommended. Make sure you are using a `supported version <http://www.postgresql.org/support/versioning/>`_.
 
 If your existing PostgreSQL installation is version 9.2 or earlier, it
 is recommended that you upgrade to a more up-to-date version.  Before

--- a/omero/sysadmins/windows/server-postgresql.txt
+++ b/omero/sysadmins/windows/server-postgresql.txt
@@ -15,7 +15,7 @@ Ensuring you have a valid PostgreSQL version
 For OMERO |version|, PostgreSQL version 9.3 or later is required; version 9.4
 is recommended. Make sure you are using a `supported version <http://www.postgresql.org/support/versioning/>`_.
 
-If your existing PostgreSQL installation is version 9.2 or earlier, it
+If your existing PostgreSQL installation is version 9.3 or earlier, it
 is recommended that you upgrade to a more up-to-date version.  Before
 upgrading, stop the OMERO server and then perform a full dump of the
 database using :program:`pg_dump`.  See the :ref:`server_backup`


### PR DESCRIPTION
These pages were obviously missed when the version requirements were updated for 5.2.
