### PR TITLE
Add polygon to python ROIs examples

### DIFF
--- a/omero/developers/Python.txt
+++ b/omero/developers/Python.txt
@@ -781,12 +781,6 @@ ROIs
     conn.connect()
     updateService = conn.getUpdateService()
 
--  **Configuration**
-
-::
-
-    imageId = 27544
-
 -  **Create ROI.**
 
 ::
@@ -874,6 +868,74 @@ ROIs
 
 ::
 
+    def create_mask(mask_bytes, bytes_per_pixel=1):
+        if bytes_per_pixel == 2:
+            divider = 16.0
+            format_string = "H"  # Unsigned short
+            byte_factor = 0.5
+        elif bytes_per_pixel == 1:
+            divider = 8.0
+            format_string = "B"  # Unsiged char
+            byte_factor = 1
+        else:
+            message = "Format %s not supported"
+            raise ValueError(message)
+        steps = math.ceil(len(mask_bytes) / divider)
+        mask = []
+        for i in range(long(steps)):
+            binary = mask_bytes[
+                i * int(divider):i * int(divider) + int(divider)]
+            format = str(int(byte_factor * len(binary))) + format_string
+            binary = struct.unpack(format, binary)
+            s = ""
+            for bit in binary:
+                s += str(bit)
+            mask.append(int(s, 2))
+        return bytearray(mask) 
+
+::
+
+    mask_x = 50
+    mask_y = 50
+    mask_h = 100
+    mask_w = 100
+    # Create [0, 1] mask
+    mask_array = numpy.fromfunction(
+        lambda x, y: (x * y) % 2, (mask_w, mask_h))
+    # Set correct number of bytes per value
+    mask_array = mask_array.astype(numpy.uint8)
+    # Convert the mask to bytes
+    mask_array = mask_array.tostring()
+    # Pack the bytes to a bit mask
+    mask_packed = create_mask(mask_array, 1) 
+
+::
+
+    # Define mask's fill color
+    mask_color = ColorHolder()
+    mask_color.setRed(255)
+    mask_color.setBlue(0)
+    mask_color.setGreen(0)
+    mask_color.setAlpha(100) 
+
+::
+
+    # create an ROI with a single mask
+    mask = omero.model.MaskI()
+    mask.setTheC(rint(0))
+    mask.setTheZ(rint(0))
+    mask.setTheT(rint(0))
+    mask.setX(rdouble(mask_x))
+    mask.setY(rdouble(mask_y))
+    mask.setWidth(rdouble(mask_w))
+    mask.setHeight(rdouble(mask_h))
+    mask.setFillColor(rint(mask_color.getInt()))
+    mask.setTextValue(rstring("test-Mask"))
+    mask.setBytes(mask_packed)
+    createROI(image, [mask])
+
+::
+
     # create an ROI with single point shape
     point = omero.model.PointI()
     point.cx = rdouble(x)
@@ -938,8 +1000,14 @@ ROIs
                 shape['x2'] = s.getX2().getValue()
                 shape['y1'] = s.getY1().getValue()
                 shape['y2'] = s.getY2().getValue()
+            elif type(s) == omero.model.MaskI:
+                shape['type'] = 'Mask'
+                shape['x'] = s.getX().getValue()
+                shape['y'] = s.getY().getValue()
+                shape['width'] = s.getWidth().getValue()
+                shape['height'] = s.getHeight().getValue()
             elif type(s) in (
-                    omero.model.MaskI, omero.model.LabelI, omero.model.PolygonI):
+                    omero.model.LabelI, omero.model.PolygonI):
                 print type(s), " Not supported by this code"
             # Do some processing here, or just print:
             print "   Shape:",

--- a/omero/developers/Python.txt
+++ b/omero/developers/Python.txt
@@ -819,10 +819,12 @@ ROIs
 ::
 
     # Another helper for generating the color integers for shapes
-    def rgbToRGBInt(red, green, blue):
-        """ Convert an R,G,B value to an int """
-        RGBInt = (red << 16) + (green << 8) + blue
-        return int(RGBInt)
+    def rgbaToInt(red, green, blue, alpha=255):
+        """ Convert an R,G,B,A value to an int """
+        RGBAInt = (alpha << 24) + (red << 16) + (green << 8) + blue
+        if (RGBAInt > (2**31-1)):       # convert to signed 32-bit int
+            RGBAInt = RGBAInt - 2**32
+        return int(RGBAInt)
 
 ::
 
@@ -892,8 +894,8 @@ ROIs
     polygon = omero.model.PolygonI()
     polygon.theZ = rint(theZ)
     polygon.theT = rint(theT)
-    polygon.fillColor = rint(rgbToRGBInt(255, 0, 255))
-    polygon.strokeColor = rint(rgbToRGBInt(0, 255, 0))
+    polygon.fillColor = rint(rgbaToInt(255, 0, 255, 50))
+    polygon.strokeColor = rint(rgbaToInt(255, 255, 0))
     polygon.strokeWidth = omero.model.LengthI(10, UnitsLength.PIXEL)
     points = [[10, 20], [50, 150], [200, 200], [250, 75]]
     polygon.points = rstring(pointsToString(points))

--- a/omero/developers/Python.txt
+++ b/omero/developers/Python.txt
@@ -794,8 +794,7 @@ ROIs
     # We are using the core Python API and omero.model objects here, since ROIs
     # are not yet supported in the Python Blitz Gateway.
     #
-    # In this example, we create an ROI linked to several shapes
-    # and attach it to an image.
+    # First we load our image and pick some parameters for shapes
     x = 50
     y = 200
     width = 100
@@ -806,14 +805,28 @@ ROIs
 
 ::
 
