### PR TITLE
Fixing typo on homebrew install page

### DIFF
--- a/omero/sysadmins/unix/server-install-homebrew.txt
+++ b/omero/sysadmins/unix/server-install-homebrew.txt
@@ -66,7 +66,7 @@ Install PostgreSQL database server::
 
     $ export LANG=${LANG:-en_US.UTF-8}
     $ export LANGUAGE=${LANGUAGE:-en_US:en}
-    $ brew install postgres
+    $ brew install postgresql
 
 .. _`Homebrew and Python`: https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Homebrew-and-Python.md
 


### PR DESCRIPTION
See https://trello.com/c/gtfC9e9F/405-bug-typo-in-osx-omero-install-instructions typo reported by Gus.

Will be staged at https://www.openmicroscopy.org/site/support/omero5.2-staging/sysadmins/unix/server-install-homebrew.html
