### PR TITLE
Add Scientifica to list of OME-TIFF supporters

### DIFF
--- a/formats/ome-tiff/index.txt
+++ b/formats/ome-tiff/index.txt
@@ -42,6 +42,7 @@ OME-TIFF is supported by:
 * `Micro-Manager <http://valelab.ucsf.edu/~MM/MMwiki/>`_
 * `Molecular Devices Inc. <http://www.moleculardevices.com>`_
 * `PerkinElmer <http://www.perkinelmer.com/>`_
+* `Scientifica <http://www.scientifica.uk.com>`_
 * `Scientific Volume Imaging B.V. <http://www.svi.nl/>`_
 * `Strand Life Sciences <http://www.strandls.com>`_
 * `TILL Photonics GmbH, now FEI Munich <http://www.fei.com/>`_


### PR DESCRIPTION
See https://trello.com/c/2D2KM6Iy/400-sciscan-ome-compatibility
Company got in touch to tell us this and ask to be added. I have a logo they sent too but given the rest of the page is plain text, it didn't seem appropriate to add.

Staged on https://www.openmicroscopy.org/site/support/ome-model-staging/ome-tiff/index.html
