### PR TITLE
fixing the incorrect usage of Ice.IPv6 property in the example.

### DIFF
--- a/omero/sysadmins/troubleshooting.txt
+++ b/omero/sysadmins/troubleshooting.txt
@@ -112,7 +112,7 @@ Server fails to start
    restarting OMERO, the registry will be automatically re-created.
 5. If you see an error message mentioning "Protocol family unavailable",
    you will need to set the :property:`Ice.IPv6` property with
-   :omerocmd:`config set IPv6 0`.
+   :omerocmd:`config set Ice.IPv6 0`.
 6. If you upgraded from a 5.0.2 server or older and copied the entire content
    of the :file:`etc/grid` directory from the old server to the new server,
    you will need to revert the changes made to :file:`templates.xml` to


### PR DESCRIPTION
The property documented https://www.openmicroscopy.org/site/support/omero5.1/sysadmins/config.html#ice-ipv6 is `Ice.IPv6`, where it's usage in the troubleshooting page here is just `IPv6`. 

In the community, users have been copying our example, as they should, and expecting it to work, as is natural.

cf https://twitter.com/robpumphrey/status/722749789159366656
cf https://www.openmicroscopy.org/community/viewtopic.php?f=5&t=8039

Example has been updated to the correct usage of the property.
