### PR TITLE
Contributing: DEV modifications

### DIFF
--- a/contributing/ci-consortium.txt
+++ b/contributing/ci-consortium.txt
@@ -12,10 +12,6 @@ Jenkins.
 		* Latest jobs
 		* Release jobs
 
-	-	* FLIMfit
-		*
-		* :term:`FLIMfit-release-downloads`
-
 	-	* OMERO.mtools
 		*
 		* :term:`MTOOLS-release-downloads`
@@ -24,31 +20,12 @@ Jenkins.
 		*
 		* :term:`WEBTAGGING-release-downloads`
 
-	-	* u-track
-		* | :term:`U-TRACK-latest`
-		* | :term:`U-TRACK-release`
-		  | :term:`U-TRACK-release-downloads`
-
 FLIMfit
 ^^^^^^^
 
 The source code for the FLIMfit is hosted under
-https://github.com/imperial-photonics/FLIMfit
-
-.. glossary::
-
-	:jenkinsjob:`FLIMfit-release-downloads`
-
-		This job is used to build the FLIMfit downloads page
-
-		#. Checks out the `develop` branch of
-		   https://github.com/openmicroscopy/ome-release
-		#. Merge PRs opened against `develop`
-		#. Copy the FLIMfit Windows artifacts over SSH to
-		   :file:`/ome/www/download.openmicroscopy.org/flimfit/RELEASE`
-		#. Build the FLIMfit downloads pages using :command:`make flimfit`
-		#. Copy the FLIMfit downloads page over SSH to
-		   :file:`/ome/www/download.openmicroscopy.org/flimfit/RELEASE`
+https://github.com/imperial-photonics/FLIMfit. Since 4.11.1, the downloads are
+hosted at http://flimfit.org/.
 
 OMERO.mtools
 ^^^^^^^^^^^^
@@ -82,37 +59,3 @@ OMERO.webtagging
 		   :command:`make webtagging`
 		#. Copy the OMERO.webtagging downloads page over SSH to
 		   :file:`/ome/www/download.openmicroscopy.org/webtagging/RELEASE`
-
-
-
-u-track
-^^^^^^^
-
-.. glossary::
-
-	:jenkinsjob:`U-TRACK-latest`
-
-		This job is used to build the latest version of u-track
-
-		#. Build u-track
-		#. Runs the unit and integration tests
-
-	:jenkinsjob:`U-TRACK-release`
-
-		This job is used to build the release artifacts for u-track
-
-		#. Build u-track
-		#. Copy the u-track artifacts over SSH to
-		   :file:`/ome/www/download.openmicroscopy.org/u-track/RELEASE`
-		#. Trigger :term:`U-TRACK-release-downloads`
-
-	:jenkinsjob:`U-TRACK-release-downloads`
-
-		This job is used to build the u-track downloads page
-
-		#. Checks out the `develop` branch of
-		   https://github.com/openmicroscopy/ome-release
-		#. Merge PRs opened against `develop`
-		#. Build the u-track downloads pages using :command:`make u-track`
-		#. Copy the u-track downloads page over SSH to
-		   :file:`/ome/www/download.openmicroscopy.org/u-track/RELEASE`

--- a/contributing/ci-docs.txt
+++ b/contributing/ci-docs.txt
@@ -185,7 +185,7 @@ The branch for the 5.2.x series of the OMERO documentation is dev_5_2.
 	:jenkinsjob:`OMERO-5.2-latest-docs`
 
 		This job is used to build the dev_5_2 branch of the OMERO
-		documentation and publish the official documentation for the 5.1.x
+		documentation and publish the official documentation for the 5.2.x
 		release of OMERO
 
 		#. |sphinxbuild|
@@ -216,18 +216,18 @@ The branch for the 5.3.x series of the OMERO documentation is develop.
 	:jenkinsjob:`OMERO-DEV-latest-docs`
 
 		This job is used to review the PRs opened against the develop branch
-		of the OMERO documentation
+		of the OMERO 5.3.x documentation
 
 		#. |merge|
 		#. |sphinxbuild|
 		#. |linkcheck|
-		#. |ssh-doc| :file:`omero-5.2.tmp`
+		#. |ssh-doc| :file:`omero-5.3.tmp`
 		#. |deploy-doc| http://www.openmicroscopy.org/site/support/omero5.3/
 
 	:jenkinsjob:`OMERO-DEV-merge-docs`
 
 		This job is used to review the PRs opened against the develop branch
-		of the OMERO documentation
+		of the OMERO 5.3.x documentation
 
 		#. |merge|
 		#. Pushes the branch to :omedoc_scc_branch:`develop/merge/daily`

--- a/contributing/ci-docs.txt
+++ b/contributing/ci-docs.txt
@@ -8,32 +8,39 @@ tab of Jenkins.
 	:header-rows: 1
 
 	-	* Job task
-		* 5.1.x series
-		* 5.2.x series
+		* OMERO 5.2.x series
+		* OMERO 5.3.x series
 
 	-	* Builds the latest OMERO documentation for publishing
-		* :term:`OMERO-5.1-latest-docs`
+		* :term:`OMERO-5.2-latest-docs`
 		* :term:`OMERO-DEV-latest-docs`
+
+	-	* Builds the OMERO documentation for review
+		* :term:`OMERO-5.2-merge-docs`
+		* :term:`OMERO-DEV-merge-docs`
+
+	-	* Builds the auto-generated OMERO documentation
+		*
+		* :term:`OMERO-DEV-latest-docs-autogen`
+
+	-	* Builds the auto-generated OMERO documentation for review
+		*
+		* :term:`OMERO-DEV-merge-docs-autogen`
+
+.. list-table::
+	:header-rows: 1
+
+	-	* Job task
+		* Bio-Formats 5.1.x series
+		* Bio-Formats 5.2.x series
 
 	-	* Builds the latest Bio-Formats documentation for publishing
 		* :term:`BIOFORMATS-5.1-latest-docs`
 		* :term:`BIOFORMATS-DEV-latest-docs`
 
