### PR TITLE
Initial webclient doc page

### DIFF
--- a/omero/developers/Web/Webclient.txt
+++ b/omero/developers/Web/Webclient.txt
@@ -46,9 +46,9 @@ to setup their own event listeners.
 Switching Groups and Users
 --------------------------
 
-The current group and user are stored in the html session as 'active_group' and
-'user_id'. These are used to define the data that is loaded in the
-main 'userdata' and 'usertags' pages.
+The current group and user are stored in the html session as ``active_group`` and
+``user_id``. These are used to define the data that is loaded in the
+main ``userdata`` and ``usertags`` pages.
 
 The group and user are switched by the Groups and Users menu, which updates the
 session and reloads the page.
@@ -58,11 +58,11 @@ Show queries
 ------------
 
 Data in OMERO can be linked from the webclient with URLs of the form
-```/webclient/?show=image-23|image-34```
+``/webclient/?show=image-23|image-34``
 
 In the load_template view, the first object is queried from OMERO and its parent
 containers are also loaded. The owner and group of the top container is
-used to set the 'active_group' and 'user_id' so that the main page loads
+used to set the ``active_group`` and ``user_id`` so that the main page loads
 the appropriate data hierarchy.
 
 The jsTree does its own lookup from the query string, retrieving json

--- a/omero/developers/Web/Webclient.txt
+++ b/omero/developers/Web/Webclient.txt
@@ -4,11 +4,11 @@ The OMERO.web client application
 The webclient Django app provides the main OMERO.web client UI.
 
 Data is retrieved from OMERO using the :doc:`/developers/Python` and
-is rendered to html using :djangodoc:`Django templates <topics/templates/>` before being
+is rendered to HTML using :djangodoc:`Django templates <topics/templates/>` before being
 sent to the browser. Additional javascript (jQuery-based) functionality in the browser
 is used to update the UI in response to user interactions such as 
 browsing or modifying the data.
-This will often involve AJAX calls to load more data as html or JSON objects.
+This will often involve AJAX calls to load more data as HTML or JSON objects.
 
 .. note::
     The webclient should **NOT** be considered as a stable public API. URLs and methods
@@ -18,7 +18,7 @@ This will often involve AJAX calls to load more data as html or JSON objects.
 Top level pages
 ---------------
 
-There are a small number of top level html pages that the user will start at.
+There are a small number of top level HTML pages that the user will start at.
 These are all handled by the load_template view:
 
 - / (homepage delegates to /userdata)
@@ -47,7 +47,7 @@ Selection changes in the jsTree and centre panel thumbnails cause events to be
 triggered by jQuery on the ``$("body")`` element of the page, allowing other scripts
 to listen for these events.
 These are used to load selected data into the centre and right panels.
-The html for these panels contains additional scripts that also run when they load
+The HTML for these panels contains additional scripts that also run when they load
 to setup their own event listeners.
 
 There is also a global ``update_thumbnails_panel`` function that can be called
@@ -86,7 +86,7 @@ Javascript code
 ---------------
 
 The majority of javascript code is jQuery-based code that is embedded within the
-html templates and is run when the page loads.
+HTML templates and is run when the page loads.
 
 Additional code is in static scripts, with functions generally name-spaced
 under an ``OME`` module.

