### PR TITLE
Nginx version

### DIFF
--- a/omero/sysadmins/version-requirements.txt
+++ b/omero/sysadmins/version-requirements.txt
@@ -187,8 +187,8 @@ The planned changes for 5.2 depend upon our support of
 
 * nginx
 
-  * [5.2] 1.0 dropped, 1.2 deprecated, 1.4 deprecated, 1.6 supported, 1.8 or 1.9 recommemded
-  * [5.3] 1.2 dropped, 1.4 dropped, 1.6 supported, 1.8 or 1.9 recommemded
+  * [5.2] 1.0 dropped, 1.2 deprecated, 1.4 deprecated, 1.6 supported, 1.8 or 1.9 recommended
+  * [5.3] 1.2 dropped, 1.4 dropped, 1.6 supported, 1.8 or 1.9 recommended
   * Rationale: 1.4 is the Ubuntu 14.04 and Debian 8 version.
     Removed for 5.3 accordingly.
 

--- a/omero/sysadmins/version-requirements.txt
+++ b/omero/sysadmins/version-requirements.txt
@@ -187,10 +187,8 @@ The planned changes for 5.2 depend upon our support of
 
 * nginx
 
-  * [5.2] 1.0 dropped, 1.2 deprecated, 1.4 deprecated, 1.6 supported, 1.8 or 1.9 recommended
-  * [5.3] 1.2 dropped, 1.4 dropped, 1.6 supported, 1.8 or 1.9 recommended
-  * Rationale: 1.4 is the Ubuntu 14.04 and Debian 8 version.
-    Removed for 5.3 accordingly.
+  * [5.2] 1.2 deprecated, 1.4 deprecated, 1.6 supported, 1.8+ recommended
+  * [5.3] 1.2 dropped, 1.4 dropped, 1.6 supported, 1.8+ recommended
 
 Support levels
 ==============

--- a/omero/sysadmins/version-requirements.txt
+++ b/omero/sysadmins/version-requirements.txt
@@ -187,8 +187,8 @@ The planned changes for 5.2 depend upon our support of
 
 * nginx
 
-  * [5.2] 1.2 deprecated, 1.4 deprecated, 1.6 supported, 1.8+ recommended
-  * [5.3] 1.2 dropped, 1.4 dropped, 1.6 supported, 1.8+ recommended
+  * [5.2] 1.4 deprecated, 1.6 supported, 1.8 recommended, 1.10 supported
+  * [5.3] 1.4 dropped, 1.6 supported, 1.8 supported, 1.10 recommended
 
 Support levels
 ==============
@@ -1701,14 +1701,14 @@ nginx
     * - 1.8
       - from Apr 2015
       - TBA
+      - Unsupported
       - Recommended
-      - Recommended
-      - Recommended
+      - Supported
     * - 1.10
       - from April 2016
       - TBA
-      - Recommended
-      - Recommended
+      - Unsupported
+      - Supported
       - Recommended
 
 Distribution support
@@ -1738,8 +1738,8 @@ Distribution support
       - 21, (22)
       - 14.10, (15.04)
       - (8.0), 7.0 bpo
-      - Yes
-      - Yes
+      - N/A
+      - N/A
     * - 1.8
       - N/A
       - N/A
@@ -1750,7 +1750,7 @@ Distribution support
     * - 1.10
       - N/A
       - N/A
-      - N/A
+      - 16.04
       - N/A
       - N/A
       - N/A

--- a/omero/sysadmins/version-requirements.txt
+++ b/omero/sysadmins/version-requirements.txt
@@ -187,7 +187,7 @@ The planned changes for 5.2 depend upon our support of
 
 * nginx
 
-  * [5.2] 1.4 deprecated, 1.6 supported, 1.8 recommended, 1.10 supported
+  * [5.2] 1.4 deprecated, 1.6 supported, 1.8 recommended, 1.10 upcoming
   * [5.3] 1.4 dropped, 1.6 supported, 1.8 supported, 1.10 recommended
 
 Support levels
@@ -1708,7 +1708,7 @@ nginx
       - from April 2016
       - TBA
       - Unsupported
-      - Supported
+      - Upcoming
       - Recommended
 
 Distribution support

