### PR TITLE
Adding note about VA being ditched

### DIFF
--- a/omero/users/index.txt
+++ b/omero/users/index.txt
@@ -90,6 +90,10 @@ to, you can apply for an account on our demo server. Alternatively, you can
 create your own using a virtual appliance (a step-by-step guide for how to do
 this is provided).
 
+.. note:: The virtual appliance is being discontinued. Previous versions will
+    remain available for download but OMERO 5.2.1 will be the most recent
+    release.
+
 .. toctree::
     :maxdepth: 1
     :titlesonly:

--- a/omero/users/virtual-appliance.txt
+++ b/omero/users/virtual-appliance.txt
@@ -1,8 +1,9 @@
 OMERO virtual appliance
 =======================
 
-.. note:: As of OMERO 5.1.2, the Virtual Appliance is now available from a
-    separate :downloads_va:`downloads page <>`.
+.. note:: The virtual appliance is being discontinued. Previous versions will
+    remain available for download but :downloads_va:`OMERO 5.2.1 <>` will be
+    the most recent release.
 
 The OMERO virtual appliance is a quick, easy, and low-cost way to try
 out OMERO.server on your laptop or desktop. This enables you to make


### PR DESCRIPTION
See https://trello.com/c/q14NpdkH/5-va-docs - no-one has downloaded the VA since we moved to the new downloads site in autumn 2013 so we aren't releasing it any more. This PR makes that clear for the 5.2 docs, for 5.3 they will be removed altogether.
