### PR TITLE
Also copy osx walkthroughs

### DIFF
--- a/omero/autogen_docs
+++ b/omero/autogen_docs
@@ -53,6 +53,7 @@ for f in \
     setup_* \
     ; do
     cp $WORKSPACE/omero-install/linux/$f $DIRECTORY
+    cp $WORKSPACE/omero-install/osx/$f $DIRECTORY
 done
 
 echo "Getting db properties"

--- a/omero/autogen_docs
+++ b/omero/autogen_docs
@@ -58,7 +58,7 @@ for f in \
     step* \
     install_* \
     ; do
-    cp $WORKSPACE/omero-install/osx/$f $DIRECTORY
+    cp $WORKSPACE/omero-install/osx/$f $DIRECTORY/osx/
 done
 
 echo "Getting db properties"

--- a/omero/autogen_docs
+++ b/omero/autogen_docs
@@ -57,6 +57,7 @@ done
 for f in \
     step* \
     install_* \
+    ; do
     cp $WORKSPACE/omero-install/osx/$f $DIRECTORY
 done
 

--- a/omero/autogen_docs
+++ b/omero/autogen_docs
@@ -53,6 +53,10 @@ for f in \
     setup_* \
     ; do
     cp $WORKSPACE/omero-install/linux/$f $DIRECTORY
+done
+for f in \
+    step* \
+    install_* \
     cp $WORKSPACE/omero-install/osx/$f $DIRECTORY
 done
 

--- a/omero/autogen_docs
+++ b/omero/autogen_docs
@@ -43,7 +43,7 @@ if [ -d "$DIRECTORY" ]; then
 	rm -rf $DIRECTORY
 fi
 
-mkdir -p $DIRECTORY
+mkdir -p $DIRECTORY/osx/
 for f in \
     README.md \
     step* \


### PR DESCRIPTION
OSX scripts were added manually but not appended to the autogeneration script. This caused the script to remove them from the repo and break the documentation build. See https://github.com/openmicroscopy/openmicroscopy/pull/4387#issuecomment-164495386.
