### PR TITLE
Add sysadmin page for repository move

### DIFF
--- a/omero/sysadmins/maintenance.txt
+++ b/omero/sysadmins/maintenance.txt
@@ -8,3 +8,4 @@ Upgrading and maintenance
     server-backup-and-restore
     server-upgrade
     UpgradeCheck
+    repository-move

--- a/omero/sysadmins/repository-move.txt
+++ b/omero/sysadmins/repository-move.txt
@@ -23,6 +23,9 @@ The current location of the data repositories can be found using the
      2 | 3  | 3ec8c878-c776-48a3-b57e-2a11b0c97045 | Public  | /Users/omero/var/omero
     (3 rows)
 
+Moving the OMERO data directory
+-------------------------------
+
 If the Managed Repository is within the OMERO data directory and the whole
 data directory is to be moved then the following steps should be used:
 
@@ -50,6 +53,9 @@ to ``/Volumes/omero``:
      1 | 2  | ScriptRepo                           | Script  | /Users/omero/dist/lib/scripts
      2 | 3  | 3ec8c878-c776-48a3-b57e-2a11b0c97045 | Public  | /Volumes/omero
     (3 rows)
+
+Moving the Managed Repository
+-----------------------------
 
 If the Managed Repository is in a separate location from OMERO data directory
 or only the Managed Repository is to be moved then the following steps

--- a/omero/sysadmins/repository-move.txt
+++ b/omero/sysadmins/repository-move.txt
@@ -51,7 +51,7 @@ to ``/Volumes/omero``:
      2 | 3  | 3ec8c878-c776-48a3-b57e-2a11b0c97045 | Public  | /Volumes/omero
     (3 rows)
 
-If the Managed Repository is in a separate location to OMERO data directory
+If the Managed Repository is in a separate location from OMERO data directory
 or only the Managed Repository is to be moved then the following steps
 should be used:
 
@@ -86,8 +86,8 @@ to ``/Volumes/imports/ManagedRepository``:
     the OMERO directory should only be moved as a whole.
 
     If the Managed Repository needs to be moved to a location other than that
-    set by :property:`omero.data.dir`, to a location outside of the OMERO, for
-    example, data directory, then :property:`omero.managed.dir` must be set.
+    set by :property:`omero.data.dir`, to a location outside of the OMERO data
+    directory, for example, then :property:`omero.managed.dir` must be set.
 
     If :property:`omero.managed.dir` is set then the Managed Repository and
     the OMERO data directory should be treated independently and thus be moved

--- a/omero/sysadmins/repository-move.txt
+++ b/omero/sysadmins/repository-move.txt
@@ -31,7 +31,7 @@ data directory is to be moved then the following steps should be used:
 
 ::
 
-    bin/omero config omero.data.dir NEW
+    bin/omero config set omero.data.dir NEW
     mv OLD NEW
 
 For example, moving the OMERO data directory from ``/Users/omero/var/omero``
@@ -41,7 +41,7 @@ to ``/Volumes/omero``:
 
     $ bin/omero admin stop
     ...
-    $ bin/omero config omero.data.dir /Volumes/omero
+    $ bin/omero config set omero.data.dir /Volumes/omero
     $ mv /Users/omero/var/omero /Volumes/omero
     $ bin/omero admin start
     ...
@@ -63,7 +63,7 @@ steps should be used:
 
 ::
 
-    bin/omero config omero.managed.dir NEW
+    bin/omero config set omero.managed.dir NEW
     mv OLD NEW
 
 For example, moving the Managed Repository from ``/Users/omero/var/omero/ManagedRepository``
@@ -73,7 +73,7 @@ to ``/Volumes/imports/ManagedRepository``:
 
     $ bin/omero admin stop
     ...
-    $ bin/omero config omero.managed.dir /Volumes/imports/ManagedRepository
+    $ bin/omero config set omero.managed.dir /Volumes/imports/ManagedRepository
     $ mv /Users/omero/var/omero/ManagedRepository /Volumes/imports/ManagedRepository
     $ bin/omero admin start
     ...

--- a/omero/sysadmins/repository-move.txt
+++ b/omero/sysadmins/repository-move.txt
@@ -1,5 +1,3 @@
-.. _repository_move:
-
 Moving the data repository
 ==========================
 
