### PR TITLE
Add windows deprecation warnings

### DIFF
--- a/omero/sysadmins/windows/index.txt
+++ b/omero/sysadmins/windows/index.txt
@@ -1,6 +1,12 @@
 Server installation on Windows
 ==============================
 
+.. warning:: OMERO 5.2 is the last major version which will feature Windows
+    support for OMERO.server and OMERO.web deployment. See
+    `this blog post <http://blog.openmicroscopy.org/tech-issues/future-plans/deployment/2016/03/22/windows-support/>`_ for details. If you are installing a new server, we highly
+    recommend you use a different OS (see
+    :doc:`/sysadmins/version-requirements`).
+
 .. toctree::
     :maxdepth: 1
     :titlesonly:

--- a/omero/sysadmins/windows/install-web.txt
+++ b/omero/sysadmins/windows/install-web.txt
@@ -4,6 +4,12 @@ OMERO.web deployment
 .. Warning:: The guidance below applies to OMERO **5.2**. Code fixes for
     OMERO.web deployment on Windows have not been back-ported to the 5.1 line
     and this guide cannot be used to deploy OMERO.web 5.1.x on Windows.
+    
+    OMERO 5.2 is the last major version which will feature Windows
+    support for OMERO.web deployment. See
+    `this blog post <http://blog.openmicroscopy.org/tech-issues/future-plans/deployment/2016/03/22/windows-support/>`_ for details. If you are deploying a new installation of
+    OMERO.web, we highly recommend you use a different OS (see
+    :doc:`/sysadmins/version-requirements`).
 
 OMERO.web is the web application component of the OMERO platform which
 allows for the management, visualization (in a fully multi-dimensional

--- a/omero/sysadmins/windows/install-web.txt
+++ b/omero/sysadmins/windows/install-web.txt
@@ -1,15 +1,17 @@
 OMERO.web deployment
 ====================
 
-.. Warning:: The guidance below applies to OMERO **5.2**. Code fixes for
-    OMERO.web deployment on Windows have not been back-ported to the 5.1 line
-    and this guide cannot be used to deploy OMERO.web 5.1.x on Windows.
+.. Warning::
     
     OMERO 5.2 is the last major version which will feature Windows
     support for OMERO.web deployment. See
     `this blog post <http://blog.openmicroscopy.org/tech-issues/future-plans/deployment/2016/03/22/windows-support/>`_ for details. If you are deploying a new installation of
     OMERO.web, we highly recommend you use a different OS (see
     :doc:`/sysadmins/version-requirements`).
+    
+    The guidance below applies to OMERO **5.2**. Code fixes for
+    OMERO.web deployment on Windows have not been back-ported to the 5.1 line
+    and this guide cannot be used to deploy OMERO.web 5.1.x on Windows.
 
 OMERO.web is the web application component of the OMERO platform which
 allows for the management, visualization (in a fully multi-dimensional

--- a/omero/sysadmins/windows/install-web/install-iis.txt
+++ b/omero/sysadmins/windows/install-web/install-iis.txt
@@ -1,6 +1,12 @@
 OMERO.web IIS deployment (Windows)
 ==================================
 
+.. warning:: OMERO 5.2 is the last major version which will feature Windows
+    support for OMERO.server and OMERO.web deployment. See
+    `this blog post <http://blog.openmicroscopy.org/tech-issues/future-plans/deployment/2016/03/22/windows-support/>`_ for details. If you are installing a new server, we highly
+    recommend you use a different OS (see
+    :doc:`/sysadmins/version-requirements`).
+
 .. _iis_configuration:
 
 IIS configuration (Windows)

--- a/omero/sysadmins/windows/server-binary-repository.txt
+++ b/omero/sysadmins/windows/server-binary-repository.txt
@@ -1,6 +1,12 @@
 OMERO.server binary repository
 ==============================
 
+.. warning:: OMERO 5.2 is the last major version which will feature Windows
+    support for OMERO.server and OMERO.web deployment. See
+    `this blog post <http://blog.openmicroscopy.org/tech-issues/future-plans/deployment/2016/03/22/windows-support/>`_ for details. If you are installing a new server, we highly
+    recommend you use a different OS (see
+    :doc:`/sysadmins/version-requirements`).
+
 .. topic:: About
 
     The OMERO.server binary data repository is a fundamental piece of   

--- a/omero/sysadmins/windows/server-installation.txt
+++ b/omero/sysadmins/windows/server-installation.txt
@@ -1,10 +1,11 @@
 OMERO.server installation
 =========================
 
-.. seealso::
-
-    :doc:`/sysadmins/server-upgrade`
-         Instructions for **upgrading** your OMERO.server installation.
+.. warning:: OMERO 5.2 is the last major version which will feature Windows
+    support for OMERO.server and OMERO.web deployment. See
+    `this blog post <http://blog.openmicroscopy.org/tech-issues/future-plans/deployment/2016/03/22/windows-support/>`_ for details. If you are installing a new server, we highly
+    recommend you use a different OS (see
+    :doc:`/sysadmins/version-requirements`).
 
 Limitations
 -----------

--- a/omero/sysadmins/windows/server-postgresql.txt
+++ b/omero/sysadmins/windows/server-postgresql.txt
@@ -1,6 +1,12 @@
 OMERO.server and PostgreSQL
 ===========================
 
+.. warning:: OMERO 5.2 is the last major version which will feature Windows
+    support for OMERO.server and OMERO.web deployment. See
+    `this blog post <http://blog.openmicroscopy.org/tech-issues/future-plans/deployment/2016/03/22/windows-support/>`_ for details. If you are installing a new server, we highly
+    recommend you use a different OS (see
+    :doc:`/sysadmins/version-requirements`).
+
 In order to be installed, OMERO.server requires a running PostgreSQL
 instance that is configured to accept connections over TCP. This
 section explains how to ensure that you have the correct PostgreSQL

--- a/omero/sysadmins/windows/service-tools.txt
+++ b/omero/sysadmins/windows/service-tools.txt
@@ -1,6 +1,12 @@
 OMERO.server Windows Service
 ============================
 
+.. warning:: OMERO 5.2 is the last major version which will feature Windows
+    support for OMERO.server and OMERO.web deployment. See
+    `this blog post <http://blog.openmicroscopy.org/tech-issues/future-plans/deployment/2016/03/22/windows-support/>`_ for details. If you are installing a new server, we highly
+    recommend you use a different OS (see
+    :doc:`/sysadmins/version-requirements`).
+
 OMERO.server installs a Windows Service to make the startup of the software
 automatic at Windows boot time.
 


### PR DESCRIPTION
See https://trello.com/c/tVSjHnee/432-add-warnings-for-windows-end-of-support-to-5-2-3-sysadmin-docs - as pointed out by @aleksandra-tarkowska - as well as updating the version requirements page, we should warn new sysadmins starting with 5.2 that Windows is best avoided.

I went with these pages on the assumption that would be enough for people to notice, but I can add the warning to all the windows installation folder pages if anyone thinks that is necessary.
