### PR TITLE
Fix generateDS link & remove duplicate

### DIFF
--- a/formats/developers/EnumTool.txt
+++ b/formats/developers/EnumTool.txt
@@ -134,12 +134,12 @@ Acknowledgments
 ---------------
 
 Thanks to `Dave Kuhlman <http://www.davekuhlman.org>`_ for his work on
-`generateDS <http://www.davekuhlman.org/generateDS.html>`_ which
-Enum Tool makes heavy use of internally.
+`generateDS <http://www.davekuhlman.org/pages/generateds-generate-data-structures-from-xml-schema.html>`_
+which Enum Tool makes heavy use of internally.
 
 --------------
 
 .. SeeAlso::
 
     - `http://genshi.edgewall.org/ <http://genshi.edgewall.org/>`_
-    - `http://www.davekuhlman.org/generateDS.html <http://www.davekuhlman.org/generateDS.html>`_
+


### PR DESCRIPTION
Dave Kuhlman released an updated version yesterday and the URL has changed.

Should make https://ci.openmicroscopy.org/view/Docs/job/FORMATS-merge-docs/ green again 

Staged at http://www.openmicroscopy.org/site/support/ome-model-staging/developers/EnumTool.html
