### PR TITLE
update graphs migration documentation for OMERO 5.3

### DIFF
--- a/omero/developers/Server/GraphsMigration.txt
+++ b/omero/developers/Server/GraphsMigration.txt
@@ -1,5 +1,5 @@
-Using the new 5.1 graph requests
-================================
+Using graph requests
+====================
 
 Migration is required
 ---------------------

--- a/omero/developers/Server/GraphsMigration.txt
+++ b/omero/developers/Server/GraphsMigration.txt
@@ -64,7 +64,7 @@ Move images
   chgrps.requests = [Chgrp(type="/Image", id=n, grp=5) for n in [1,2,3]]
   sf.submit(chgrps)
 
-becomes,
+used in OMERO 5.0 should now be written as,
 
 .. code-block:: python
 
@@ -81,7 +81,7 @@ Delete plate, but not annotations
   delete = Delete(type="/Plate", id=8, options=keepAnn)
   sf.submit(delete)
 
-becomes,
+used in OMERO 5.0 should now be written as,
 
 .. code-block:: python
 
@@ -98,7 +98,7 @@ Delete an image's rendering settings
   delete = Delete(type="/Image/Pixels/RenderingDef", id=6)
   sf.submit(delete)
 
-becomes,
+used in OMERO 5.0 should now be written as,
 
 .. code-block:: python
 

--- a/omero/developers/Server/GraphsMigration.txt
+++ b/omero/developers/Server/GraphsMigration.txt
@@ -34,9 +34,8 @@ set ``startFrom`` to ``RenderingDef``.
 Translating options
 -------------------
 
-:javadoc:`GraphModify2
-<slice2html/omero/cmd/GraphModify2.html>` offers ``childOptions``, an ordered
-list of :javadoc:`ChildOption
+:javadoc:`GraphModify2 <slice2html/omero/cmd/GraphModify2.html>` offers
+``childOptions``, an ordered list of :javadoc:`ChildOption
 <slice2html/omero/cmd/graphs/ChildOption.html>` instances, each of which
 allows its applicability to annotations to be limited by namespace. Some
 examples:

--- a/omero/developers/Server/GraphsMigration.txt
+++ b/omero/developers/Server/GraphsMigration.txt
@@ -11,24 +11,15 @@ offered through the API via :javadoc:`Chgrp2
 <slice2html/omero/cmd/Delete2.html>`, and their superclass
 :javadoc:`GraphModify2 <slice2html/omero/cmd/GraphModify2.html>`. OMERO
 5.1.2 added :javadoc:`Chmod2 <slice2html/omero/cmd/Chmod2.html>`. The
-legacy request operations :javadoc:`Chgrp
-<slice2html/omero/cmd/Chgrp.html>`, :javadoc:`Chmod
-<slice2html/omero/cmd/Chmod.html>`, :javadoc:`Chown
-<slice2html/omero/cmd/Chown.html>`, :javadoc:`Delete
-<slice2html/omero/cmd/Delete.html>`, and their superclass
-:javadoc:`GraphModify <slice2html/omero/cmd/GraphModify.html>`, are now
-deprecated and will be *removed* in OMERO 5.3. *Now* is the time to
-adjust client code accordingly so that the OME team can fix any
-regressions before the release of OMERO 5.3.
+corresponding deprecated legacy request operations are *removed* in
+OMERO 5.3. Client code must be adjusted accordingly.
 
 
 Target objects
 --------------
 
 For specifying which model objects to operate on, instead of using one
-request for each object through :javadoc:`GraphModify
-<slice2html/omero/cmd/GraphModify.html>`'s ``type`` and ``id`` data
-members, use :javadoc:`GraphModify2
+request for each object, use :javadoc:`GraphModify2
 <slice2html/omero/cmd/GraphModify2.html>`'s ``targetObjects`` which
 allows specification of multiple model object classes, each with an
 unordered list of IDs, all in a single request. To specify a type, no
@@ -43,9 +34,8 @@ set ``startFrom`` to ``RenderingDef``.
 Translating options
 -------------------
 
-:javadoc:`GraphModify <slice2html/omero/cmd/GraphModify.html>`'s
-``options`` data member has its related analog in :javadoc:`GraphModify2
-<slice2html/omero/cmd/GraphModify2.html>`'s ``childOptions``, an ordered
+:javadoc:`GraphModify2
+<slice2html/omero/cmd/GraphModify2.html>` offers ``childOptions``, an ordered
 list of :javadoc:`ChildOption
 <slice2html/omero/cmd/graphs/ChildOption.html>` instances, each of which
 allows its applicability to annotations to be limited by namespace. Some
@@ -61,12 +51,6 @@ examples:
 - To delete annotations except for the tags that are in a specific
   namespace, use ``Delete2`` with a ``ChildOption``'s ``excludeType``
   set to ``TagAnnotation`` and ``includeNs`` set to that namespace.
-
-:source:`GraphUtil.java
-<components/blitz/src/omero/cmd/graphs/GraphUtil.java>` includes the
-``translateOptions`` method that may give additional insight on how to
-translate the previous style of option. This method too will be removed
-in OMERO 5.3.
 
 
 Examples in Python

--- a/omero/developers/Server/GraphsMigration.txt
+++ b/omero/developers/Server/GraphsMigration.txt
@@ -121,12 +121,15 @@ the requests from the above Python examples to be created by,
 .. code-block:: java
 
   // move images
-  Chgrp2 example1 = Requests.chgrp("Image", Arrays.asList(1L,2L,3L), 5L);
+  Chgrp2 example1 = Requests.chgrp().target("Image").id(1L,2L,3L)
+      .toGroup(5L).build();
 
   // delete plate, but not annotations
-  ChildOption childOption = Requests.option(null, "Annotation");
-  Delete2 example2 = Requests.delete("Plate", 8L, childOption);
+  ChildOption childOption = Requests.option()
+      .excludeType("Annotation").build();
+  Delete2 example2 = Requests.delete().target("Plate").id(8L)
+      .option(childOption).build();
 
   // delete an image's rendering settings
-  SkipHead example3 =
-      Requests.skipHead("Image", 6L, "RenderingDef", new Delete2());
+  SkipHead example3 = Requests.skipHead().target("Image").id(6L)
+      .startFrom("RenderingDef").request(Delete2.class).build();


### PR DESCRIPTION
The legacy graphs requests are to be removed and the Java gateway methods have changed. Staged at http://www.openmicroscopy.org/site/support/omero5.3-staging/developers/Server/GraphsMigration.html.

--no-rebase
