### PR TITLE
Adding downloads refs to troubleshooting

### DIFF
--- a/omero/sysadmins/troubleshooting.txt
+++ b/omero/sysadmins/troubleshooting.txt
@@ -368,6 +368,17 @@ is loaded prior to omeroweb.conf
 
     2016/01/01 00:00:00 [error] 1234#0: *5 "/usr/share/nginx/html/webclient/login/index.html" is not found (2: No such file or directory), client: 1.2.3.4, server
 
+OMERO.web not responding/timeout issues
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    [CRITICAL] WORKER TIMEOUT (pid:1234)
+
+OMERO.web deployed with Gunicorn relies on the operating system to provide
+all of the load balancing while handling requests. Scale the number of
+workers starting with (2 x NUM_CORES) + 1 workers. For more details refer to
+:ref:`gunicorn_default_configuration`.
 
 Issues with downloading data from OMERO.web
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/omero/sysadmins/troubleshooting.txt
+++ b/omero/sysadmins/troubleshooting.txt
@@ -376,9 +376,10 @@ OMERO.web not responding/timeout issues
     [CRITICAL] WORKER TIMEOUT (pid:1234)
 
 OMERO.web deployed with Gunicorn relies on the operating system to provide
-all of the load balancing while handling requests. Scale the number of
-workers starting with (2 x NUM_CORES) + 1 workers. For more details refer to
-:ref:`gunicorn_default_configuration`.
+all of the load balancing while handling requests. Adjust the timeout using
+:property:`omero.web.wsgi_timeout` and scale the number of
+:property:`omero.web.wsgi_workers` starting with (2 x NUM_CORES) + 1 workers.
+For more details refer to :ref:`gunicorn_default_configuration`.
 
 Issues with downloading data from OMERO.web
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/omero/sysadmins/troubleshooting.txt
+++ b/omero/sysadmins/troubleshooting.txt
@@ -369,6 +369,14 @@ is loaded prior to omeroweb.conf
     2016/01/01 00:00:00 [error] 1234#0: *5 "/usr/share/nginx/html/webclient/login/index.html" is not found (2: No such file or directory), client: 1.2.3.4, server
 
 
+Issues with downloading data from OMERO.web
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+An :ref:`gunicorn_advance_configuration` is available for testing with nginx
+if you are encountering problems with downloads failing. You can also
+configure OMERO.web to limit downloads - refer to the :doc:`unix/install-web`
+documentation and :ref:`download_restrictions` for further details.
+
 OMERO.web piecharts
 ^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
This adds reference to the new experimental web configurations to the troubleshooting page since people upgrading are unlikely to revisit the installation docs.

The upgrade page probably needs some work too but that isn't going to happen in time for 5.2.2 unless there is a blocker.