@@ -7,7 +5,7 @@ It may be necessary to move either the whole OMERO data directory or only the
 Managed Repository to a new location on the file system. This should be done
 with care following the steps below.
 
-.. note::
+.. warning::
     Before moving OMERO data it is wise to ensure that both the data and the
     database are fully backed up. See :ref:`server_backup`.
 

--- a/omero/sysadmins/repository-move.txt
+++ b/omero/sysadmins/repository-move.txt
@@ -23,6 +23,11 @@ The current location of the data repositories can be found using the
      2 | 3  | 3ec8c878-c776-48a3-b57e-2a11b0c97045 | Public  | /Users/omero/var/omero
     (3 rows)
 
+.. note::
+    This command can be slow, :omerocmd:`config get` can also be used to
+    determine if :property:`omero.data.dir` or :property:`omero.managed.dir`
+    have non-default values.
+
 Moving the OMERO data directory
 -------------------------------
 
@@ -31,8 +36,15 @@ data directory is to be moved then the following steps should be used:
 
 ::
 
+    bin/omero admin stop
     bin/omero config set omero.data.dir NEW
     mv OLD NEW
+    bin/omero admin start
+
+.. warning::
+    The use of :omerocmd:`config set` is absolutely necessary here. The steps:
+    :omerocmd:`admin stop`, ``mv``, :omerocmd:`admin start` without
+    :omerocmd:`config set` could lead to an unstable situation.
 
 For example, moving the OMERO data directory from ``/Users/omero/var/omero``
 to ``/Volumes/omero``:
@@ -63,8 +75,15 @@ steps should be used:
 
 ::
 
+    bin/omero admin stop
     bin/omero config set omero.managed.dir NEW
     mv OLD NEW
+    bin/omero admin start
+
+.. warning::
+    The use of :omerocmd:`config set` is absolutely necessary here. The steps:
+    :omerocmd:`admin stop`, ``mv``, :omerocmd:`admin start` without
+    :omerocmd:`config set` could lead to an unstable situation.
 
 For example, moving the Managed Repository from ``/Users/omero/var/omero/ManagedRepository``
 to ``/Volumes/imports/ManagedRepository``:

--- a/omero/sysadmins/repository-move.txt
+++ b/omero/sysadmins/repository-move.txt
@@ -7,10 +7,10 @@ with care following the steps below.
 
 .. warning::
     Before moving OMERO data it is wise to ensure that both the data and the
-    database are fully backed up. See :ref:`server_backup`.
+    database are fully backed up. See :doc:`server-backup-and-restore`.
 
-The current location of the data repositories can be found using ``fs repos``
-command:
+The current location of the data repositories can be found using the
+:omerocmd:`fs repos` command:
 
 ::
 
@@ -81,14 +81,14 @@ to ``/Volumes/imports/ManagedRepository``:
     (3 rows)
 
 .. note::
-    If ``omero.managed.dir`` is not set then the location of the Managed
-    Repository will be determined by ``omero.data.dir`` and the OMERO
-    directory should only be moved as a whole.
+    If :property:`omero.managed.dir` is not set then the location of the
+    Managed Repository will be determined by :property:`omero.data.dir` and
+    the OMERO directory should only be moved as a whole.
 
     If the Managed Repository needs to be moved to a location other than that
-    set by ``omero.data.dir``, to a location outside of the OMERO, for
-    example, data directory, then ``omero.managed.dir`` must be set.
+    set by :property:`omero.data.dir`, to a location outside of the OMERO, for
+    example, data directory, then :property:`omero.managed.dir` must be set.
 
-    If ``omero.managed.dir`` is set then the Managed Repository and the OMERO
-    data directory should be treated independently and thus be moved
+    If :property:`omero.managed.dir` is set then the Managed Repository and
+    the OMERO data directory should be treated independently and thus be moved
     separately if necessary.