-	-	* Builds the OMERO documentation for review
-		* :term:`OMERO-5.1-merge-docs`
-		* :term:`OMERO-DEV-merge-docs`
-
 	-	* Builds the Bio-Formats documentation for review
 		* :term:`BIOFORMATS-5.1-merge-docs`
 		* :term:`BIOFORMATS-DEV-merge-docs`
-
-	-	* Builds the auto-generated OMERO documentation
-		* :term:`OMERO-5.1-latest-docs-autogen`
-		* :term:`OMERO-DEV-latest-docs-autogen`
-
-	-	* Builds the auto-generated OMERO documentation for review
-		* :term:`OMERO-5.1-merge-docs-autogen`
-		* :term:`OMERO-DEV-merge-docs-autogen`
 
 	-	* Builds the auto-generated Bio-Formats documentation
 		* :term:`BIOFORMATS-5.1-latest-docs-autogen`
@@ -42,7 +49,6 @@ tab of Jenkins.
 	-	* Builds the auto-generated Bio-Formats documentation for review
 		* :term:`BIOFORMATS-5.1-merge-docs-autogen`
 		* :term:`BIOFORMATS-DEV-merge-docs-autogen`
-
 
 The OME Model, OME help and OME Contributing documentation sets are
 independent of the current OMERO/Bio-Formats version.
@@ -113,25 +119,12 @@ necromancer.openmicroscopy.org.uk under the
 :program:`scc deploy` command. The :jenkinsjob:`OME-docs-deployment-setup` job
 is used to initialize new deployment folders.
 
-5.1.x series
-^^^^^^^^^^^^
+Bio-Formats 5.1.x series
+^^^^^^^^^^^^^^^^^^^^^^^^
 
-The branch for the 5.1.x series of the OMERO/Bio-Formats documentation is
-dev_5_1.
+The branch for the 5.1.x series of the OMERO documentation is dev_5_1.
 
 .. glossary::
-
-	:jenkinsjob:`OMERO-5.1-latest-docs`
-
-		This job is used to build the dev_5_1 branch of the OMERO
-		documentation and publish the official documentation for the 5.1.x
-		release of OMERO
-
-		#. |sphinxbuild|
-		#. |linkcheck|
-		#. If the build is promoted,
-			#. |ssh-doc| :file:`omero-5.1-release.tmp`
-			#. |deploy-doc| http://www.openmicroscopy.org/site/support/omero5.1/
 
 	:jenkinsjob:`BIOFORMATS-5.1-latest-docs`
 
@@ -144,17 +137,6 @@ dev_5_1.
 		#. If the build is promoted,
 			#. |ssh-doc| :file:`bf-5.1-release.tmp`
 			#. |deploy-doc| http://www.openmicroscopy.org/site/support/bio-formats5.1/
-
-	:jenkinsjob:`OMERO-5.1-merge-docs`
-
-		This job is used to review the PRs opened against the dev_5_1 branch
-		of the OMERO documentation
-
-		#. |merge|
-		#. |sphinxbuild|
-		#. |linkcheck|
-		#. |ssh-doc| :file:`omero-5.1-staging.tmp`
-		#. |deploy-doc| http://www.openmicroscopy.org/site/support/omero5.1-staging/
 
 	:jenkinsjob:`BIOFORMATS-5.1-merge-docs`
 
@@ -193,34 +175,41 @@ dev_5_1.
 		#. Pushes the auto-generated changes to 
 		   :bf_scc_branch:`dev_5_1/merge/autogen`
 
-	:jenkinsjob:`OMERO-5.1-latest-docs-autogen`
-
-		This job is used to build the latest auto-generated pages for the
-		dev_5_1 branch of the OMERO documentation
-
-		#. Checks out the dev_5_1 branch of ome-documentation.git_
-		#. Downloads the OMERO.server and OMERO.clients from
-		   :term:`OMERO-5.1-latest`
-		#. Runs the :file:`omero/autogen_docs` autogeneration script
-		#. Pushes the auto-generated changes to
-		   :omedoc_scc_branch:`dev_5_1/latest/autogen`
-
-	:jenkinsjob:`OMERO-5.1-merge-docs-autogen`
-
-		This job is used to review the component auto-generation for the
-		dev_5_1 branch of the OMERO documentation
-
-		#. Checks out :omedoc_scc_branch:`dev_5_1/merge/daily`
-		#. Downloads the OMERO.server and OMERO.clients from
-		   :term:`OMERO-5.1-merge-build`
-		#. Runs the :file:`omero/autogen_docs` autogeneration script
-		#. Pushes the auto-generated changes to
-		   :omedoc_scc_branch:`dev_5_1/merge/autogen`
-
 OMERO 5.2.x series
 ^^^^^^^^^^^^^^^^^^
 
