### PR TITLE
revert: avoid link checking for Blitz API requests

### DIFF
--- a/omero/conf.py
+++ b/omero/conf.py
@@ -126,5 +126,4 @@ linkcheck_ignore += [r'http://localhost:\d+/?', 'http://localhost/',
     'http://www.hibernate.org',
     r'^https?://www\.openmicroscopy\.org/site/team/.*',
     r'.*[.]?example\.com/.*',
-    r'^https://spreadsheets.google.com/.*',
-    r'/slice2html/omero/cmd/.*\.html']
+    r'^https://spreadsheets.google.com/.*']

--- a/omero/conf.py
+++ b/omero/conf.py
@@ -127,4 +127,4 @@ linkcheck_ignore += [r'http://localhost:\d+/?', 'http://localhost/',
     r'^https?://www\.openmicroscopy\.org/site/team/.*',
     r'.*[.]?example\.com/.*',
     r'^https://spreadsheets.google.com/.*',
-    r'http://downloads\.openmicroscopy\.org/latest/omero5\.3/api/slice2html/omero/cmd/.*\.html']
+    r'/slice2html/omero/cmd/.*\.html']


### PR DESCRIPTION
See #1443 and https://trello.com/c/mMCeEwYn/49-revert-https-github-com-openmicroscopy-ome-documentation-pull-1443. CI should remain green despite resurrecting the link checks for the Ice docs.
