### PR TITLE
Some windows install fixes

### DIFF
--- a/omero/sysadmins/windows/install-web/install-iis.txt
+++ b/omero/sysadmins/windows/install-web/install-iis.txt
@@ -21,9 +21,28 @@ Install `Django 1.8`_ using package requirements file:
 
 .. note:: For more details refer to `Django 1.8 installation on Windows <https://docs.djangoproject.com/en/1.8/howto/windows/>`_.
 
+Install additional Python libraries:
 
-Once you have IIS installed on your system, a straightforward set of
-steps is required to get the `ISAPI
+Download the following whl files then run::
+
+   set PYTHONPIP=C:\Python27\Scripts\pip.exe
+
+   %PYTHONPIP% install matplotlib-1.4.3-cp27-none-win_amd64.whl
+   %PYTHONPIP% install numpy-1.9.2+mkl-cp27-none-win_amd64.whl
+   %PYTHONPIP% install numexpr-2.4.3-cp27-none-win_amd64.whl
+   %PYTHONPIP% install Pillow-2.8.1-cp27-none-win_amd64.whl
+   %PYTHONPIP% install pyparsing-2.0.3-py2-none-any.whl
+   %PYTHONPIP% install python_dateutil-2.4.2-py2.py3-none-any.whl
+   %PYTHONPIP% install pytz-2015.2-py2.py3-none-any.whl
+   %PYTHONPIP% install six-1.9.0-py2.py3-none-any.whl
+   %PYTHONPIP% install tables-3.1.1-cp27-none-win_amd64.whl
+   %PYTHONPIP% install virtualenv-12.1.1-py2.py3-none-any.whl
+
+   %PYTHONPIP% install pywin32-219-cp27-none-win_amd64.whl
+   C:\Python27\Scripts\pywin32_postinstall.py -install
+
+
+A straightforward set of steps is required to get the `ISAPI
 WSGI <http://code.google.com/p/isapi-wsgi/>`_ handler for OMERO.web
 working with your IIS deployment.
 
@@ -86,7 +105,7 @@ working with your IIS deployment.
 
    ::
 
-       C:\omero_dist>bin\omero web iis
+       C:\OMERO.server> bin\omero web iis
 
    This will automatically add two applications, `/omero` and `/static`,
    to the default web site and application pool. You can customize these

--- a/omero/sysadmins/windows/server-installation.txt
+++ b/omero/sysadmins/windows/server-installation.txt
@@ -88,7 +88,7 @@ Python 2
 - If you have downloaded Ice 3.5.1 from our downloads page, you will
   need to install the `latest Python 2.7 release <http://www.python.org/downloads/windows/>`_.
 
-As these are the "vanilla" python distributions (no extra libraries), you will
+As these are the "vanilla" python distributions (no extra libraries), you might
 need to install further dependencies, making sure to download the correct
 version (32/64-bit) for your Python distribution.
 

--- a/omero/sysadmins/windows/server-installation.txt
+++ b/omero/sysadmins/windows/server-installation.txt
@@ -81,12 +81,15 @@ Python 2
 
 .. note::
 
-    OMERO does not currently support Python 3.
+    OMERO does not currently support Python 3. 
 
 **Make sure you install the correct Python 2 version for your Ice version:**
 
 - If you have downloaded Ice 3.5.1 from our downloads page, you will
-  need to install the `latest Python 2.7 release <http://www.python.org/downloads/windows/>`_.
+  need to install `Python 2.7 <https://www.python.org/downloads/release/python-279/>`_.
+
+**Python 2.7.9 is strongly recommended.** OMERO has been successfully tested with this
+version and there were problems noticed with later versions.
 
 As these are the "vanilla" python distributions (no extra libraries), you might
 need to install further dependencies, making sure to download the correct


### PR DESCRIPTION
Adds the instructions to explicitly install the python libraries for OMERO.web via *.whl files, like @manics  scripts does.