-The branch for the 5.2.x series of the OMERO documentation is develop.
+The branch for the 5.2.x series of the OMERO documentation is dev_5_2.
+
+.. glossary::
+
+	:jenkinsjob:`OMERO-5.2-latest-docs`
+
+		This job is used to build the dev_5_2 branch of the OMERO
+		documentation and publish the official documentation for the 5.1.x
+		release of OMERO
+
+		#. |sphinxbuild|
+		#. |linkcheck|
+		#. If the build is promoted,
+			#. |ssh-doc| :file:`omero-5.2-release.tmp`
+			#. |deploy-doc| http://www.openmicroscopy.org/site/support/omero5.2/
+
+
+	:jenkinsjob:`OMERO-5.2-merge-docs`
+
+		This job is used to review the PRs opened against the dev_5_2 branch
+		of the OMERO documentation
+
+		#. |merge|
+		#. |sphinxbuild|
+		#. |linkcheck|
+		#. |ssh-doc| :file:`omero-5.2-staging.tmp`
+		#. |deploy-doc| http://www.openmicroscopy.org/site/support/omero5.2-staging/
+
+OMERO 5.3.x series
+^^^^^^^^^^^^^^^^^^
+
+The branch for the 5.3.x series of the OMERO documentation is develop.
 
 .. glossary::
 
@@ -233,7 +222,7 @@ The branch for the 5.2.x series of the OMERO documentation is develop.
 		#. |sphinxbuild|
 		#. |linkcheck|
 		#. |ssh-doc| :file:`omero-5.2.tmp`
-		#. |deploy-doc| http://www.openmicroscopy.org/site/support/omero5.2/
+		#. |deploy-doc| http://www.openmicroscopy.org/site/support/omero5.3/
 
 	:jenkinsjob:`OMERO-DEV-merge-docs`
 
@@ -244,8 +233,8 @@ The branch for the 5.2.x series of the OMERO documentation is develop.
 		#. Pushes the branch to :omedoc_scc_branch:`develop/merge/daily`
 		#. |sphinxbuild|
 		#. |linkcheck|
-		#. |ssh-doc| :file:`omero-5.2-staging.tmp`
-		#. |deploy-doc| http://www.openmicroscopy.org/site/support/omero5.2-staging/
+		#. |ssh-doc| :file:`omero-5.3-staging.tmp`
+		#. |deploy-doc| http://www.openmicroscopy.org/site/support/omero5.3-staging/
 
 	:jenkinsjob:`OMERO-DEV-latest-docs-autogen`
 

--- a/contributing/ci-omero.txt
+++ b/contributing/ci-omero.txt
@@ -5,60 +5,42 @@ OMERO jobs
     :header-rows: 1
 
     -   * Job task
-        * 5.1.x series
         * DEV series
         * Breaking series
 
     -   * Builds the latest OMERO artifacts
-        * :term:`OMERO-5.1-latest`
         * :term:`OMERO-DEV-latest`
         *
 
     -   * Deploys the latest OMERO server
-        * | :term:`OMERO-5.1-latest-deploy`
-          | :term:`OMERO-5.1-latest-deploy-win`
-          | :term:`OMERO-5.1-latest-deploy-win2012`
         * :term:`OMERO-DEV-latest-deploy`
         *
 
     -   * Updates submodules
-        * :term:`OMERO-5.1-latest-submods`
-        *
+        * :term:`OMERO-DEV-latest-submods`
         *
 
     -   * Runs the daily OMERO merge builds
-        * :term:`OMERO-5.1-merge-daily`
         * :term:`OMERO-DEV-merge-daily`
         * :term:`OMERO-DEV-breaking-trigger`
 
     -   * Merges the PRs
-        * :term:`OMERO-5.1-merge-push`
         * :term:`OMERO-DEV-merge-push`
         * :term:`OMERO-DEV-breaking-push`
 
     -   * Builds the merge OMERO artifacts
-        * :term:`OMERO-5.1-merge-build`
         * :term:`OMERO-DEV-merge-build`
         * :term:`OMERO-DEV-breaking-build`
 
     -   * Deploys the merge OMERO server
-        * | :term:`OMERO-5.1-merge-deploy`
-          | :term:`OMERO-5.1-merge-deploy-win`
-          | :term:`OMERO-5.1-merge-deploy-win2012`
         * :term:`OMERO-DEV-merge-deploy`
         * :term:`OMERO-DEV-breaking-deploy`
 
     -   * Runs the OMERO upgrade scripts
-        * :term:`OMERO-5.1-merge-upgrade`
         *
         * :term:`OMERO-DEV-breaking-upgrade`
 
     -   * Runs the OMERO integration tests
-        * | :term:`OMERO-5.1-merge-integration`
-          | :term:`OMERO-5.1-merge-integration-broken`
-          | :term:`OMERO-5.1-merge-integration-java`
-          | :term:`OMERO-5.1-merge-integration-python`
-          | :term:`OMERO-5.1-merge-integration-web`
         * | :term:`OMERO-DEV-merge-integration`
           | :term:`OMERO-DEV-merge-integration-broken`
           | :term:`OMERO-DEV-merge-integration-java`
@@ -71,23 +53,18 @@ OMERO jobs
           | :term:`OMERO-DEV-breaking-integration-web`
 
     -   * Runs the OMERO.matlab tests
-        * :term:`OMERO-5.1-merge-matlab`
         * :term:`OMERO-DEV-merge-matlab`
         *
 
     -   * Runs the robot framework tests
-        * :term:`OMERO-5.1-merge-robotframework`
         * :term:`OMERO-DEV-merge-robotframework`
         *
 
     -   * Installs OMERO using Homebrew
-        * :term:`OMERO-5.1-merge-homebrew`
-        *
+        * :term:`OMERO-DEV-merge-homebrew`
         *
 
     -   * Pushes SNAPSHOTS to Maven
-        * | :term:`OMERO-5.1-latest-maven`
-          | :term:`OMERO-5.1-merge-maven`
         * | :term:`OMERO-DEV-latest-maven`
           | :term:`OMERO-DEV-merge-maven`
         *
@@ -109,48 +86,6 @@ clients of the deployment jobs described above:
         * Hostname
         * Port
         * Webclient
