### PR TITLE
Update the Consortium CI page post migration of the FLIMfit jobs

### DIFF
--- a/contributing/ci-consortium.txt
+++ b/contributing/ci-consortium.txt
@@ -13,12 +13,8 @@ Jenkins.
 		* Release jobs
 
 	-	* FLIMfit
-		* | :term:`FLIMfit-latest-mac`
-		  | :term:`FLIMfit-latest-win`
-		* | :term:`FLIMfit-release`
-		  | :term:`FLIMfit-release-mac`
-		  | :term:`FLIMfit-release-win`
-		  | :term:`FLIMfit-release-downloads`
+		*
+		* :term:`FLIMfit-release-downloads`
 
 	-	* OMERO.mtools
 		*
@@ -37,53 +33,9 @@ FLIMfit
 ^^^^^^^
 
 The source code for the FLIMfit is hosted under
-https://github.com/openmicroscopy/Imperial-FLIMfit
+https://github.com/imperial-photonics/FLIMfit
 
 .. glossary::
-
-	:jenkinsjob:`FLIMfit-latest-mac`
-
-		This job is used to build the latest Mac OS X compiled version of
-		FLIMfit with OMERO 5.1
-
-		#. Polls the repo for SCM change
-		#. Checks out the `master` branch of FLIMfit
-		#. Build FLIMfit using :file:`compile.m`
-		#. Trigger `FLIMfit-latest-win`
-
-	:jenkinsjob:`FLIMfit-latest-win`
-
-		This job is used to build the latest Windows compiled version of
-		FLIMfit with OMERO 5.1
-
-		#. Checks out the `master` branch of FLIMfit
-		#. Build FLIMfit using :file:`compile.m`
-
-	:jenkinsjob:`FLIMfit-release`
-
-		This job is used to prepare a release of FLIMfit and
-
-		#. Trigger :term:`FLIMfit-release-mac` and
-		   :term:`FLIMfit-release-win`
-		#. Upon completion, trigger :term:`FLIMfit-release-downloads`
-		
-		See :jenkinsjob:`the build graph <FLIMfit-release/lastSuccessfulBuild/BuildGraph>`
-
-	:jenkinsjob:`FLIMfit-release-mac`
-
-		This job is used to build the release Mac OS X compiled version of
-		FLIMfit with OMERO 5.1
-
-		#. Build FLIMfit using :file:`compile.m`
-		#. Copy the FLIMfit artifacts over SSH to
-		   :file:`/ome/apache_repo/public/flimfit/RELEASE`
-
-	:jenkinsjob:`FLIMfit-release-win`
-
-		This job is used to build the release Windows compiled version of
-		FLIMfit with OMERO 5.1
-
-		#. Build FLIMfit using :file:`compile.m`
 
 	:jenkinsjob:`FLIMfit-release-downloads`
 
@@ -93,10 +45,10 @@ https://github.com/openmicroscopy/Imperial-FLIMfit
 		   https://github.com/openmicroscopy/ome-release
 		#. Merge PRs opened against `develop`
 		#. Copy the FLIMfit Windows artifacts over SSH to
-		   :file:`/ome/apache_repo/public/flimfit/RELEASE`
+		   :file:`/ome/www/download.openmicroscopy.org/flimfit/RELEASE`
 		#. Build the FLIMfit downloads pages using :command:`make flimfit`
 		#. Copy the FLIMfit downloads page over SSH to
-		   :file:`/ome/apache_repo/public/flimfit/RELEASE`
+		   :file:`/ome/www/download.openmicroscopy.org/flimfit/RELEASE`
 
 OMERO.mtools
 ^^^^^^^^^^^^
@@ -110,7 +62,7 @@ OMERO.mtools
 		#. Merge PRs opened against `develop`
 		#. Build the OMERO.mtools downloads pages using :command:`make mtools`
 		#. Copy the OMERO.mtools downloads page over SSH to
-		   :file:`/ome/apache_repo/public/mtools/RELEASE`
+		   :file:`/ome/www/download.openmicroscopy.org/mtools/RELEASE`
 
 OMERO.webtagging
 ^^^^^^^^^^^^^^^^
@@ -124,12 +76,12 @@ OMERO.webtagging
 		#. Download the :envvar:`RELEASE` artifacts from
 		   https://github.com/MicronOxford/webtagging
 		#. Copy the OMERO.webtagging source zip over SSH to
-		   :file:`/ome/apache_repo/public/webtagging/RELEASE`
+		   :file:`/ome/www/download.openmicroscopy.org/webtagging/RELEASE`
 		#. Merge PRs opened against `develop`
 		#. Build the OMERO.webtagging downloads pages using
 		   :command:`make webtagging`
 		#. Copy the OMERO.webtagging downloads page over SSH to
-		   :file:`/ome/apache_repo/public/webtagging/RELEASE`
+		   :file:`/ome/www/download.openmicroscopy.org/webtagging/RELEASE`
 
 
 
@@ -151,7 +103,7 @@ u-track
 
 		#. Build u-track
 		#. Copy the u-track artifacts over SSH to
-		   :file:`/ome/apache_repo/public/u-track/RELEASE`
+		   :file:`/ome/www/download.openmicroscopy.org/u-track/RELEASE`
 		#. Trigger :term:`U-TRACK-release-downloads`
 
 	:jenkinsjob:`U-TRACK-release-downloads`
@@ -163,4 +115,4 @@ u-track
 		#. Merge PRs opened against `develop`
 		#. Build the u-track downloads pages using :command:`make u-track`
 		#. Copy the u-track downloads page over SSH to
-		   :file:`/ome/apache_repo/public/u-track/RELEASE`
+		   :file:`/ome/www/download.openmicroscopy.org/u-track/RELEASE`


### PR DESCRIPTION
- Fix the FLIMfit source code repository name
- Remove all archived FLIMFit jobs
- Remove remaining references to apache_repo
