### PR TITLE
Removing old reference to controlling foreground/background as per #1370

### DIFF
--- a/omero/sysadmins/windows/install-web.txt
+++ b/omero/sysadmins/windows/install-web.txt
@@ -79,12 +79,6 @@ to access the OMERO.webclient:
 
    OMERO.web login
 
-.. note::
-	This starts the server in the foreground. It is your
-	responsibility to place it in the background, if required, and
-	manage its shutdown.
-
-
 .. _windows_omero_web_maintenance:
 
 OMERO.web Maintenance (Windows)


### PR DESCRIPTION
Same text as removed in omero/sysadmins/unix/install-web.txt during https://github.com/openmicroscopy/ome-documentation/pull/1370 
