### PR TITLE
Fixing codahale metrics link

### DIFF
--- a/omero/sysadmins/server-performance.txt
+++ b/omero/sysadmins/server-performance.txt
@@ -237,7 +237,7 @@ Useful metrics include:
       Time taken to generate tiled-pyramids for a big image. (PixelData-only)
 
 .. _Check_MK: https://mathias-kettner.de/check_mk.html
-.. _Codahale: http://metrics.codahale.com/
+.. _Codahale: http://codahale.com
 .. _JConsole: http://openjdk.java.net/tools/svc/jconsole/
 .. _JVisualVM: http://visualvm.java.net/
 .. _Nagios: http://www.nagios.org/

--- a/omero/sysadmins/server-performance.txt
+++ b/omero/sysadmins/server-performance.txt
@@ -179,7 +179,7 @@ care must be taken to protect the exposed ports.
 Metrics
 -------
 
-Building on top of the `Codahale`_ "Metrics" library, OMERO provides
+Building on top of the Coda Hale's `Metrics`_ library, OMERO provides
 the ome.system.metrics package which measures a number of internal
 events and makes them available both via |JMX| as described under
 :ref:`jvm_monitoring` but also prints them to the log files.
@@ -237,7 +237,7 @@ Useful metrics include:
       Time taken to generate tiled-pyramids for a big image. (PixelData-only)
 
 .. _Check_MK: https://mathias-kettner.de/check_mk.html
-.. _Codahale: http://metrics.dropwizard.io
+.. _Metrics: http://metrics.dropwizard.io
 .. _JConsole: http://openjdk.java.net/tools/svc/jconsole/
 .. _JVisualVM: http://visualvm.java.net/
 .. _Nagios: http://www.nagios.org/

--- a/omero/sysadmins/server-performance.txt
+++ b/omero/sysadmins/server-performance.txt
@@ -179,7 +179,7 @@ care must be taken to protect the exposed ports.
 Metrics
 -------
 
-Building on top of the Coda Hale's `Metrics`_ library, OMERO provides
+Building on top of Coda Hale's `Metrics`_ library, OMERO provides
 the ome.system.metrics package which measures a number of internal
 events and makes them available both via |JMX| as described under
 :ref:`jvm_monitoring` but also prints them to the log files.

--- a/omero/sysadmins/server-performance.txt
+++ b/omero/sysadmins/server-performance.txt
@@ -237,7 +237,7 @@ Useful metrics include:
       Time taken to generate tiled-pyramids for a big image. (PixelData-only)
 
 .. _Check_MK: https://mathias-kettner.de/check_mk.html
-.. _Codahale: http://codahale.com
+.. _Codahale: http://metrics.dropwizard.io
 .. _JConsole: http://openjdk.java.net/tools/svc/jconsole/
 .. _JVisualVM: http://visualvm.java.net/
 .. _Nagios: http://www.nagios.org/


### PR DESCRIPTION
Link isn't loading so I've changed it to the home page. Alternatively, we could link to http://codahale.com/projects or directly to https://github.com/codahale/metrics - happy to switch to one of those if it's deemed more suitable.