--- a/omero/sysadmins/repository-move.txt
+++ b/omero/sysadmins/repository-move.txt
@@ -1,0 +1,85 @@
+.. _repository_move:
+
+Moving the data repository
+==========================
+
+It may be necessary to move either the whole OMERO data directory or only the
+Managed Repository to a new location on the file system. This should be done
+with care following the steps below.
+
+.. note::
+    Before moving OMERO data it is wise to ensure that both the data and the
+    database are fully backed up. See :ref:`server_backup`.
+
+The current location of the data repositories can be found using ``fs repos``
+command:
+
+::
+
+    $ bin/omero fs repos
+
+     # | Id | UUID                                 | Type    | Path
+    ---+----+--------------------------------------+---------+-----------------------------------------
+     0 | 1  | 309ea513-a23c-48d1-abd2-9ceed1b3ffa4 | Managed | /Users/omero/var/omero/ManagedRepository
+     1 | 2  | ScriptRepo                           | Script  | /Users/omero/dist/lib/scripts
+     2 | 3  | 3ec8c878-c776-48a3-b57e-2a11b0c97045 | Public  | /Users/omero/var/omero
+    (3 rows)
+
+If the Managed Repository is within the OMERO data directory and the whole
+data directory is to be moved then the following steps should be used:
+
+::
+
+    bin/omero config omero.data.dir NEW
+    mv OLD NEW
+
+For example, moving the OMERO data directory from ``/Users/omero/var/omero``
+to ``/Users/omero/var/omero-new``:
+
+::
+
+    $ bin/omero admin stop
+    ...
+    $ bin/omero config omero.data.dir /Users/omero/var/omero-new
+    $ mv /Users/omero/var/omero /Users/omero/var/omero-new
+    $ bin/omero admin start
+    ...
+    $ bin/omero fs repos
+
+     # | Id | UUID                                 | Type    | Path
+    ---+----+--------------------------------------+---------+---------------------------------------------
+     0 | 1  | 309ea513-a23c-48d1-abd2-9ceed1b3ffa4 | Managed | /Users/omero/var/omero-new/ManagedRepository
+     1 | 2  | ScriptRepo                           | Script  | /Users/omero/dist/lib/scripts
+     2 | 3  | 3ec8c878-c776-48a3-b57e-2a11b0c97045 | Public  | /Users/omero/var/omero-new
+    (3 rows)
+
+If the Managed Repository is in a separate location to OMERO data directory
+or only the Managed Repository is to be moved then the following steps
+should be used:
+
+::
+
+    bin/omero config omero.managed.dir NEW
+    mv OLD NEW
+
+For example, moving the Managed Repository from ``/Users/omero/var/omero/ManagedRepository``
+to ``/Users/omero/var/omero-new/ManagedRepository``:
+
+::
+
+    $ bin/omero admin stop
+    ...
+    $ bin/omero config omero.managed.dir /Users/omero/var/omero-new/ManagedRepository
+    $ mkdir /Users/omero/var/omero-new
+    $ mv /Users/omero/var/omero/ManagedRepository /Users/omero/var/omero-new/ManagedRepository
+    $ bin/omero admin start
+    ...
+    $ bin/omero fs repos
+
+     # | Id | UUID                                 | Type    | Path
+    ---+----+--------------------------------------+---------+---------------------------------------------
+     0 | 1  | 309ea513-a23c-48d1-abd2-9ceed1b3ffa4 | Managed | /Users/omero/var/omero-new/ManagedRepository
+     1 | 2  | ScriptRepo                           | Script  | /Users/omero/dist/lib/scripts
+     2 | 3  | 3ec8c878-c776-48a3-b57e-2a11b0c97045 | Public  | /Users/omero/var/omero
+    (3 rows)
+

--- a/omero/sysadmins/repository-move.txt
+++ b/omero/sysadmins/repository-move.txt
@@ -32,23 +32,23 @@ data directory is to be moved then the following steps should be used:
     mv OLD NEW
 
 For example, moving the OMERO data directory from ``/Users/omero/var/omero``
-to ``/Users/omero/var/omero-new``:
+to ``/Volumes/omero``:
 
 ::
 
     $ bin/omero admin stop
     ...
-    $ bin/omero config omero.data.dir /Users/omero/var/omero-new
-    $ mv /Users/omero/var/omero /Users/omero/var/omero-new
+    $ bin/omero config omero.data.dir /Volumes/omero
+    $ mv /Users/omero/var/omero /Volumes/omero
     $ bin/omero admin start
     ...
     $ bin/omero fs repos
 
      # | Id | UUID                                 | Type    | Path
