### PR TITLE
Adding ldap create to CLI docs 

### DIFF
--- a/omero/developers/Web.txt
+++ b/omero/developers/Web.txt
@@ -12,7 +12,7 @@ from data retrieved from the OMERO server. OMERO.web acts as a Python
 client of the OMERO server using the OMERO API, as well as being a web
 server itself (see 'infrastructure' info below). It uses Django 'apps'
 to provide modular web tools, such as the webclient (working with image
-data) and webadmin (administrator management). This modular framework
+data, administrator management). This modular framework
 makes it possible to extend OMERO.web with your own apps.
 
 One of the apps, :doc:`/developers/Web/WebGateway`, provides
@@ -44,16 +44,14 @@ Web apps
 
 The OMERO.web framework consists of several Django apps denoted by
 folders named 'web....'. These include webgateway, as
-discussed above, as well as released tools (webadmin, webclient) and
+discussed above, as well as released tools (webclient) and
 other apps in development:
 
 .. glossary::
     webclient
-        Main web client for viewing images, annotating etc. More
-        information available under :ref:`OMERO.web <omero-web>`.
-
-    webadmin
-        For administration of user and group settings.
+        Main web client for viewing images, annotating, administration
+        of user and group settings etc. More information available
+        under :ref:`OMERO.web <omero-web>`.
 
     webgateway
         A web services interface, providing rendered images and

--- a/omero/developers/Web/CreateApp.txt
+++ b/omero/developers/Web/CreateApp.txt
@@ -15,7 +15,7 @@ Getting set up
 In order to deploy OMERO.web in a development or testing environment please 
 follow the instructions under :doc:`Deployment`.
 
-You should make sure that you can access the webclient and webadmin on
+You should make sure that you can access the webclient on
 your local machine before starting to develop your own code. Be sure to
 use the correct port number, e.g.:
 

--- a/omero/developers/Web/WebGateway.txt
+++ b/omero/developers/Web/WebGateway.txt
@@ -19,7 +19,7 @@ and try the URLs out for yourself!
 
 The HTTP request will need to include login details for creating or using a
 current server connection. This will be true for any request made after
-logging in to the server, e.g. login using webclient or webadmin login pages
+logging in to the server, e.g. login using the webclient login page
 then go to ``webgateway/…`` or if you have logged in to a server at
 ``http://ome.example.com/webclient`` then go to, for example,
 ``http://ome.example.com/webgateway/render_image/<imageid>/<z>/<t>/``

--- a/omero/sysadmins/cli/usergroup.txt
+++ b/omero/sysadmins/cli/usergroup.txt
@@ -21,6 +21,12 @@ enter::
 Additional parameters such as the email address, institution, middle name etc
 can be passed as optional arguments to the :omerocmd:`user add` command.
 
+    $ bin/omero ldap create jsmith 
+
+If you are using ldap as an authentication backend this command will create
+an OMERO user account for `jsmith`. This allows the administrator to add 
+`jsmith` to an OMERO group, before they have ever logged in to OMERO. 
+
 .. _ldap_setdn:
 
 Converting non-LDAP users to LDAP authentication

--- a/omero/sysadmins/cli/usergroup.txt
+++ b/omero/sysadmins/cli/usergroup.txt
@@ -7,7 +7,8 @@ add and manage users and groups on your database.
 User creation
 ^^^^^^^^^^^^^
 
-New users can be added to the database using the :omerocmd:`user add` command::
+New users can be added to the database using the :omerocmd:`user add`
+command::
 
     $ bin/omero user add -h
 
@@ -21,11 +22,13 @@ enter::
 Additional parameters such as the email address, institution, middle name etc
 can be passed as optional arguments to the :omerocmd:`user add` command.
 
-    $ bin/omero ldap create jsmith 
+If you are using ldap as an authentication backend, you can create
+an OMERO user account for jsmith using the :omerocmd:`ldap create` command,
+which allows the administrator to add jsmith to an OMERO group, before they
+have ever logged in to OMERO::
 
-If you are using ldap as an authentication backend this command will create
-an OMERO user account for `jsmith`. This allows the administrator to add 
-`jsmith` to an OMERO group, before they have ever logged in to OMERO. 
+    $ bin/omero ldap create jsmith
+
 
 .. _ldap_setdn:
 

--- a/omero/sysadmins/server-ldap.txt
+++ b/omero/sysadmins/server-ldap.txt
@@ -43,7 +43,9 @@ If you would prefer to only have the ``user_filter`` applied during user
 creation and not on every login, see :ref:`legacy_password_providers`.
 
 You can take existing non-LDAP users and 'upgrade' them to using LDAP with the
-OMERO command line tool, see :ref:`ldap_setdn`.
+OMERO command line tool, see :ref:`ldap_setdn`. You can also use
+:omerocmd:`ldap create` to add an ldap user to OMERO groups without requiring
+them to log in first, see :doc:`cli/usergroup` for details.
 
 LDAP properties
 ---------------

--- a/omero/sysadmins/windows/server-installation.txt
+++ b/omero/sysadmins/windows/server-installation.txt
@@ -518,9 +518,9 @@ to access the OMERO.web interface:
    .. figure:: /images/installation-images/login.png
       :align: center
       :width: 55%
-      :alt: OMERO.webadmin login
+      :alt: OMERO.web login
 
-      OMERO.webadmin login
+      OMERO.web login
 
 Post-installation items
 -----------------------


### PR DESCRIPTION
Adding `ldap create` to the CLI docs. Very useful feature as a Sysadmin, you'd have to stumble across on the forums or `omero ldap -h` to know about.
