### PR TITLE
Update 5.1 docs banner to be latest version agnostic

### DIFF
--- a/omero/conf.py
+++ b/omero/conf.py
@@ -46,9 +46,11 @@ else:
     release = 'UNKNOWN'
 
 rst_prolog = """
-.. note:: **This documentation is for the superseded OMERO 5.1 line.** See the `latest
-    OMERO 5.2.x version <http://www.openmicroscopy.org/site/support/omero5.2/>`_ for the
-    most up-to-date documentation.
+.. note:: **This documentation is for the OMERO 5.1 line which is now unsupported
+    and will not be updated.** You should upgrade to take advantage of fixes and
+    performance improvements. See the
+    `latest documentation <http://www.openmicroscopy.org/site/support/omero/>`_
+    for the current release version.
 """
 
 rst_epilog += """

--- a/omero/conf.py
+++ b/omero/conf.py
@@ -47,8 +47,8 @@ else:
 
 rst_prolog = """
 .. note:: **This documentation is for the OMERO 5.1 line which is now unsupported
-    and will not be updated.** You should upgrade to take advantage of fixes and
-    performance improvements. See the
+    and will not be updated.** You should upgrade to take advantage of major fixes
+    and improvements. See the
     `latest documentation <http://www.openmicroscopy.org/site/support/omero/>`_
     for the current release version.
 """


### PR DESCRIPTION
See https://trello.com/c/1nnkc0BD/446-omero-5-3-x-5-2-x-status - this is the last change that should go into the 5.1 line, making the banner correct whether 5.2.x is the current version or we've moved onto 5.3.x

Staged at https://www.openmicroscopy.org/site/support/omero5.1-staging/
