### PR TITLE
Review and clarify the sysadmin section about the CLI admin command

### DIFF
--- a/omero/sysadmins/cli/admin.txt
+++ b/omero/sysadmins/cli/admin.txt
@@ -6,22 +6,91 @@ Server start
 
 Once your database has been properly configured and your config profile
 is set to use that database, you are ready to start your server using the
-:omerocmd:`admin start` command::
+:program:`omero admin start` command::
 
     $ bin/omero admin start
 
-.. note::
+This command performs the following operations in order:
 
-    :omerocmd:`admin start` and :omerocmd:`admin restart` provide a useful
-    debugging and maintenance option called :option:`--foreground`. Using
-    this option allows for starting the server up in the foreground, that is
+#. rewrites the configuration files if :option:`--force-rewrite` is  passed or
+   the server has never been started
+#. checks the server status and aborts the command if a server is running
+#. rewrites the configuration files if it has not been done at step 1
+#. starts the server
+#. waits until the server status returns zero
+
+Most configuration files under :file:`etc/grid` are generated using the
+templates under :file:`etc/grid/templates` and the server configuration stored
+in :file:`etc/grid/config.xml`. During this rewriting step, the JVM memory
+settings are recalculated (see :ref:`jvm_memory_settings`)  and the new server
+ports (see :ref:`ports_configuration`).
+
+.. program:: omero admin start
+
+.. option:: -h, --help
+
+    Display the help for this subcommand.
+
+.. option:: --foreground
+
+    This option is particularly useful for debugging and maintenance option
+    and allows for starting the server up in the foreground, that is
     without creating a daemon on UNIX-like systems or service on Windows.
     During the lifetime of the server, the prompt from which it was launched
     will be blocked.
 
+.. option:: --force-rewrite
+
+    This option forces the server configuration files under :file:`etc/grid`
+    to be rewritten before the status of the server is checked.
+
+Server stop
+^^^^^^^^^^^^
+
+To stop a running server, you can invoke the :program:`omero admin stop`
+subcommand::
+
+    $ bin/omero admin stop
+
+This command does the following operations in order:
+
+#. rewrites the server configuration files if :option:`--force-rewrite` is
+   passed
+#. checks the server status and aborts the command if no server is running
+#. stops the server
+#. waits until the server status returns one
+
+.. program:: omero admin stop
+
+.. option:: -h, --help
+
+    Display the help for this subcommand.
+
+.. option:: --force-rewrite
+
+    This option forces the configuration files to be rewritten before the
+    server status is checked. 
+
+Server restart
+^^^^^^^^^^^^^^
+
+To stop and start the server in a single command, you can use the
+:program:`omero admin restart` command::
+
+    $ bin/omero admin restart
+
+The ``restart`` subcommand supports the same options as :program:`omero admin start`.
+
 Server diagnostics
 ^^^^^^^^^^^^^^^^^^
 
-::
+To debug a server or inspect the configuration, you can use the :program:`omero admin diagnostics` command::
 
     $ bin/omero admin diagnostics
+    
+The output of this command will report information about:
+
+* the server prerequisites (:program:`psql`, :program:`java`)
+* the server environment variables
+* the server memory settings and ports
+* the status of the binary repository

--- a/omero/sysadmins/cli/admin.txt
+++ b/omero/sysadmins/cli/admin.txt
@@ -12,17 +12,19 @@ is set to use that database, you are ready to start your server using the
 
 This command performs the following operations in order:
 
-#. rewrites the configuration files if :option:`--force-rewrite` is  passed or
+#. rewrites the configuration files if :option:`--force-rewrite` is passed or
    the server has never been started
-#. checks the server status and aborts the command if a server is running
+#. checks the server status, i.e. pings the ``master`` node using the IceGrid
+   administration tool
+#. aborts the command if a server is running
 #. rewrites the configuration files if it has not been done at step 1
 #. starts the server
-#. waits until the server status returns zero
+#. waits until the server is up
 
 Most configuration files under :file:`etc/grid` are generated using the
 templates under :file:`etc/grid/templates` and the server configuration stored
 in :file:`etc/grid/config.xml`. During this rewriting step, the JVM memory
-settings are recalculated (see :ref:`jvm_memory_settings`)  and the new server
+settings are recalculated (see :ref:`jvm_memory_settings`) and the new server
 ports (see :ref:`ports_configuration`).
 
 .. program:: omero admin start
@@ -56,9 +58,11 @@ This command does the following operations in order:
 
 #. rewrites the server configuration files if :option:`--force-rewrite` is
    passed
-#. checks the server status and aborts the command if no server is running
+#. checks the server status, i.e. pings the ``master`` node using the IceGrid
+   administration tool
+#. aborts the command if no server is running
 #. stops the server
-#. waits until the server status returns one
+#. waits until the server is down
 
 .. program:: omero admin stop
 
@@ -87,7 +91,7 @@ Server diagnostics
 To debug a server or inspect the configuration, you can use the :program:`omero admin diagnostics` command::
 
     $ bin/omero admin diagnostics
-    
+
 The output of this command will report information about:
 
 * the server prerequisites (:program:`psql`, :program:`java`)

--- a/omero/sysadmins/cli/admin.txt
+++ b/omero/sysadmins/cli/admin.txt
@@ -23,9 +23,9 @@ This command performs the following operations in order:
 
 Most configuration files under :file:`etc/grid` are generated using the
 templates under :file:`etc/grid/templates` and the server configuration stored
-in :file:`etc/grid/config.xml`. During this rewriting step, the JVM memory
-settings are recalculated (see :ref:`jvm_memory_settings`) and the new server
-ports (see :ref:`ports_configuration`).
+in :file:`etc/grid/config.xml`. The rewriting step updates the JVM memory
+settings (see :ref:`jvm_memory_settings`) and the server ports (see
+:ref:`ports_configuration`) based on the server configuration.
 
 .. program:: omero admin start
 

--- a/omero/sysadmins/cli/admin.txt
+++ b/omero/sysadmins/cli/admin.txt
@@ -35,9 +35,9 @@ ports (see :ref:`ports_configuration`).
 
 .. option:: --foreground
 
-    This option is particularly useful for debugging and maintenance option
-    and allows for starting the server up in the foreground, that is
-    without creating a daemon on UNIX-like systems or service on Windows.
+    This option is particularly useful for debugging and maintenance and
+    allows for starting the server up in the foreground, that is without
+    creating a daemon on UNIX-like systems or service on Windows.
     During the lifetime of the server, the prompt from which it was launched
     will be blocked.
 


### PR DESCRIPTION
- Describes the operations performed by admin start and admin stop
- Mention admin restart and expand the diagnostics command
- Expand the supported options including --force-rewrite

Follows the improvements described in https://github.com/openmicroscopy/openmicroscopy/pull/4379
