### PR TITLE
Use ~/OMERO.data as data.dir for homebrew docs

### DIFF
--- a/omero/sysadmins/unix/server-install-homebrew.txt
+++ b/omero/sysadmins/unix/server-install-homebrew.txt
@@ -157,7 +157,7 @@ Create and run script to initialize the OMERO database::
 
 Set up OMERO data directory::
 
-    $ export OMERO_DATA_DIR=${OMERO_DATA_DIR:-/tmp/var/OMERO.data}
+    $ export OMERO_DATA_DIR=${OMERO_DATA_DIR:-~/OMERO.data}
     $ mkdir -p $OMERO_DATA_DIR
     $ omero config set omero.data.dir $OMERO_DATA_DIR
 


### PR DESCRIPTION
See https://trello.com/c/AaOOJ8IU/70-homebrew-docs-data-dir-not-tmp

This uses a more suitable data directory than /tmp.