--- a/omero/developers/Web/Webclient.txt
+++ b/omero/developers/Web/Webclient.txt
@@ -1,0 +1,82 @@
+OMERO.webclient
+===============
+
+The webclient Django app provides the main OMERO.web client UI.
+
+Data from OMERO is rendered to html using Django templates before being
+sent to the browser. Additional javascript (jQuery-based) functionality in the browser
+is used to update the UI in response to user interactions such as 
+browsing or modifying the data.
+
+
+Top level pages
+---------------
+
+There are a small number of top level html pages that the user will start at.
+These are all handled by the load_template view:
+
+ - / (homepage delegates to /userdata)
+ - /userdata
+ - /usertags
+ - /public
+ - /history
+ - /search
+
+These pages contain many different jQuery scripts that run when the page loads,
+to setup event listeners and to load additional data.
+
+Additional top-level pages are used in popup windows for running scripts and
+downloading data.
+
+JsTree
+------
+
+A jsTree is used by the userdata, usertags and public pages to browse hierarchical
+data. Each time a node is expanded, it uses appropriate AJAX calls to load children as
+json data.
+Further POST or DELETE AJAX calls are made to modify the data hierachy by
+creating or deleting links between objects.
+
+Selection changes and other updates to the jsTree trigger loading 
+of the centre and right panels.
+The html for these panels contains additional scripts that also run when they load
+to setup thier own event listeners.
+
+
+Switching Groups & Users
+------------------------
+
+The current group and user are stored in the html session as 'active_group' and
+'user_id'. These are used to define the data that is loaded in the
+main 'userdata' and 'usertags' pages.
+
+The group and user are switched by the Groups and Users menu, which updates the
+session and reloads the page.
+
+
+Show queries
+------------
+
+Data in OMERO can be linked from the webclient with urls of the form
+/webclient/?show=image-23|image-34
+
+In the load_template view, the first object is queried from OMERO parent
+containers are also loaded. The owner and group of the top container is
+used to set the 'active_group' and 'user_id' so that the main page loads
+the appropriate data hierarchy.
+
+The jsTree does it's own lookup from the query string, retrieving json
+data and using this to expand the appropriate nodes to show the
+specified objects.
+
+
+Javascript code
+---------------
+
+The majority of javascript code is jQuery-based code that is embedded within the
+html templates and is run when the page loads.
+
+Additional code is in static scripts, with functions generally name-spaced
+under an 'OME' module. 
+
+

--- a/omero/developers/Web/Webclient.txt
+++ b/omero/developers/Web/Webclient.txt
@@ -8,6 +8,11 @@ sent to the browser. Additional javascript (jQuery-based) functionality in the b
 is used to update the UI in response to user interactions such as 
 browsing or modifying the data.
 
+.. note::
+    The webclient should **NOT** be considered as a stable public API. URLs and methods
+    within the app are purely designed to provide internal functionality for
+    the webclient itself and may change in minor releases without warning.
+
 Top level pages
 ---------------
 
@@ -80,6 +85,6 @@ The majority of javascript code is jQuery-based code that is embedded within the
 html templates and is run when the page loads.
 
 Additional code is in static scripts, with functions generally name-spaced
-under an 'OME' module. 
+under an ``OME`` module.
 
 

--- a/omero/developers/Web/Webclient.txt
+++ b/omero/developers/Web/Webclient.txt
@@ -1,5 +1,5 @@
-The OMERO.webclient application
-===============================
+The OMERO.web client application
+================================
 
 The webclient Django app provides the main OMERO.web client UI.
 

--- a/omero/developers/Web/Webclient.txt
+++ b/omero/developers/Web/Webclient.txt
@@ -15,12 +15,12 @@ Top level pages
 There are a small number of top level html pages that the user will start at.
 These are all handled by the load_template view:
 
- - / (homepage delegates to /userdata)
- - /userdata
- - /usertags
- - /public
- - /history
- - /search
+- / (homepage delegates to /userdata)
+- /userdata
+- /usertags
+- /public
+- /history
+- /search
 
 These pages contain many different jQuery scripts that run when the page loads,
 to setup event listeners and to load additional data.
@@ -40,11 +40,11 @@ creating or deleting links between objects.
 Selection changes and other updates to the jsTree trigger loading 
 of the centre and right panels.
 The html for these panels contains additional scripts that also run when they load
-to setup thier own event listeners.
+to setup their own event listeners.
 
 
-Switching Groups & Users
-------------------------
+Switching Groups and Users
+--------------------------
 
 The current group and user are stored in the html session as 'active_group' and
 'user_id'. These are used to define the data that is loaded in the
@@ -57,15 +57,15 @@ session and reloads the page.
 Show queries
 ------------
 
-Data in OMERO can be linked from the webclient with urls of the form
-/webclient/?show=image-23|image-34
+Data in OMERO can be linked from the webclient with URLs of the form
+```/webclient/?show=image-23|image-34```
 
-In the load_template view, the first object is queried from OMERO parent
+In the load_template view, the first object is queried from OMERO and its parent
 containers are also loaded. The owner and group of the top container is
 used to set the 'active_group' and 'user_id' so that the main page loads
 the appropriate data hierarchy.
 