-
-    -   * 5.1.x
-        * :term:`OMERO-5.1-merge-deploy`
-        * trout.openmicroscopy.org
-        * 4064
-        * https://trout.openmicroscopy.org/merge
-
-    -   * 5.1.x
-        * :term:`OMERO-5.1-merge-deploy-win`
-        * hake.openmicroscopy.org
-        * 4064
-        * http://hake.openmicroscopy.org/merge
-
-    -   * 5.1.x
-        * :term:`OMERO-5.1-merge-deploy-win2012`
-        * burbot.openmicroscopy.org
-        * 4064
-        * http://burbot.openmicroscopy.org/merge
-
-    -   * 5.1.x
-        * :term:`OMERO-5.1-latest-deploy`
-        * trout.openmicroscopy.org
-        * 14064
-        * https://trout.openmicroscopy.org/latest
-
-    -   * 5.1.x
-        * :term:`OMERO-5.1-latest-deploy-win`
-        * hake.openmicroscopy.org
-        * 14064
-        * http://hake.openmicroscopy.org/latest
-
-    -   * 5.1.x
-        * :term:`OMERO-5.1-latest-deploy-win2012`
-        * burbot.openmicroscopy.org
-        * 14064
-        * http://burbot.openmicroscopy.org/latest
-
-    -   * 5.1.x
-        * :term:`OMERO-5.1-merge-integration`
-        * trout.openmicroscopy.org
-        * 24064
-        * https://trout.openmicroscopy.org/integration
 
     -   * 5.2.x
         * :term:`OMERO-DEV-merge-deploy`
@@ -176,184 +111,6 @@ clients of the deployment jobs described above:
         * 34064
         * https://trout.openmicroscopy.org/breaking
 
-5.1.x series
-^^^^^^^^^^^^
-
-The branch for the 5.1.x series of OMERO is dev_5_1. All jobs are listed
-under the :jenkinsview:`5.1` view tab of Jenkins.
-
-.. glossary::
-
-    :jenkinsjob:`OMERO-5.1-latest`
-
-        This job builds the dev_5_1 branch of OMERO with Ice 3.4 or 3.5
-
-        #. |buildOMERO|
-        #. |archiveOMEROartifacts|
-
-        See :jenkinsjob:`the build graph <OMERO-5.1-latest/lastSuccessfulBuild/BuildGraph>`
-
-    :jenkinsjob:`OMERO-5.1-latest-deploy`
-
-        This job deploys the latest 5.1.x server (see
-        :ref:`deployment_servers`)
-
-    :jenkinsjob:`OMERO-5.1-latest-deploy-win`
-
-        This job deploys the latest 5.1.x server on Windows (see
-        :ref:`deployment_servers`)
-
-    :jenkinsjob:`OMERO-5.1-latest-deploy-win2012`
-
-        This job deploys the latest 5.1.x server on Windows 2012
-        (see :ref:`deployment_servers`)
-
-    :jenkinsjob:`OMERO-5.1-latest-submods`
-
-        This job updates the submodules on the dev_5_1 branch
-
-        #. |updatesubmodules| and pushes the merge branch to
-           :omero_scc_branch:`dev_5_1/latest/submodules`
-        #. If the submodules are updated, opens a new PR or updates the
-           existing dev_5_1 submodules PR
-
-    :jenkinsjob:`OMERO-5.1-merge-daily`
-
-        This job triggers all the morning merge builds listed below
-
-        #. Triggers :term:`OMERO-5.1-merge-push`
-        #. Triggers :term:`OMERO-5.1-merge-build` and
-           :term:`OMERO-5.1-merge-integration`
-        #. Triggers :term:`OMERO-5.1-merge-deploy`
-        #. Triggers other downstream merge jobs
-
-        See :jenkinsjob:`the build graph <OMERO-5.1-merge-daily/lastSuccessfulBuild/BuildGraph>`
-
-    :jenkinsjob:`OMERO-5.1-merge-push`
-
-        This job merges all the PRs opened against dev_5_1
-
-        #. |merge|
-        #. Pushes the branch to :omero_scc_branch:`dev_5_1/merge/daily`
-
-    :jenkinsjob:`OMERO-5.1-merge-build`
-
-        These jobs builds the OMERO components with Ice 3.4 or 3.5
-
-        #. Checks out :omero_scc_branch:`dev_5_1/merge/daily`
-        #. |buildOMERO| for each version of Ice
-        #. |archiveOMEROartifacts|
-
-    :jenkinsjob:`OMERO-5.1-merge-deploy`
-
-        This job deploys the merge 5.1.x server (see
-        :ref:`deployment_servers`)
-
-    :jenkinsjob:`OMERO-5.1-merge-deploy-win`
-
-        This job deploys the merge 5.1.x server on Windows (see
-        :ref:`deployment_servers`)
-
-    :jenkinsjob:`OMERO-5.1-merge-deploy-win2012`
-
-        This job deploys the merge 5.1.x server on Windows 2012
-        (see :ref:`deployment_servers`)
-
-    :jenkinsjob:`OMERO-5.1-merge-integration`
-
-        This job runs the integration tests of OMERO
-
-        #. Checks out :omero_scc_branch:`dev_5_1/merge/daily`
-        #. Builds OMERO.server and starts it
-        #. Runs the OMERO.java, OMERO.py and OMERO.web integration tests
-        #. Archives the results
-        #. Triggers downstream collection jobs:
-           :term:`OMERO-5.1-merge-integration-broken`,
-           :term:`OMERO-5.1-merge-integration-java`,
-           :term:`OMERO-5.1-merge-integration-python`,
-           :term:`OMERO-5.1-merge-integration-web`
-
-    :jenkinsjob:`OMERO-5.1-merge-integration-broken`
-
-        This job collects the OMERO.java broken test results
-
-        #. Receives TestNG results under
-           :file:`components/tools/OmeroJava/target/reports/broken` from
-           :term:`OMERO-5.1-merge-integration`,
-        #. Generates TestNG report
-
-    :jenkinsjob:`OMERO-5.1-merge-integration-java`
-
-        This job collects the OMERO.java integration test results
-
-        #. Receives TestNG results under
-           :file:`components/tools/OmeroJava/target/reports/integration` from
-           :term:`OMERO-5.1-merge-integration`,
-        #. Generates TestNG report
-
-    :jenkinsjob:`OMERO-5.1-merge-integration-python`
-
-        This job collects the OMERO.py integration test results
-
-        #. Receives pytest results under
-           :file:`components/tools/OmeroPy/target/reports` from
-           :term:`OMERO-5.1-merge-integration`,
-        #. Generates pytest report
-
-    :jenkinsjob:`OMERO-5.1-merge-integration-web`
-
-        This job collects the OMERO.web integration test results
-
-        #. Receives pytest results under
-           :file:`components/tools/OmeroWeb/target/reports` from
-           :term:`OMERO-5.1-merge-integration`,
-        #. Generates pytest report
-
-    :jenkinsjob:`OMERO-5.1-merge-matlab`
-
-        This job runs the OMERO.matlab tests
-
-        #. Checks out :omero_scc_branch:`dev_5_1/merge/daily`
-        #. Collects the MATLAB artifacts from :term:`OMERO-5.1-merge-build`
-        #. Runs the MATLAB unit tests under
-           :file:`components/tools/OmeroM/test/unit` and collect the results
-
-    :jenkinsjob:`OMERO-5.1-merge-maven`
-
-        This job is used to generate SNAPSHOT jars and push them to artifactory.
-
-        #. Runs :file:`docs/hudson/OMERO.sh`
-        #. Executes the `release-hudson` target for the `ome.unstable` repository.
-
-    :jenkinsjob:`OMERO-5.1-latest-maven`
-
-        The same as :term:`OMERO-5.1-merge-maven`, but pushes to `ome.snapshots`.
-
-    :jenkinsjob:`OMERO-5.1-merge-robotframework`
-
-        This job runs the robot framework tests of OMERO
-
-        #. Checks out :omero_scc_branch:`dev_5_1/merge/daily`
-        #. Builds OMERO.server and starts it
-        #. Runs the robot framework tests and collect the results
-
-    :jenkinsjob:`OMERO-5.1-merge-homebrew`
-
-        This job tests the installation of OMERO 5.1 using Homebrew
-
-        #. Cleans :file:`/usr/local`
-        #. Installs Homebrew from https://github.com/ome/omero-install
-        #. Installs OMERO via :file:`homebrew/install_omero51`
-
-    :jenkinsjob:`OMERO-5.1-merge-upgrade`
-
-        This job tests the DB upgrade script from the 5.0.0 server
-
-        #. Initializes a database using the script from the 5.0.0 release
-        #. Starts the OMERO server
-        #. Stops the OMERO server
-        #. Runs the upgrade script under :file:`sql/psql/OMERO5.1_DEVx/`
-        #. Restarts the OMERO server
 
 5.2.x series
 ^^^^^^^^^^^^
