### PR TITLE
Updating Insight contributing page

### DIFF
--- a/omero/developers/Insight/Contributing.txt
+++ b/omero/developers/Insight/Contributing.txt
@@ -38,34 +38,7 @@ is also set to UTF-8.
 Build system
 ^^^^^^^^^^^^
 
-Ant
-"""
-
-The compilation, testing, launch, and delivery of the application are
-automated by means of an `Ant <http://ant.apache.org/>`_ build file,
-located under the ``build`` directory (See :doc:`/developers/Insight/DirectoryContents`). 
-Move to the build directory and, from the command line, enter:
-
-::
-
-    java build
-
-This will display the available targets to compile, run, test, and
-create a distribution bundle. Use the target you wish, for example:
-
-::
-
-    java build all
-
-Because all the tools needed to build the software are already included
-in the build directory, you do not need to have Ant on your machine. If
-you wish to use Ant instead, you can still do it by using the
-``build.xml`` file under the ``build`` directory. However, there are
-some dependencies to satisfy before; these are clearly documented in the
-``build.xml`` file itself.
-
-Jenkins
-"""""""
+See :doc:`/developers/build-system` for details.
 
 The OME project currently uses Jenkins_ (formerly known as hudson) as a
 continuous integration server available :jenkins:`here <>`. OMERO.insight is

--- a/omero/developers/Insight/Contributing.txt
+++ b/omero/developers/Insight/Contributing.txt
@@ -20,7 +20,7 @@ http://git.openmicroscopy.org.
 Requirements
 ^^^^^^^^^^^^
 
--  Install a Java 6 or Java 7 Development Kit (JDK), available from
+-  Install a Java 7+ Development Kit (JDK), available from
    `Java SE Downloads 
    <http://www.oracle.com/technetwork/java/javase/downloads/index.html>`_ and
    required for both the OMERO server and client code. Set the ``JAVA_HOME``


### PR DESCRIPTION
Out of date Java is a quick fix, other quick fixes can be added, everything else can go on a Trello card for 5.2.2.

https://trello.com/c/XF44F6RN/396-update-build-instructions-contributing-docs
