### PR TITLE
Labelling server queries page more clearly

### DIFF
--- a/omero/developers/Server/Queries.txt
+++ b/omero/developers/Server/Queries.txt
@@ -1,5 +1,12 @@
-Queries
-=======
+Using server queries internally
+===============================
+
+.. topic:: Overview
+
+    This page is aimed at internal server developers and does not
+    contain information of how to perform API queries. If that is the kind of
+    information you are looking for, you may find
+    :doc:`/developers/Modules/Api` more useful as a starting point.
 
 .. figure:: /images/omero-queries-queryfactory-collaboration.png
   :align: center

--- a/omero/developers/Server/Queries.txt
+++ b/omero/developers/Server/Queries.txt
@@ -4,7 +4,7 @@ Using server queries internally
 .. topic:: Overview
 
     This page is aimed at internal server developers and does not
-    contain information of how to perform API queries. If that is the kind of
+    contain information for how to perform API queries. If that is the kind of
     information you are looking for, you may find
     :doc:`/developers/Modules/Api` more useful as a starting point.
 


### PR DESCRIPTION
Addresses https://trac.openmicroscopy.org/ome/ticket/10907 by renaming the page and adding an overview box to signpost the content more clearly.

Open to suggestions for a better alternative link if anyone has one.

Will be staged at https://www.openmicroscopy.org/site/support/omero5.2-staging/developers/Server/Queries.html once built.
