### PR TITLE
fix list e-mail address

### DIFF
--- a/contributing/team-communication.txt
+++ b/contributing/team-communication.txt
@@ -167,7 +167,7 @@ Internal mailing lists
 In addition to the two public mailing lists mentioned above, there are
 also:
 
-* **ome-nitpick@lists.openmicroscopy.org**, used for team-wide,
+* **ome-nitpick@lists.openmicroscopy.org.uk**, used for team-wide,
   developer communication that isn’t appropriate for the wider OME
   community such as organizing mini-group meetings, scheduling
   vacation, etc.


### PR DESCRIPTION
Fix the nitpick address to be `ome-nitpick@lists.openmicroscopy.org.uk`. Staged at http://www.openmicroscopy.org/site/support/contributing-staging/team-communication.html#internal-mailing-lists.

--no-rebase as in contributing
