### PR TITLE
Pillow version

### DIFF
--- a/omero/sysadmins/unix/server-centos6.txt
+++ b/omero/sysadmins/unix/server-centos6.txt
@@ -154,8 +154,7 @@ For example, download :download:`walkthrough/omero-centos6py27ius.env
 
 Install additional Python modules in the virtual environment::
 
-    # Cap Pillow version due to a limitation in OMERO.figure
-    /home/omero/omeroenv/bin/pip2.7 install "Pillow<3.0"
+    /home/omero/omeroenv/bin/pip2.7 install Pillow
     /home/omero/omeroenv/bin/pip2.7 install numpy matplotlib
 
     # Install Django

--- a/omero/sysadmins/unix/server-centos7.txt
+++ b/omero/sysadmins/unix/server-centos7.txt
@@ -54,8 +54,7 @@ Install Ice, Java, PostgreSQL::
     libjpeg-devel \
     gcc
 
-  # Cap Pillow version due to a limitation in OMERO.figure with v3.0.0
-  pip install 'Pillow<3.0'
+  pip install Pillow
 
   # Django
   pip install 'Django>=1.8,<1.9'

--- a/omero/sysadmins/unix/walkthrough/step01_centos6_deps.sh
+++ b/omero/sysadmins/unix/walkthrough/step01_centos6_deps.sh
@@ -22,7 +22,7 @@ yum -y install \
 	hdf5-devel
 
 # Requires gcc {libjpeg,libpng,libtiff,zlib}-devel
-pip install pillow
+pip install Pillow
 pip install numexpr==1.4.2
 # Requires gcc, Cython, hdf5-devel
 pip install tables==2.4.0

--- a/omero/sysadmins/unix/walkthrough/step01_centos6_py27_deps.sh
+++ b/omero/sysadmins/unix/walkthrough/step01_centos6_py27_deps.sh
@@ -9,8 +9,11 @@ curl -o /etc/yum.repos.d/zeroc-ice-el6.repo \
 yum -y install \
 	unzip \
 	wget \
+	tar
+
+yum -y install \
 	java-1.8.0-openjdk \
-	db53 db53-devel db53-utils mcpp-devel
+	db53 db53-utils mcpp
 
 yum -y install \
 	python27 \
@@ -22,9 +25,7 @@ yum -y install \
 	zlib-devel \
 	hdf5-devel \
 	freetype-devel \
-	expat-devel \
-	bzip2-devel \
-	openssl-devel
+	expat-devel
 
 # TODO: this installs a lot of unecessary packages:
 yum -y groupinstall "Development Tools"
@@ -35,7 +36,9 @@ set -u
 easy_install pip
 
 export PYTHONWARNINGS="ignore:Unverified HTTPS request"
-pip install tables pillow matplotlib
+pip install tables matplotlib
+
+pip install Pillow
 
 # Django
 pip install "Django>=1.8,<1.9"
@@ -49,24 +52,18 @@ sed -i.bak -re 's/^(host.*)ident/\1md5/' /var/lib/pgsql/9.4/data/pg_hba.conf
 chkconfig postgresql-9.4 on
 service postgresql-9.4 start
 
-# Now get and build ice
-yum -y install tar
+# Now install ice
+mkdir /tmp/ice-download
+cd /tmp/ice-download
 
-mkdir /tmp/ice
-cd /tmp/ice
+wget http://downloads.openmicroscopy.org/ice/experimental/Ice-3.5.1-b1-centos6-sclpy27-x86_64.tar.gz
 
-curl -Lo Ice-3.5.1.tar.gz https://zeroc.com/download/Ice/3.5/Ice-3.5.1.tar.gz
+tar -zxvf /tmp/ice-download/Ice-3.5.1-b1-centos6-sclpy27-x86_64.tar.gz
 
-tar xvf Ice-3.5.1.tar.gz
-cd Ice-3.5.1
+# so we don't have to update ICE_HOME
+mv Ice-3.5.1-b1-centos6-sclpy27-x86_64 /opt/Ice-3.5.1
 
-cd cpp
-make && make test && make install
-cd ../py
-set +u
-source /opt/rh/python27/enable
-set -u
-make && make test && make install
-
+# make path to Ice globally accessible
+# if globally set, there is no need to export LD_LIBRARY_PATH
 echo /opt/Ice-3.5.1/lib64 > /etc/ld.so.conf.d/ice-x86_64.conf
 ldconfig

--- a/omero/sysadmins/unix/walkthrough/step01_centos7_deps.sh
+++ b/omero/sysadmins/unix/walkthrough/step01_centos7_deps.sh
@@ -24,8 +24,7 @@ yum -y install \
 	libjpeg-devel \
 	gcc
 
-# Cap Pillow version due to a limitation in OMERO.figure with v3.0.0
-pip install 'Pillow<3.0'
+pip install Pillow
 
 # Django
 pip install 'Django>=1.8,<1.9'

--- a/omero/sysadmins/unix/walkthrough/step01_ubuntu1404_deps.sh
+++ b/omero/sysadmins/unix/walkthrough/step01_ubuntu1404_deps.sh
@@ -20,7 +20,7 @@ apt-get -y install \
 	tcl8.6-dev \
 	tk8.6-dev
 
-pip install --upgrade "Pillow<3.0"
+pip install --upgrade Pillow
 
 # Django
 pip install "Django>=1.8,<1.9"


### PR DESCRIPTION
Corresponding doc PR for https://github.com/ome/omero-install/pull/86

Note that the centOS 6 page will be reworked in another PR to use "literal include" now that the scripts on omero-install have been created.
