### PR TITLE
remove obsolete note about annotation deletion

### DIFF
--- a/omero/developers/Modules/Delete.txt
+++ b/omero/developers/Modules/Delete.txt
@@ -164,8 +164,6 @@ Edge cases
 These are 'known issues' that may cause problems for some users (not for
 most). These will be resolved in future depending on priority.
 
--  Annotations of annotations are not deleted, e.g. a Tag is not deleted
-   if a Tag Set is deleted (only true if directly using the API).
 -  Other users' ROIs (and associated measurements) are deleted from
    images.
 -  Multiply-linked objects are unlinked and not deleted e.g. Project p1 


### PR DESCRIPTION
Noticed this in looking around for pages that are sensitive to API changes. Now a comment on a comment on a comment will get deleted along with the original, assuming they are singly linked. The example of tags is a bit of a special case anyway, see https://trello.com/c/S0mR1aqp/34-have-delete2-never-delete-tags-implicitly, also `AnnotationDeleteTest.testDeleteTargetSharedTag` for the current state of http://trac.openmicroscopy.org/ome/ticket/5793.