@@ -495,6 +252,14 @@ under the :jenkinsview:`DEV` view tab of Jenkins.
         #. Checks out :omero_scc_branch:`develop/merge/daily` 
         #. Builds OMERO.server and starts it
         #. Runs the robot framework tests and collect the results
+
+    :jenkinsjob:`OMERO-DEV-merge-homebrew`
+
+        This job tests the installation of OMERO 5.2 using Homebrew
+
+        #. Cleans :file:`/usr/local`
+        #. Installs Homebrew from https://github.com/ome/omero-install
+        #. Installs OMERO via :file:`osx/nstall_homebrew.sh`
 
 .. _omero_breaking:
 

--- a/contributing/ci-omero.txt
+++ b/contributing/ci-omero.txt
@@ -87,19 +87,19 @@ clients of the deployment jobs described above:
         * Port
         * Webclient
 
-    -   * 5.2.x
+    -   * DEV
         * :term:`OMERO-DEV-merge-deploy`
         * eel.openmicroscopy.org
         * 4064
         * https://eel.openmicroscopy.org/merge
 
-    -   * 5.2.x
+    -   * DEV
         * :term:`OMERO-DEV-latest-deploy`
         * eel.openmicroscopy.org
         * 14064
         * https://eel.openmicroscopy.org/latest
 
-    -   * 5.2.x
+    -   * DEV
         * :term:`OMERO-DEV-merge-integration`
         * eel.openmicroscopy.org
         * 24064
@@ -112,10 +112,10 @@ clients of the deployment jobs described above:
         * https://trout.openmicroscopy.org/breaking
 
 
-5.2.x series
+5.3.x series
 ^^^^^^^^^^^^
 
-The branch for the 5.2.x series of OMERO is develop. All jobs are listed
+The branch for the 5.3.x series of OMERO is develop. All jobs are listed
 under the :jenkinsview:`DEV` view tab of Jenkins.
 
 .. glossary::
@@ -131,7 +131,7 @@ under the :jenkinsview:`DEV` view tab of Jenkins.
 
     :jenkinsjob:`OMERO-DEV-latest-deploy`
 
