### PR TITLE
avoid link checking for Blitz API requests

### DIFF
--- a/omero/conf.py
+++ b/omero/conf.py
@@ -128,4 +128,4 @@ linkcheck_ignore += [r'http://localhost:\d+/?', 'http://localhost/',
     r'^https?://www\.openmicroscopy\.org/site/team/.*',
     r'.*[.]?example\.com/.*',
     r'^https://spreadsheets.google.com/.*',
-    r'/slice2html/omero/cmd/.*\.html']
+    r'http://downloads\.openmicroscopy\.org/latest/omero5\.3/api/slice2html/omero/cmd/.*\.html']

--- a/omero/conf.py
+++ b/omero/conf.py
@@ -127,4 +127,5 @@ linkcheck_ignore += [r'http://localhost:\d+/?', 'http://localhost/',
     'http://www.hibernate.org',
     r'^https?://www\.openmicroscopy\.org/site/team/.*',
     r'.*[.]?example\.com/.*',
-    r'^https://spreadsheets.google.com/.*']
+    r'^https://spreadsheets.google.com/.*',
+    r'/slice2html/omero/cmd/.*\.html']


### PR DESCRIPTION
Allow docs to refer to Blitz API docs not yet staged; see https://github.com/openmicroscopy/ome-documentation/pull/1441#issuecomment-205184417. To be closed once `5.3.0-m2` is tagged.