-    ---+----+--------------------------------------+---------+---------------------------------------------
-     0 | 1  | 309ea513-a23c-48d1-abd2-9ceed1b3ffa4 | Managed | /Users/omero/var/omero-new/ManagedRepository
+    ---+----+--------------------------------------+---------+---------------------------------
+     0 | 1  | 309ea513-a23c-48d1-abd2-9ceed1b3ffa4 | Managed | /Volumes/omero/ManagedRepository
      1 | 2  | ScriptRepo                           | Script  | /Users/omero/dist/lib/scripts
-     2 | 3  | 3ec8c878-c776-48a3-b57e-2a11b0c97045 | Public  | /Users/omero/var/omero-new
+     2 | 3  | 3ec8c878-c776-48a3-b57e-2a11b0c97045 | Public  | /Volumes/omero
     (3 rows)
 
 If the Managed Repository is in a separate location to OMERO data directory
@@ -61,22 +61,21 @@ should be used:
     mv OLD NEW
 
 For example, moving the Managed Repository from ``/Users/omero/var/omero/ManagedRepository``
-to ``/Users/omero/var/omero-new/ManagedRepository``:
+to ``/Volumes/imports/ManagedRepository``:
 
 ::
 
     $ bin/omero admin stop
     ...
-    $ bin/omero config omero.managed.dir /Users/omero/var/omero-new/ManagedRepository
-    $ mkdir /Users/omero/var/omero-new
-    $ mv /Users/omero/var/omero/ManagedRepository /Users/omero/var/omero-new/ManagedRepository
+    $ bin/omero config omero.managed.dir /Volumes/imports/ManagedRepository
+    $ mv /Users/omero/var/omero/ManagedRepository /Volumes/imports/ManagedRepository
     $ bin/omero admin start
     ...
     $ bin/omero fs repos
 
      # | Id | UUID                                 | Type    | Path
-    ---+----+--------------------------------------+---------+---------------------------------------------
-     0 | 1  | 309ea513-a23c-48d1-abd2-9ceed1b3ffa4 | Managed | /Users/omero/var/omero-new/ManagedRepository
+    ---+----+--------------------------------------+---------+-----------------------------------
+     0 | 1  | 309ea513-a23c-48d1-abd2-9ceed1b3ffa4 | Managed | /Volumes/imports/ManagedRepository
      1 | 2  | ScriptRepo                           | Script  | /Users/omero/dist/lib/scripts
      2 | 3  | 3ec8c878-c776-48a3-b57e-2a11b0c97045 | Public  | /Users/omero/var/omero
     (3 rows)

--- a/omero/sysadmins/repository-move.txt
+++ b/omero/sysadmins/repository-move.txt
@@ -80,3 +80,15 @@ to ``/Volumes/imports/ManagedRepository``:
      2 | 3  | 3ec8c878-c776-48a3-b57e-2a11b0c97045 | Public  | /Users/omero/var/omero
     (3 rows)
 
+.. note::
+    If ``omero.managed.dir`` is not set then the location of the Managed
+    Repository will be determined by ``omero.data.dir`` and the OMERO
+    directory should only be moved as a whole.
+
+    If the Managed Repository needs to be moved to a location other than that
+    set by ``omero.data.dir``, to a location outside of the OMERO, for
+    example, data directory, then ``omero.managed.dir`` must be set.
+
+    If ``omero.managed.dir`` is set then the Managed Repository and the OMERO
+    data directory should be treated independently and thus be moved
+    separately if necessary.

--- a/omero/sysadmins/repository-move.txt
+++ b/omero/sysadmins/repository-move.txt
@@ -57,9 +57,9 @@ to ``/Volumes/omero``:
 Moving the Managed Repository
 -----------------------------
 
-If the Managed Repository is in a separate location from OMERO data directory
-or only the Managed Repository is to be moved then the following steps
-should be used:
+If the Managed Repository is in a separate location from the OMERO data
+directory or only the Managed Repository is to be moved then the following
+steps should be used:
 
 ::
 


### PR DESCRIPTION
This page provides some basic advice and examples for moving the OMERO data repository or Managed Repository.
- The markup could probably be tweaked.
- Should the note be a warning?
- Maybe links are needed to the infor on Managed Repository/fs commands?
