### PR TITLE
Manual link fix

### DIFF
--- a/omero/sysadmins/config.txt
+++ b/omero/sysadmins/config.txt
@@ -1414,7 +1414,7 @@ many script JobParams will be kept in memory
 for how long.
 
 For more information, see
-http://docs.guava-libraries.googlecode.com/git/javadoc/com/google/common/cache/CacheBuilderSpec.html
+http://google.github.io/guava/releases/17.0/api/docs/com/google/common/cache/CacheBuilderSpec.html
 
 Default: `maximumSize=1000`
 


### PR DESCRIPTION
This would usually be fixed on the code side but there's no infrastructure set up to do so given we are hoping not to have another 5.2.x release so I've just manually fixed it in the docs page instead.

Staged on http://www.openmicroscopy.org/site/support/omero5.2-staging/sysadmins/config.html#scripts