-The jsTree does it's own lookup from the query string, retrieving json
+The jsTree does its own lookup from the query string, retrieving json
 data and using this to expand the appropriate nodes to show the
 specified objects.
 

--- a/omero/developers/Web/Webclient.txt
+++ b/omero/developers/Web/Webclient.txt
@@ -1,12 +1,14 @@
-OMERO.webclient
-===============
+The OMERO.webclient application
+===============================
 
 The webclient Django app provides the main OMERO.web client UI.
 
-Data from OMERO is rendered to html using Django templates before being
+Data is retrieved from OMERO using the :doc:`/developers/Python` and
+is rendered to html using :djangodoc:`Django templates <topics/templates/>` before being
 sent to the browser. Additional javascript (jQuery-based) functionality in the browser
 is used to update the UI in response to user interactions such as 
 browsing or modifying the data.
+This will often involve AJAX calls to load more data as html or JSON objects.
 
 .. note::
     The webclient should **NOT** be considered as a stable public API. URLs and methods
@@ -55,8 +57,10 @@ is used to add or remove Images from a selected Dataset.
 Switching Groups and Users
 --------------------------
 
-The current group and user are stored in the html session as ``active_group`` and
-``user_id``. These are used to define the data that is loaded in the
+The current group and user are stored in
+the :djangodoc:`HTTP session <topics/http/sessions/>`
+as ``request.session['active_group']`` and ``request.session['user_id']``.
+These are used to define the data that is loaded in the
 main ``userdata`` and ``usertags`` pages.
 
 The group and user are switched by the Groups and Users menu, which updates the

--- a/omero/developers/Web/Webclient.txt
+++ b/omero/developers/Web/Webclient.txt
@@ -42,7 +42,7 @@ Further POST or DELETE AJAX calls are made to modify the data hierachy by
 creating or deleting links between objects.
 
 Selection changes in the jsTree and centre panel thumbnails cause events to be
-triggered by jQuery on the ``body`` element of the page, allowing other scripts
+triggered by jQuery on the ``$("body")`` element of the page, allowing other scripts
 to listen for these events.
 These are used to load selected data into the centre and right panels.
 The html for these panels contains additional scripts that also run when they load

--- a/omero/developers/Web/Webclient.txt
+++ b/omero/developers/Web/Webclient.txt
@@ -8,7 +8,6 @@ sent to the browser. Additional javascript (jQuery-based) functionality in the b
 is used to update the UI in response to user interactions such as 
 browsing or modifying the data.
 
-
 Top level pages
 ---------------
 
@@ -37,11 +36,16 @@ json data.
 Further POST or DELETE AJAX calls are made to modify the data hierachy by
 creating or deleting links between objects.
 
-Selection changes and other updates to the jsTree trigger loading 
-of the centre and right panels.
+Selection changes in the jsTree and centre panel thumbnails cause events to be
+triggered by jQuery on the ``body`` element of the page, allowing other scripts
+to listen for these events.
+These are used to load selected data into the centre and right panels.
 The html for these panels contains additional scripts that also run when they load
 to setup their own event listeners.
 
+There is also a global ``update_thumbnails_panel`` function that can be called
+by any script that needs to refresh the centre panel. For example, when the jsTree
+is used to add or remove Images from a selected Dataset.
 
 Switching Groups and Users
 --------------------------
@@ -52,7 +56,6 @@ main ``userdata`` and ``usertags`` pages.
 
 The group and user are switched by the Groups and Users menu, which updates the
 session and reloads the page.
-
 
 Show queries
 ------------

--- a/omero/developers/index.txt
+++ b/omero/developers/index.txt
@@ -115,6 +115,7 @@ Web
     Web/WritingViews
     Web/WritingTemplates
     Web/CSRF
+    Web/Webclient
 
 
 *******


### PR DESCRIPTION
In preparation for discussions and presentations on the future of webclient, it will be useful to have some developer docs for the current state of webclient.

These are still a work-in-progress, but it will be useful to have the staging pages of these available over the next few weeks.

Changes staged at https://www.openmicroscopy.org/site/support/omero5.2-staging/developers/Web/Webclient.html
