### PR TITLE
Windows web deployment guide 5.2 only

### DIFF
--- a/omero/sysadmins/windows/install-web.txt
+++ b/omero/sysadmins/windows/install-web.txt
@@ -3,7 +3,7 @@ OMERO.web deployment
 
 .. Warning:: The guidance below applies to OMERO **5.2**. Code fixes for
     OMERO.web deployment on Windows have not been back-ported to the 5.1 line
-    and this guide cannot be used to deploy OMERO 5.1.x on Windows.
+    and this guide cannot be used to deploy OMERO.web 5.1.x on Windows.
 
 OMERO.web is the web application component of the OMERO platform which
 allows for the management, visualization (in a fully multi-dimensional

--- a/omero/sysadmins/windows/install-web.txt
+++ b/omero/sysadmins/windows/install-web.txt
@@ -1,6 +1,10 @@
 OMERO.web deployment
 ====================
 
+.. Warning:: The guidance below applies to OMERO **5.2**. Code fixes for
+    OMERO.web deployment on Windows have not been back-ported to the 5.1 line
+    and this guide cannot be used to deploy OMERO 5.1.x on Windows.
+
 OMERO.web is the web application component of the OMERO platform which
 allows for the management, visualization (in a fully multi-dimensional
 image viewer) and annotation of images from a web browser. It also


### PR DESCRIPTION
See https://trello.com/c/00l9Q5tK/67-deployment-docs-improvements - warning added to Windows web deployment page to make clear this is for 5.2.x and will not work on 5.1.x because code fixes have not been back-ported.
