### PR TITLE
Update 5.1 ref on upgrade page

### DIFF
--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -157,9 +157,9 @@ Upgrade your database
 Ensure Unicode character encoding
 """""""""""""""""""""""""""""""""
 
-OMERO 5.1 requires a Unicode-encoded database; without it, the upgrade
-script aborts with a message warning how the "OMERO database character
-encoding must be UTF8". From :command:`psql`::
+Versions of OMERO from 5.1.0 onwards require a Unicode-encoded database;
+without it, the upgrade script aborts with a message warning how the "OMERO
+database character encoding must be UTF8". From :command:`psql`::
 
   # SELECT datname, pg_encoding_to_char(encoding) FROM pg_database;
     datname   | pg_encoding_to_char


### PR DESCRIPTION
Spotted this when checking over docs for release, former wording was misleading, implying these are 5.1 docs.
