### PR TITLE
Exclude CI servers from the linkcheck in the contributing documentation

### DIFF
--- a/contributing/conf.py
+++ b/contributing/conf.py
@@ -107,4 +107,10 @@ linkcheck_ignore += [r'http://localhost:\d+/?', 'http://localhost/',
     r'.*[.]?example\.com/.*',
     r'^https?://www\.openmicroscopy\.org/site/support/faq.*',
     r'^https://spreadsheets.google.com/.*',
-    r'^http://trac.openmicroscopy.org/ome/admin/.*']
+    r'^http://trac.openmicroscopy.org/ome/admin/.*',
+    r'^https?://hake.openmicroscopy.org/.*',
+    r'^https?://eel.openmicroscopy.org/.*',
+    r'^https?://burbot.openmicroscopy.org/.*',
+    r'^https?://seabass.openmicroscopy.org/.*',
+    r'^https?://trout.openmicroscopy.org/.*',
+]


### PR DESCRIPTION
All these servers are currently under firewall and can be intermittently
unavailable either due to redeployment or major work. Running the linkcheck
on them is currently causing more noise than necessary.
/cc @hflynn 
