### PR TITLE
Update dev build page to refer to sysadmin docs

### DIFF
--- a/omero/developers/installation.txt
+++ b/omero/developers/installation.txt
@@ -53,38 +53,8 @@ Building OMERO
 
 To install the dependencies required to run the OMERO.server on Linux
 or Mac OS X, take a look at the
-:doc:`/sysadmins/unix/server-installation` or the
-:doc:`/sysadmins/unix/server-install-homebrew` sections.
-
-Additional dependencies are necessary for building the server and clients:
-
-- Ice Python and Java development packages may need to be explicitly installed
-  on Linux.
-
-Finally, some environment variables may need to be set up before building
-the server:
-
-- If the system slice files cannot be found you must set :envvar:`SLICEPATH`
-  to point to the :file:`slice` directory of the Ice installation.
-
-For example, on CentOS 6 the following should be sufficient to run the default
-build::
-
-    yum install java-1.7.0-openjdk-devel python-genshi python-setuptools \
-        ice-servers ice-python-devel ice-java-devel ice-c++-devel
-
-On Ubuntu 14.04::
-
-    apt-get install openjdk-7-jdk python-genshi python-setuptools zeroc-ice
-
-Once all the dependencies and environment variables are set up, you can build
-the server using::
-
-    python build.py
-
-or the clients using::
-
-    python build.py release-clients
+:doc:`/sysadmins/unix/server-installation` page where you will also find links
+to walk-throughs for specific platforms.
 
 .. seealso::
 

--- a/omero/developers/installation.txt
+++ b/omero/developers/installation.txt
@@ -56,6 +56,20 @@ or Mac OS X, take a look at the
 :doc:`/sysadmins/unix/server-installation` page where you will also find links
 to walk-throughs for specific platforms.
 
+Some environment variables may need to be set up before building the server:
+
+- If the system slice files cannot be found you must set :envvar:`SLICEPATH`
+  to point to the :file:`slice` directory of the Ice installation.
+
+Once all the dependencies and environment variables are set up, you can build
+the server using::
+
+    python build.py
+
+or the clients using::
+
+    python build.py release-clients
+
 .. seealso::
 
     :doc:`build-system`


### PR DESCRIPTION
http://www.openmicroscopy.org/site/support/omero5.2-staging/developers/installation.html#building-omero is out-of-date because we forgot to update it during our push to update the installation docs for 5.2. This PR removes most of the content to reduce the burden of upkeep, and refers people to the sysadmin docs instead.
