### PR TITLE
expand notes on inter-patch upgrade scripts

### DIFF
--- a/contributing/conf.py
+++ b/contributing/conf.py
@@ -45,6 +45,7 @@ contributing_extlinks = {
     # Doc links
     'omero_doc' : (oo_site_root + '/support/omero/%s', ''),
     'bf_doc' : (oo_site_root + '/support/bio-formats/%s', ''),
+    'model_doc' : (oo_site_root + '/support/ome-model/%s', ''),
     }
 extlinks.update(contributing_extlinks)
 

--- a/contributing/schema-changes.txt
+++ b/contributing/schema-changes.txt
@@ -142,8 +142,8 @@ Review workflow
 
 Any Pull Request introducing a schema change will be initially marked and
 reviewed with a `breaking` label (see :doc:`ci-introduction`) so after
-opening your Pull Request please have it labeled as being breaking. This implies
-the Pull Request will first be included in the :ref:`omero_breaking` and
-:ref:`bf_breaking` exclusively. Once positively reviewed, the `breaking` label
-will be removed so that the Pull Request is included in the daily merge builds
-before final merging.
+opening your Pull Request please have it labeled as being breaking. This
+implies the Pull Request will first be included in the
+:ref:`omero_breaking` and :ref:`bf_breaking` exclusively. Once positively
+reviewed, the `breaking` label will be removed so that the Pull Request is
+included in the daily merge builds before final merging.

--- a/contributing/schema-changes.txt
+++ b/contributing/schema-changes.txt
@@ -140,10 +140,10 @@ changes to :omero_source:`omero.properties <etc/omero.properties>` and
 Review workflow
 ---------------
 
-Any Pull Request introducing a schema change will be initially marked and
+Any pull request introducing a schema change will be initially marked and
 reviewed with a `breaking` label (see :doc:`ci-introduction`) so after
-opening your Pull Request please have it labeled as being breaking. This
-implies the Pull Request will first be included in the
+opening your pull request please have it labeled as being breaking. This
+implies the pull request will first be included in the
 :ref:`omero_breaking` and :ref:`bf_breaking` exclusively. Once positively
-reviewed, the `breaking` label will be removed so that the Pull Request is
+reviewed, the `breaking` label will be removed so that the pull request is
 included in the daily merge builds before final merging.

--- a/contributing/schema-changes.txt
+++ b/contributing/schema-changes.txt
@@ -108,9 +108,16 @@ Move the previous patch's SQL scripts into their new directory.
 
         $ git mv sql/psql/OMERO5.1DEV__4 sql/psql/OMERO5.1DEV__5
 
+Restore the upgrade to that previous patch.
+
+::
+
+        $ mkdir sql/psql/OMERO5.1DEV__4
+        $ git mv sql/psql/OMERO5.1DEV__5/OMERO5.1DEV__3.sql sql/psql/OMERO5.1DEV__4/OMERO5.1DEV__3.sql
+
 Build OMERO.server with your code that changes the schema, then use
 the :literal:`build-schema` build target to update the SQL scripts in
-the new :literal:`sql/psql/OMERO5.1DEV__5` directory.
+the new :file:`sql/psql/OMERO5.1DEV__5` directory.
 
 ::
 
@@ -120,6 +127,11 @@ Now, when you use :omerocmd:`db script` in setting up a database for
 your modified server, the generated SQL script creates the new schema
 that your code requires. Use this script to set up your database so
 that you can start OMERO.server and test your changes thoroughly.
+
+A combination of :file:`sql/psql/OMERO5.1DEV__4/OMERO5.1DEV__3.sql` and
+the changes within :file:`sql/psql/OMERO5.1DEV__5` that :command:`git
+diff` reports should help you to create a new
+:file:`sql/psql/OMERO5.1DEV__5/OMERO5.1DEV__4.sql`.
 
 When you commit your code and issue a pull request, include the
 changes to :omero_source:`omero.properties <etc/omero.properties>` and

--- a/contributing/schema-changes.txt
+++ b/contributing/schema-changes.txt
@@ -141,7 +141,8 @@ Review workflow
 ---------------
 
 Any Pull Request introducing a schema change will be initially marked and
-reviewed with a `breaking` label (see :doc:`ci-introduction`). This implies
+reviewed with a `breaking` label (see :doc:`ci-introduction`) so after
+opening your Pull Request please have it labeled as being breaking. This implies
 the Pull Request will first be included in the :ref:`omero_breaking` and
 :ref:`bf_breaking` exclusively. Once positively reviewed, the `breaking` label
 will be removed so that the Pull Request is included in the daily merge builds

--- a/contributing/schema-changes.txt
+++ b/contributing/schema-changes.txt
@@ -20,6 +20,12 @@ necessary, if your pull request affects the schema then you **must**
 increment the database patch number and provide an updated schema as
 described below.
 
+Changes to the :model_doc:`OME-XML model <developers/model-overview.html>`
+typically require corresponding changes in the OMERO data schema as
+defined in its :omero_source:`XML mappings files
+<components/model/resources/mappings/>`. These feed into OMERO's database
+schema so this process is then required.
+
 Patch number conflicts
 ----------------------
 


### PR DESCRIPTION
The current notes say too little about the inter-patch SQL upgrade scripts: this PR should at least improve the situation. Staged at https://www.openmicroscopy.org/site/support/contributing-staging/schema-changes.html.

@aleksandra-tarkowska may suggest further ways to improve the process.

--no-rebase as on contributing
