### PR TITLE
Pillow version

### DIFF
--- a/omero/sysadmins/unix/install-web.txt
+++ b/omero/sysadmins/unix/install-web.txt
@@ -28,8 +28,7 @@ Prerequisites
 
 -  Python 2.7
 
-   -  `Pillow`_ should be available for your distribution. We currently do not
-      support version 3.0 due to a limitation in `OMERO.figure <http://figure.openmicroscopy.org/>`_
+   -  `Pillow`_ should be available for your distribution.
 
    -  `Matplotlib`_ should be available for your distribution
 

--- a/omero/sysadmins/unix/server-installation.txt
+++ b/omero/sysadmins/unix/server-installation.txt
@@ -217,8 +217,7 @@ The following Python packages are required:
        and `Django 1.8`_ are required for security support.
 
 .. [2] Make sure to have `libjpeg <http://libjpeg.sourceforge.net/>`_ 
-       installed when building `Pillow`_. Version 3.0.0 is currently
-       not supported by OMERO.figure.
+       installed when building `Pillow`_.
 
 .. [3] May already have been installed as a dependency of Matplot Lib.
 

--- a/omero/sysadmins/windows/install-web.txt
+++ b/omero/sysadmins/windows/install-web.txt
@@ -39,8 +39,7 @@ Prerequisites
 
 -  Python 2.7
 
-   -  `Pillow`_ should be available for your distribution. We currently do not
-      support version 3.0 due to a limitation in `OMERO.figure <http://figure.openmicroscopy.org/>`_
+   -  `Pillow`_ should be available for your distribution.
 
    -  `Matplotlib`_ should be available for your distribution
 

--- a/omero/sysadmins/windows/server-installation.txt
+++ b/omero/sysadmins/windows/server-installation.txt
@@ -544,7 +544,7 @@ The following are optional depending on what services you require:
       - OMERO.web
       - `Django website <https://www.djangoproject.com/>`_
 
-    * - Pillow (2.9.0)
+    * - Pillow
       - OMERO.web and Figure Export
       - `Pillow`_
 


### PR DESCRIPTION
- Remove pillow version in text
- Do not remove it from files in `/unix/walkthrough` 
  This is taken care of by omero-install
