### PR TITLE
Removing Django 1.6 links

### DIFF
--- a/omero/sysadmins/unix/server-centos6.txt
+++ b/omero/sysadmins/unix/server-centos6.txt
@@ -22,7 +22,7 @@ Python 2.7
 ^^^^^^^^^^
 
 CentOS 6 provides Python 2.6. However, OMERO.web requires Python 2.7
-in order to use `Django 1.8`_. While `Django 1.6`_ may be used with Python
+in order to use `Django 1.8`_. While Django 1.6 may be used with Python
 2.6, this version of Django no longer has security support.  In
 consequence, it is necessary to upgrade to Python 2.7 in order to
 obtain Django security updates, which are required for a production

--- a/omero/sysadmins/version-requirements.txt
+++ b/omero/sysadmins/version-requirements.txt
@@ -105,7 +105,7 @@ Components
     with a single major version, and removes a number of portability
     issues, but most importantly is a requirement of `Django 1.8`_.
     Python 2.6 will continue to work for 5.2 with Django 1.6, but this
-    not a recommended combination due to security vulnerabilities.
+    is not recommended due to security vulnerabilities.
 
 * GCC
 

--- a/omero/sysadmins/version-requirements.txt
+++ b/omero/sysadmins/version-requirements.txt
@@ -104,9 +104,8 @@ Components
     in the 5.3 timeframe. Dropping 2.6 for 5.3 unifies python support
     with a single major version, and removes a number of portability
     issues, but most importantly is a requirement of `Django 1.8`_.
-    Python 2.6 will continue to work for 5.2 with `Django 1.6`_, but this
-    not a recommended combination due to the potential for future
-    security vulnerabilities in the absence of security support.
+    Python 2.6 will continue to work for 5.2 with Django 1.6, but this
+    not a recommended combination due to security vulnerabilities.
 
 * GCC
 
@@ -894,9 +893,7 @@ installable with ``pip`` using any Python version.
 The supported version of the Django module used by OMERO.web (1.8)
 requires Python 2.7. The older version (1.6) will work with Python
 2.6 but lacks security support, and is consequently not recommended
-for production use. However, if you are using IIS on Windows, Django 1.8
-support is still upcoming and you must use 1.6 for now. We aim to add support
-for Django 1.8 in OMERO.web within the 5.2.x development line.
+for production use.
 
 GCC
 ---


### PR DESCRIPTION
Removing broken links especially as 1.6 is not needed for Windows now either. Should make https://ci.openmicroscopy.org/view/Docs/job/OMERO-DEV-merge-docs/ green again.