-    # create an ROI, link it to Image
-    roi = omero.model.RoiI()
-    # use the omero.model.ImageI that underlies the 'image' wrapper
-    roi.setImage(image._obj)
+    # We have a helper function for creating an ROI and linking it to new shapes
+    def createROI(img, shapes):
+        # create an ROI, link it to Image
+        roi = omero.model.RoiI()
+        # use the omero.model.ImageI that underlies the 'image' wrapper
+        roi.setImage(img._obj)
+        for shape in shapes:
+            roi.addShape(shape)
+        # Save the ROI (saves any linked shapes too)
+        updateService.saveObject(roi)
 
 ::
 
-    # create a rectangle shape and add to ROI
+    # Another helper for generating the color integers for shapes
+    def rgbToRGBInt(red, green, blue):
+        """ Convert an R,G,B value to an int """
+        RGBInt = (red << 16) + (green << 8) + blue
+        return int(RGBInt)
+
+::
+
+    # create a rectangle shape (added to ROI below)
     print ("Adding a rectangle at theZ: %s, theT: %s, X: %s, Y: %s, width: %s,"
            " height: %s" % (theZ, theT, x, y, width, height))
     rect = omero.model.RectangleI()
@@ -824,13 +837,10 @@ ROIs
     rect.theZ = rint(theZ)
     rect.theT = rint(theT)
     rect.textValue = rstring("test-Rectangle")
-    roi.addShape(rect)
 
 ::
 
-    # create an Ellipse shape and add to ROI
-    print ("Adding ellipse at theZ: %s, theT: %s, cx: %s, cy: %s, rx: %s,"
-           " ry: %s" % (theZ, theT, x, y, width, height))
+    # create an Ellipse shape (added to ROI below)
     ellipse = omero.model.EllipseI()
     ellipse.cx = rdouble(y)
     ellipse.cy = rdouble(x)
@@ -839,13 +849,17 @@ ROIs
     ellipse.theZ = rint(theZ)
     ellipse.theT = rint(theT)
     ellipse.textValue = rstring("test-Ellipse")
-    roi.addShape(ellipse) 
 
 ::
 
-    # create a line shape and add to ROI
-    print ("Adding line at theZ: %s, theT: %s, x1: %s, y1: %s, x2: %s,"
-       " y2: %s" % (theZ, theT, x, y, x+width, y+height))
+    # Create an ROI containing 2 shapes on same plane
+    # NB: OMERO.insight client doesn't support this
+    # The ellipse is removed later (see below)
+    createROI(image, [rect, ellipse])
+
+::
+
+    # create an ROI with single line shape
     line = omero.model.LineI()
     line.x1 = rdouble(x)
     line.x2 = rdouble(x+width)
@@ -854,23 +868,36 @@ ROIs
     line.theZ = rint(theZ)
     line.theT = rint(theT)
     line.textValue = rstring("test-Line")
-    roi.addShape(line) 
+    createROI(image, [line])
 
 ::
 
-    # create a point shape and add to ROI
+    # create an ROI with single point shape
     point = omero.model.PointI()
     point.cx = rdouble(x)
     point.cy = rdouble(y)
     point.theZ = rint(theZ)
     point.theT = rint(theT)
     point.textValue = rstring("test-Point")
-    roi.addShape(point) 
+    createROI(image, [point])
 
 ::
 
-    # Save the ROI (saves any linked shapes too)
-    r = updateService.saveAndReturnObject(roi) 
+    def pointsToString(points):
+        """ Returns strange format supported by Insight """
+        points = ["%s,%s" % (p[0], p[1]) for p in points]
+        csv = ", ".join(points)
+        return "points[%s] points1[%s] points2[%s]" % (csv, csv, csv)
+    # create an ROI with a single polygon, setting colors and lineWidth
+    polygon = omero.model.PolygonI()
+    polygon.theZ = rint(theZ)
+    polygon.theT = rint(theT)
+    polygon.fillColor = rint(rgbToRGBInt(255, 0, 255))
+    polygon.strokeColor = rint(rgbToRGBInt(0, 255, 0))
+    polygon.strokeWidth = omero.model.LengthI(10, UnitsLength.PIXEL)
+    points = [[10, 20], [50, 150], [200, 200], [250, 75]]
+    polygon.points = rstring(pointsToString(points))
+    createROI(image, [polygon])
 
 -  **Retrieve ROIs linked to an Image.**
 

--- a/omero/developers/Python.txt
+++ b/omero/developers/Python.txt
@@ -849,8 +849,9 @@ ROIs
 ::
 
     # Create an ROI containing 2 shapes on same plane
-    # NB: OMERO.insight client doesn't support this
-    # The ellipse is removed later (see below)
+    # NB: OMERO.insight client doesn't support display
+    # of multiple shapes on a single plane.
+    # Therefore the ellipse is removed later (see below)
     createROI(image, [rect, ellipse])
 
 ::
@@ -948,7 +949,7 @@ ROIs
 ::
 
     def pointsToString(points):
-        """ Returns strange format supported by Insight """
+        """ Returns legacy format supported by Insight """
         points = ["%s,%s" % (p[0], p[1]) for p in points]
         csv = ", ".join(points)
         return "points[%s] points1[%s] points2[%s]" % (csv, csv, csv)


### PR DESCRIPTION
This updates the Python ROIs example code according to changes in the examples at https://github.com/openmicroscopy/openmicroscopy/pull/4412 (Polygons)
and 
https://github.com/openmicroscopy/openmicroscopy/pull/4415 (Masks).
Check for formatting errors etc.
Code changes themselves are checked by the above PRs.
