### PR TITLE
upgrade dependences

### DIFF
--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -69,7 +69,8 @@ server upgrade.
 OMERO.web dependences
 ^^^^^^^^^^^^^^^^^^^^^
 
-It is best when updating the server to also upgrade OMERO.web dependences:
+While upgrading the server it is recommended to keep OMERO.web dependencies
+up to date to ensure that security updates are applied.
 
 - Nginx on Unix::
 

--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -69,15 +69,20 @@ server upgrade.
 OMERO.web dependences
 ^^^^^^^^^^^^^^^^^^^^^
 
-Upgrade OMERO.web dependences
+It is best when updating the server to also upgrade OMERO.web dependences
 
-- Nginx::
+- Nginx on Unix::
 
      $ pip install --upgrade -r share/web/requirements-py27-nginx.txt
 
-- Apache::
+- Apache on Unix::
 
      $ pip install --upgrade -r share/web/requirements-py27-apache.txt
+
+- Windows::
+
+     $ pip install --upgrade -r share/web/requirements-py27-win.txt
+
 
 Web plugin updates
 ^^^^^^^^^^^^^^^^^^

--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -66,8 +66,8 @@ server upgrade.
     see :ref:`python-requirements` on the
     :doc:`/sysadmins/version-requirements` page.
 
-OMERO.web dependences
-^^^^^^^^^^^^^^^^^^^^^
+OMERO.web dependencies
+^^^^^^^^^^^^^^^^^^^^^^
 
 While upgrading the server it is recommended to keep OMERO.web dependencies
 up to date to ensure that security updates are applied.

--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -66,6 +66,19 @@ server upgrade.
     see :ref:`python-requirements` on the
     :doc:`/sysadmins/version-requirements` page.
 
+OMERO.web dependences
+^^^^^^^^^^^^^^^^^^^^^
+
+Upgrade OMERO.web dependences
+
+- Nginx::
+
+     $ pip install --upgrade -r share/web/requirements-py27-nginx.txt
+
+- Apache::
+
+     $ pip install --upgrade -r share/web/requirements-py27-apache.txt
+
 Web plugin updates
 ^^^^^^^^^^^^^^^^^^
 OMERO.web plugins are very closely integrated into the webclient. For this

--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -69,7 +69,7 @@ server upgrade.
 OMERO.web dependences
 ^^^^^^^^^^^^^^^^^^^^^
 
-It is best when updating the server to also upgrade OMERO.web dependences
+It is best when updating the server to also upgrade OMERO.web dependences:
 
 - Nginx on Unix::
 


### PR DESCRIPTION
upgrading omero needs to remind about upgrading dependencies. This will make sure people install the latest Django version