-        This job deploys the latest 5.2.x server (see
+        This job deploys the latest 5.3.x server (see
         :ref:`deployment_servers`)
 
     :jenkinsjob:`OMERO-DEV-latest-submods`
@@ -172,7 +172,7 @@ under the :jenkinsview:`DEV` view tab of Jenkins.
 
     :jenkinsjob:`OMERO-DEV-merge-deploy`
 
-        This job deploys the merge 5.2.x server (see
+        This job deploys the merge 5.3.x server (see
         :ref:`deployment_servers`)
 
     :jenkinsjob:`OMERO-DEV-merge-integration`
@@ -354,12 +354,12 @@ Jenkins.
 
     :jenkinsjob:`OMERO-DEV-breaking-upgrade`
 
-        This job tests the DB upgrade script from a 5.1.0 server and the
-        last patch number of the 5.2.x series
+        This job tests the DB upgrade script from a 5.2.0 server and the
+        last patch number of the 5.3.x series
 
-        #. Initializes a database using the script from the 5.1.0 release or
-           the last patch number of the 5.2.x series
+        #. Initializes a database using the script from the 5.2.0 release or
+           the last patch number of the 5.3.x series
         #. Starts the OMERO server
         #. Stops the OMERO server
-        #. Runs the upgrade script under :file:`sql/psql/OMERO5.2_DEVx/`
+        #. Runs the upgrade script under :file:`sql/psql/OMERO5.3_DEVx/`
         #. Restarts the OMERO server

--- a/contributing/ci-release.txt
+++ b/contributing/ci-release.txt
@@ -66,13 +66,13 @@ Bio-Formats
 
     :jenkinsjob:`BIOFORMATS-DEV-release-trigger`
 
-        This job triggers the Bio-Formats release  jobs. Prior
+        This job triggers the Bio-Formats release jobs. Prior
         to running it, its variables need to be properly configured:
 
         - :envvar:`RELEASE` is the Bio-Formats release number.
 
         #. Triggers :term:`BIOFORMATS-DEV-release-push`
-        #. Triggers :term:`BIOFORMATS-DEV-release-java`
+        #. Triggers :term:`BIOFORMATS-DEV-release`
 
     :jenkinsjob:`BIOFORMATS-DEV-release-push`
 
@@ -81,7 +81,7 @@ Bio-Formats
         #. Runs `scc tag-release $RELEASE` and pushes the tag to the
            snoopycrimecop fork of bioformats.git_
 
-    :jenkinsjob:`BIOFORMATS-DEV-release-java`
+    :jenkinsjob:`BIOFORMATS-DEV-release`
 
         This job builds the Java downloads artifacts of Bio-Formats
 

--- a/contributing/ci-release.txt
+++ b/contributing/ci-release.txt
@@ -9,53 +9,32 @@ jobs should be listed under the :jenkinsview:`Release` view.
     :header-rows: 1
 
     -   * Job task
-        * 5.1.x
-        * 5.2.x
+        * OMERO
     -   * Trigger the OMERO release jobs
-        * :jenkinsjob:`OMERO-5.1-release-trigger`
         * :jenkinsjob:`OMERO-DEV-release-trigger`
     -   * Tags the OMERO source code repository
-        * :jenkinsjob:`OMERO-5.1-release-push`
         * :jenkinsjob:`OMERO-DEV-release-push`
     -   * Build the OMERO download artifacts
-        * :jenkinsjob:`OMERO-5.1-release`
         * :jenkinsjob:`OMERO-DEV-release`
     -   * Generate the OMERO downloads page
-        * :jenkinsjob:`OMERO-5.1-release-downloads`
         * :jenkinsjob:`OMERO-DEV-release-downloads`
     -   * Run the OMERO integration tests
-        * :jenkinsjob:`OMERO-5.1-release-integration`
         * :jenkinsjob:`OMERO-DEV-release-integration`
+
+.. list-table::
+    :header-rows: 1
+
+    -   * Job task
+        * Bio-Formats   
     -   * Trigger the Bio-Formats release jobs
-        * :jenkinsjob:`BIOFORMATS-5.1-release-trigger`
-        *
+        * :jenkinsjob:`BIOFORMATS-DEV-release-trigger`
     -   * Tags the Bio-Formats source code repository
-        * :jenkinsjob:`BIOFORMATS-5.1-release-push`
-        *
-    -   * Build the Bio-Formats Java download artifacts
-        * :jenkinsjob:`BIOFORMATS-5.1-release-java`
-        *
-    -   * Generate the Bio-Formats Java downloads page
-        * :jenkinsjob:`BIOFORMATS-5.1-release-downloads`
-        *
-    -   * Trigger the Bio-Formats C++ release jobs
-        * :jenkinsjob:`BIOFORMATS-CPP-5.1-release-trigger`
-        *
-    -   * Tags the Bio-Formats SuperBuild source code repository
-        * :jenkinsjob:`BIOFORMATS-CPP-5.1-release-push-superbuild`
-        *
-    -   * Builds the release native C++ implementation for Bio-Formats
-        * :jenkinsjob:`BIOFORMATS-CPP-5.1-release`
-        *
-    -   * Builds the release native C++ implementation for Bio-Formats (Unix superbuild)
-        * :jenkinsjob:`BIOFORMATS-CPP-5.1-release-superbuild`
-        *
-    -   * Builds the release native C++ implementation for Bio-Formats ("Windows superbuild)
-        * :jenkinsjob:`BIOFORMATS-CPP-5.1-release-win-superbuild`
-        *
-    -   * Generate the Bio-Formats C++ downloads page
-        * :jenkinsjob:`BIOFORMATS-CPP-5.1-release-downloads`
-        *
+        * :jenkinsjob:`BIOFORMATS-DEV-release-push`
+    -   * Build the Bio-Formats download artifacts
+        * :jenkinsjob:`BIOFORMATS-DEV-release`
+    -   * Generate the Bio-Formats downloads page
+        * :jenkinsjob:`BIOFORMATS-DEV-release-downloads`
+
 
 Deployment servers
 ^^^^^^^^^^^^^^^^^^
@@ -73,12 +52,6 @@ clients of the deployment jobs described above:
         * Port
         * Webclient
 
-    -   * 5.1.x
-        * :term:`OMERO-5.1-release-integration`
-        * seabass.openmicroscopy.org
-        * 14064
-        * https://seabass.openmicroscopy.org/5.1
-
     -   * 5.2.x
         * :term:`OMERO-DEV-release-integration`
         * seabass.openmicroscopy.org
@@ -86,140 +59,29 @@ clients of the deployment jobs described above:
         * https://seabass.openmicroscopy.org/5.2
 
 
-5.1.x series
-^^^^^^^^^^^^
+Bio-Formats
+^^^^^^^^^^^
 
 .. glossary::
 
-    :jenkinsjob:`OMERO-5.1-release-trigger`
+    :jenkinsjob:`BIOFORMATS-DEV-release-trigger`
 
-        This job triggers the OMERO release jobs. Prior to running it, its
-        variables need to be properly configured:
-
-        - :envvar:`RELEASE` is the OMERO release number.
-        - :envvar:`ANNOUNCEMENT_URL` is the URL of the forum release
-          announcement and should be set to the value of the URL of the
-          private post until it becomes public.
-        - :envvar:`MILESTONE` is the name of the Trac milestone which the
-          download pages should be linked to.
-
-        #. Triggers :term:`OMERO-5.1-release-push`
-        #. Triggers :term:`OMERO-5.1-release-integration`
-        #. Triggers :term:`OMERO-5.1-release`
-
-        See :jenkinsjob:`the build graph <OMERO-5.1-release-trigger/lastSuccessfulBuild/BuildGraph>`
-
-    :jenkinsjob:`OMERO-5.1-release-push`
-
-        This job creates a tag on the `dev_5_1` branch
-
-        #. Runs `scc tag-release $RELEASE` and pushes the tag to the
-           snoopycrimecop fork of openmicroscopy.git_
-
-    :jenkinsjob:`OMERO-5.1-release`
-
-        This matrix job builds the OMERO components with Ice 3.4 or 3.5
-
-        #. Checks out the :envvar:`RELEASE` tag of the
-           snoopycrimecop fork of openmicroscopy.git_
-        #. |buildOMERO| for each version of Ice
-        #. Executes the `release-hudson` target for the `ome.staging` Maven
-           repository
-        #. |copyreleaseartifacts|
-        #. Triggers :term:`OMERO-5.1-release-downloads`
-
-    :jenkinsjob:`OMERO-5.1-release-downloads`
-
-        This job builds the OMERO downloads page
-
-        #. Checks out the `dev_5_1` branch of
-           https://github.com/openmicroscopy/ome-release.git
-        #. Runs `make clean omero`
-
-    :jenkinsjob:`OMERO-5.1-release-integration`
-
-        This job runs the integration tests
-
-        #. Checks out the :envvar:`RELEASE` tag of the
-           snoopycrimecop fork of openmicroscopy.git_
-        #. Builds OMERO.server and starts it
-        #. Runs the OMERO.java, OMERO.py and OMERO.web integration tests
-        #. Archives the results
-        #. Triggers downstream collection jobs:
-           :term:`OMERO-5.1-release-integration-broken`,
-           :term:`OMERO-5.1-release-integration-java`,
-           :term:`OMERO-5.1-release-integration-python`,
-           :term:`OMERO-5.1-release-integration-web`,
-           :term:`OMERO-5.1-release-training`,
-           :term:`OMERO-5.1-release-robotframework`
-
-    :jenkinsjob:`OMERO-5.1-release-integration-broken`
-
-        This job collects the OMERO.java broken test results
-
-        #. Receives TestNG results under
-           :file:`components/tools/OmeroJava/target/reports/broken` from
-           :term:`OMERO-5.1-release-integration`
-        #. Generates TestNG report
-
-    :jenkinsjob:`OMERO-5.1-release-integration-java`
-
-        This job collects the OMERO.java integration test results
-
-        #. Receives TestNG results under
-           :file:`components/tools/OmeroJava/target/reports/integration` from
-           :term:`OMERO-5.1-release-integration`
-        #. Generates TestNG report
-
-    :jenkinsjob:`OMERO-5.1-release-integration-python`
-
-        This job collects the OMERO.py integration test results
-
-        #. Receives pytest results under
-           :file:`components/tools/OmeroPy/target/reports` from
-           :term:`OMERO-5.1-release-integration`
-        #. Generates pytest report
-
-    :jenkinsjob:`OMERO-5.1-release-integration-web`
-
-        This job collects the OMERO.web integration test results
-
-        #. Receives pytest results under
-           :file:`components/tools/OmeroWeb/target/reports` from
-           :term:`OMERO-5.1-release-integration`
-        #. Generates pytest report
-
-    :jenkinsjob:`OMERO-5.1-release-training`
-
-        This job runs the Java, MATLAB and Python training examples under
-        :file:`examples/Training`
-
-    :jenkinsjob:`OMERO-5.1-release-robotframework`
-
-        This job runs the robot framework tests of OMERO
-
-        #. Checks out the :envvar:`RELEASE` tag of the
-           snoopycrimecop fork of openmicroscopy.git_
-        #. Runs the robot framework tests and collect the results
-
-    :jenkinsjob:`BIOFORMATS-5.1-release-trigger`
-
-        This job triggers the Bio-Formats Java release  jobs. Prior
+        This job triggers the Bio-Formats release  jobs. Prior
         to running it, its variables need to be properly configured:
 
         - :envvar:`RELEASE` is the Bio-Formats release number.
 
-        #. Triggers :term:`BIOFORMATS-5.1-release-push`
-        #. Triggers :term:`BIOFORMATS-5.1-release-java`
+        #. Triggers :term:`BIOFORMATS-DEV-release-push`
+        #. Triggers :term:`BIOFORMATS-DEV-release-java`
 
-    :jenkinsjob:`BIOFORMATS-5.1-release-push`
+    :jenkinsjob:`BIOFORMATS-DEV-release-push`
 
-        This job creates a tag on the `dev_5_1` branch
+        This job creates a tag on the `develop` branch
 
         #. Runs `scc tag-release $RELEASE` and pushes the tag to the
            snoopycrimecop fork of bioformats.git_
 
-    :jenkinsjob:`BIOFORMATS-5.1-release-java`
+    :jenkinsjob:`BIOFORMATS-DEV-release-java`
 
         This job builds the Java downloads artifacts of Bio-Formats
 
@@ -228,80 +90,18 @@ clients of the deployment jobs described above:
         #. |buildBF|
         #. |fulltestBF|
         #. |copyreleaseartifacts|
-        #. Triggers :term:`BIOFORMATS-5.1-release-downloads`
+        #. Triggers :term:`BIOFORMATS-DEV-release-downloads`
 
-    :jenkinsjob:`BIOFORMATS-5.1-release-downloads`
+    :jenkinsjob:`BIOFORMATS-DEV-release-downloads`
 
         This job builds the Bio-Formats Java downloads page
 
-        #. Checks out the `dev_5_1` branch of
+        #. Checks out the `develop` branch of
            https://github.com/openmicroscopy/ome-release.git
         #. Runs `make clean bf`
 
-    :jenkinsjob:`BIOFORMATS-CPP-5.1-release-downloads`
-
-        This job builds the Bio-Formats C++ downloads page
-
-        #. Checks out the `dev_5_1` branch of
-           https://github.com/openmicroscopy/ome-release.git
-        #. Runs `make clean bfcpp`
-
-    :jenkinsjob:`BIOFORMATS-CPP-5.1-release-push-superbuild`
-
-        This job creates a tag on the ome-cmake-superbuild `dev_5_1` branch
-
-        #. Runs `scc tag-release $RELEASE` and pushes the tag to the
-           snoopycrimecop fork of ome-cmake-superbuild.git_
-
-    :jenkinsjob:`BIOFORMATS-CPP-5.1-release`
-
-        This job builds the C++ downloads artifacts of Bio-Formats for a
-        variety of platforms
-
-        #. Downloads the source zip generated by
-           :term:`BIOFORMATS-5.1-release-java`
-        #. |buildBFcpp|
-        #. |copyreleaseartifacts|
-        #. Triggers :term:`BIOFORMATS-CPP-5.1-release-downloads`
-
-    :jenkinsjob:`BIOFORMATS-CPP-5.1-release-superbuild`
-
-        This job builds the C++ downloads artifacts of Bio-Formats for a
-        variety of Unix platforms using the CMake super-build
-
-        #. Creates the source archive for ome-cmake-superbuild tagged by
-           :term:`BIOFORMATS-CPP-5.1-release-push-superbuild`
-        #. |buildBFcpp|
-        #. |copyreleaseartifacts|
-        #. Triggers :term:`BIOFORMATS-CPP-5.1-release-downloads`
-
-    :jenkinsjob:`BIOFORMATS-CPP-5.1-release-win-superbuild`
-
-        This job builds the C++ downloads artifacts of Bio-Formats for a
-        variety of Windows platforms using the CMake super-build
-
-        #. Creates the source archive for ome-cmake-superbuild tagged by
-           :term:`BIOFORMATS-CPP-5.1-release-push-superbuild`
-        #. |buildBFcpp|
-        #. |copyreleaseartifacts|
-        #. Triggers :term:`BIOFORMATS-CPP-5.1-release-downloads`
-
-    :jenkinsjob:`BIOFORMATS-5.1-release-trigger`
-
-        This job triggers the Bio-Formats C++ release jobs. Prior
-        to running it, its variables need to be properly configured:
-
-        - :envvar:`RELEASE` is the Bio-Formats C++
-          (ome-cmake-superbuild) release number.
-
-        #. Triggers :term:`BIOFORMATS-CPP-5.1-release-push-superbuild`
-        #. Triggers :term:`BIOFORMATS-CPP-5.1-release`
-        #. Triggers :term:`BIOFORMATS-CPP-5.1-release-superbuild`
-        #. Triggers :term:`BIOFORMATS-CPP-5.1-release-win-superbuild`
-
-
-5.2.x series
-^^^^^^^^^^^^
+OMERO
+^^^^^
 
 .. glossary::
 

--- a/contributing/ci-release.txt
+++ b/contributing/ci-release.txt
@@ -2,8 +2,8 @@ Release jobs
 ------------
 
 The following table lists the main Jenkins jobs used during the release
-process depending on the release branch (5.1 or 5.2 release). All release
-jobs should be listed under the :jenkinsview:`Release` view.
+process. All release jobs should be listed under the :jenkinsview:`Release`
+view.
 
 .. list-table::
     :header-rows: 1
@@ -52,7 +52,7 @@ clients of the deployment jobs described above:
         * Port
         * Webclient
 
-    -   * 5.2.x
+    -   * DEV
         * :term:`OMERO-DEV-release-integration`
         * seabass.openmicroscopy.org
         * 24064


### PR DESCRIPTION
This PR documents all the job modifications as the OMERO 5.3.x code is getting migrated to the `develop` branch.
- dropping of the OMERO 5.1.x jobs
- modification of the documentation jobs to maintain OMERO 5.2.x and OMERO 5.3.x documentation sets
