### PR TITLE
install-web changed "omero.webadmin" references

### DIFF
--- a/omero/sysadmins/unix/install-web.txt
+++ b/omero/sysadmins/unix/install-web.txt
@@ -71,12 +71,6 @@ to access the OMERO.webclient:
 
    OMERO.web login
 
-.. note::
-	This starts the server in the foreground. It is your
-	responsibility to place it in the background, if required, and
-	manage its shutdown.
-
-
 .. _unix_omero_web_maintenance:
 
 OMERO.web Maintenance (Unix/Linux)

--- a/omero/sysadmins/unix/install-web.txt
+++ b/omero/sysadmins/unix/install-web.txt
@@ -4,7 +4,7 @@ OMERO.web deployment
 OMERO.web is the web application component of the OMERO platform which
 allows for the management, visualization (in a fully multi-dimensional
 image viewer) and annotation of images from a web browser. It also
-includes OMERO.webadmin for managing users and groups.
+includes the ability to manage users and groups.
 
 
 OMERO.web is an integral part of the OMERO platform and can be deployed
@@ -59,7 +59,7 @@ Logging in to OMERO.web
 -----------------------
 
 Once you have deployed and started the server, you can use your browser
-to access OMERO.webadmin or the OMERO.webclient:
+to access the OMERO.webclient:
 
 -  **http://your\_host/omero** OR, for development server:
    **http://localhost:4080**
@@ -67,9 +67,9 @@ to access OMERO.webadmin or the OMERO.webclient:
 .. figure:: /images/installation-images/login.png
    :align: center
    :width: 55%
-   :alt: OMERO.webadmin login
+   :alt: OMERO.web login
 
-   OMERO.webadmin login
+   OMERO.web login
 
 .. note::
 	This starts the server in the foreground. It is your


### PR DESCRIPTION
Removed omero.webadmin disambiguation where there is non required any more. Reading this as it stands, It seems like there's an additional "omero.webadmin" which is separate to the webclient.