--- a/omero/sysadmins/version-requirements.txt
+++ b/omero/sysadmins/version-requirements.txt
@@ -1691,7 +1691,7 @@ nginx
       - to Mar 2014
       - Supported
       - Deprecated
-      - Supported
+      - Dropped
     * - 1.6
       - from Apr 2014
       - TBA

--- a/omero/sysadmins/version-requirements.txt
+++ b/omero/sysadmins/version-requirements.txt
@@ -187,10 +187,10 @@ The planned changes for 5.2 depend upon our support of
 
 * nginx
 
-  * [5.2] 1.0 dropped, 1.2 deprecated, 1.4 supported, 1.6 recommemded
-  * [5.3] 1.2 dropped, 1.4 deprecated, 1.6 recommemded
+  * [5.2] 1.0 dropped, 1.2 deprecated, 1.4 deprecated, 1.6 supported, 1.8 or 1.9 recommemded
+  * [5.3] 1.2 dropped, 1.4 dropped, 1.6 supported, 1.8 or 1.9 recommemded
   * Rationale: 1.4 is the Ubuntu 14.04 and Debian 8 version.
-    Deprecate for 5.3 accordingly.
+    Removed for 5.3 accordingly.
 
 Support levels
 ==============
@@ -1728,13 +1728,6 @@ Distribution support
       - Debian
       - Homebrew
       - FreeBSD Ports
-    * - 1.0
-      - N/A
-      - N/A
-      - 12.04 (1.1)
-      - N/A
-      - N/A
-      - N/A
     * - 1.2
       - N/A
       - N/A
@@ -1750,12 +1743,26 @@ Distribution support
       - N/A
       - N/A
     * - 1.6
-      - N/A
+      - EPEL
       - 21, (22)
       - 14.10, (15.04)
       - (8.0), 7.0 bpo
       - Yes
       - Yes
+    * - 1.8
+      - N/A
+      - N/A
+      - N/A
+      - N/A
+      - Yes
+      - Yes
+    * - 1.9
+      - N/A
+      - N/A
+      - 14.10
+      - (8.0), 7.0 bpo
+      - N/A
+      - N/A
     * - Details
       - 
       - 

--- a/omero/sysadmins/version-requirements.txt
+++ b/omero/sysadmins/version-requirements.txt
@@ -1688,26 +1688,26 @@ nginx
       - OMERO 5.1
       - OMERO 5.2
       - OMERO 5.3
-    * - 1.0
-      - from Apr 2011
-      - to Apr 2012
-      - Deprecated
-      - Dropped
-      - Dropped
-    * - 1.2
-      - from Apr 2012
-      - to May 2013
-      - Supported
-      - Deprecated
-      - Deprecated
     * - 1.4
       - from Apr 2013
       - to Mar 2014
       - Supported
-      - Supported
+      - Deprecated
       - Supported
     * - 1.6
       - from Apr 2014
+      - TBA
+      - Recommended
+      - Supported
+      - Supported
+    * - 1.8
+      - from Apr 2015
+      - TBA
+      - Recommended
+      - Recommended
+      - Recommended
+    * - 1.10
+      - from April 2016
       - TBA
       - Recommended
       - Recommended
@@ -1728,13 +1728,6 @@ Distribution support
       - Debian
       - Homebrew
       - FreeBSD Ports
-    * - 1.2
-      - N/A
-      - N/A
-      - 13.04
-      - 7.0, 6.0 bpo
-      - N/A
-      - N/A
     * - 1.4
       - N/A
       - 19, 20
@@ -1756,11 +1749,11 @@ Distribution support
       - N/A
       - Yes
       - Yes
-    * - 1.9
+    * - 1.10
       - N/A
       - N/A
-      - 14.10
-      - (8.0), 7.0 bpo
+      - N/A
+      - N/A
       - N/A
       - N/A
     * - Details


### PR DESCRIPTION
This replaces #1439 as Ola is too busy to follow up. Staged at https://www.openmicroscopy.org/site/support/omero5.2-staging/sysadmins/version-requirements.html#nginx

I've hopefully followed the comments re: what we support for 5.2.3 now. I couldn't make head nor tail of the Ubuntu and Debian support refs so @rleigh-dundee perhaps you'll check and let me know if the distribution support table needs updating.
