### PR TITLE
rewrite how to access information on Quartz cron expressions

### DIFF
--- a/omero/sysadmins/config.txt
+++ b/omero/sysadmins/config.txt
@@ -1112,9 +1112,12 @@ pixeldata processing.
 .. |cron| replace::
   Cron Format: seconds minutes hours day-of-month month day-of-week year
   (optional). For example, "0,30 * * * * ?" is equivalent to running every
-  30 seconds. For more information, see the `CronTrigger Tutorial`_.
+  30 seconds. For more information download the latest *1.x version* of
+  the `Quartz Job Scheduler`_ and review
+  :file:`docs/api/org/quartz/CronExpression.html` within the distribution.
 
-.. _CronTrigger Tutorial: http://quartz-scheduler.org/documentation/quartz-1.x/tutorials/crontrigger
+.. _Quartz Job Scheduler:
+  http://www.quartz-scheduler.org/downloads/
 
 |cron|
 


### PR DESCRIPTION
Unfortunately the version of Quartz we use is so ancient that one must now dig somewhat to find documentation. Staged at http://www.openmicroscopy.org/site/support/omero5.2-staging/sysadmins/config.html.
