### PR TITLE
OME-TIFF samples page restructuring

### DIFF
--- a/formats/developers/6d-7d-and-8d-storage.txt
+++ b/formats/developers/6d-7d-and-8d-storage.txt
@@ -208,5 +208,5 @@ mosaic as above or to overlap e.g.
 Sample files
 ------------
 
-Sample files are available in the :ref:`modulo-dataset` section of the OME-TIFF
+Sample files are available in the :ref:`modulo-datasets` section of the OME-TIFF
 sample data.

--- a/formats/developers/6d-7d-and-8d-storage.txt
+++ b/formats/developers/6d-7d-and-8d-storage.txt
@@ -208,42 +208,5 @@ mosaic as above or to overlap e.g.
 Sample files
 ------------
 
-Sample files are available from the
-:ometiff_downloads:`Modulo <modulo>` folder of the image downloads resource.
-
-SPIM
-^^^^
-
-- :ometiff_downloads:`SPIM-ModuloAlongZ.ome.tiff <modulo/SPIM-ModuloAlongZ.ome.tiff>` - a 2x2 tile of planes
-  each recorded at 4 angles.
-
-Big lambda
-^^^^^^^^^^
-
-- :ometiff_downloads:`LAMBDA-ModuloAlongZ-ModuloAlongT.ome.tiff <modulo/LAMBDA-ModuloAlongZ-ModuloAlongT.ome.tiff>` -
-  excitation of 5 wavelength [Λ, big-lambda] each recorded at 10 emission
-  wavelength ranges [λ, lambda].
-
-FLIM
-^^^^
-
-- :ometiff_downloads:`FLIM-ModuloAlongT-TSCPC.ome.tiff <modulo/FLIM-ModuloAlongT-TSCPC.ome.tiff>` -
-  2 channels and 8 histogram bins each recorded at 2 'real-time' points T,
-  with additional relative-time points (time relative to the
-  excitation pulse) interleaved as ModuloAlongT.
-
-- :ometiff_downloads:`FLIM-ModuloAlongC.ome.tiff <modulo/FLIM-ModuloAlongC.ome.tiff>` -
-  2 real channels and 8 histogram bins each recorded at 2 timepoints, with
-  additional relative-time points interleaved between channels as
-  ModuloAlongC.
-
-.. note:: The ModuloAlong annotation allows FLIM data to be encoded in any of
-    three dimensions (ZCT). However, a number of issues of future
-    compatibility with other modalities can be avoided by standardizing on the
-    use of one dimension for FLIM.
-    
-    The developers of our partner application
-    :partner_plone:`FLIMfit <flimfit>` intend to use only ModuloAlongT for
-    FLIM data and we would ask other developers to do the same. This leaves
-    ModuloAlong Z and C free for other modalities.
-
+Sample files are available in the :ref:`modulo-dataset` section of the OME-TIFF
+sample data.

--- a/formats/developers/compression.txt
+++ b/formats/developers/compression.txt
@@ -1,0 +1,170 @@
+File compression
+================
+
+This section provides an analysis of several file formats (including 
+:doc:`OME-XML </ome-xml/index>` and :doc:`OME-TIFF </ome-tiff/index>`) and 
+compression techniques.
+
+The figures regarding various storage formats were computed from the :ref:`tubhiswt_samples` before the current schema version. Thus, the byte counts between the downloadable ZIP files and the "zipped OME-TIFF" entry do not precisely match.  The table below also lists the space
+requirements for each dataset with various formats and compression
+types.
+
+
++-------------------------------------------------------------+-----------------------+-------------------------+--------------------------+
+| Dataset                                                     | `tubhiswt-2D.zip`_    | `tubhiswt-3D.zip`_      | `tubhiswt-4D.zip`_       |
++-------------------------------------------------------------+-----------------------+-------------------------+--------------------------+
+| Download Size                                               | 238,344 bytes         | 4,502,202 bytes         | 106,787,266 bytes        |
++-------------------------------------------------------------+-----------------------+-------------------------+--------------------------+
+| **Size (raw pixels only)**                                  | 524,288 bytes         | 10,485,760 bytes        | 225,443,840 bytes        |
++-------------------------------------------------------------+-----------------------+-------------------------+--------------------------+
+| **Size (OME-XML)**                                          | 314,346 bytes         | 5,964,603 bytes         | 142,498,355 bytes        |
++-------------------------------------------------------------+-----------------------+-------------------------+--------------------------+
+| **Size (gzipped OME-XML)**                                  | 236,708 bytes         | 4,511,329 bytes         | 107,788,464 bytes        |
++-------------------------------------------------------------+-----------------------+-------------------------+--------------------------+
+| **Size (zipped OME-XML)**                                   | 236,836 bytes         | 4,511,457 bytes         | 107,788,592 bytes        |
++-------------------------------------------------------------+-----------------------+-------------------------+--------------------------+
+| **Size (7-zipped OME-XML)**                                 | 239,052 bytes         | 4,551,263 bytes         | 108,708,700 bytes        |
++-------------------------------------------------------------+-----------------------+-------------------------+--------------------------+
+| **Size (OME-TIFF)**                                         | 531,384 bytes         | 10,499,384 bytes        | 225,874,680 bytes        |
++-------------------------------------------------------------+-----------------------+-------------------------+--------------------------+
+| **Size (OME-TIFF with LZW)**                                | 273,190 bytes         | 4,998,148 bytes         | 118,517,497 bytes        |
++-------------------------------------------------------------+-----------------------+-------------------------+--------------------------+
+| **Size (zipped OME-TIFF)**                                  | 235,764 bytes         | 4,446,727 bytes         | 105,389,599 bytes        |
++-------------------------------------------------------------+-----------------------+-------------------------+--------------------------+
+| **Size (zipped OME-TIFF with LZW)**                         | 264,875 bytes         | 4,937,246 bytes         | 116,418,287 bytes        |
++-------------------------------------------------------------+-----------------------+-------------------------+--------------------------+
+| **Size (7-zipped OME-TIFF)**                                | 209,593 bytes         | 3,891,846 bytes         | 93,939,055 bytes         |
++-------------------------------------------------------------+-----------------------+-------------------------+--------------------------+
+| **Size (7-zipped OME-TIFF with LZW)**                       | 264,292 bytes         | 4,950,897 bytes         | 116,567,097 bytes        |
++-------------------------------------------------------------+-----------------------+-------------------------+--------------------------+
+
+.. _tubhiswt-2D.zip: http://downloads.openmicroscopy.org/images/OME-TIFF/2015-01/tubhiswt-2D.zip
+.. _tubhiswt-3D.zip: http://downloads.openmicroscopy.org/images/OME-TIFF/2015-01/tubhiswt-3D.zip
+.. _tubhiswt-4D.zip: http://downloads.openmicroscopy.org/images/OME-TIFF/2015-01/tubhiswt-4D.zip
+
+
+Efficiency of planar access
+---------------------------
+
+The following table compiles our results with average plane size
+computed from the numbers above, and briefly summarizes each format's
+ability to efficiently access individual image planes. We have not
+performed benchmarks involving individual planar access for each
+format—mostly because for many of these formats (especially zip, gzip
+and 7-zip) it is quite impractical to attempt efficient access to
+individual planes.
+
++---------------------------+----------------------------+-----------------------------------------------------------------------+
+| **Format**                | **Average plane size**     | **Efficiency of access to individual planes**                         |
++---------------------------+----------------------------+-----------------------------------------------------------------------+
+| Raw pixels only           | Worst – 262,144 bytes      | Best – Pixels can be ripped directly from disk.                       |
++---------------------------+----------------------------+-----------------------------------------------------------------------+
+| OME-TIFF                  | Worst – 262,645 bytes      | Great – IFDs identify planar offsets.                                 |
++---------------------------+----------------------------+-----------------------------------------------------------------------+
+| OME-TIFF+LZW              | Good – 137,238 bytes       | Good – The plane must be decoded from LZW, but IFDs identify planar   |
+|                           |                            | offsets. With clever threading, each plane can be decoded while the   |
+|                           |                            | next is being read from disk.                                         |
++---------------------------+----------------------------+-----------------------------------------------------------------------+
+| OME-XML                   | Poor – 164,942 bytes       | Good – The plane must be decoded from base64, but the BinData Length  |
+|                           |                            | attributes can be used to derive offsets without scanning the entire  |
+|                           |                            | file. With clever threading, each plane can be decoded while the next |
+|                           |                            | is being read from disk.                                              |
++---------------------------+----------------------------+-----------------------------------------------------------------------+
+| OME-TIFF, 7-zipped        | Best – 108,692 bytes       | Poor – The appropriate OME-TIFF file must be uncompressed from the    |
+|                           |                            | archive.                                                              |
++---------------------------+----------------------------+-----------------------------------------------------------------------+
+| OME-TIFF, zipped          | Great – 122,031 bytes      | Poor – The appropriate OME-TIFF file must be uncompressed from the    |
+|                           |                            | archive.                                                              |
++---------------------------+----------------------------+-----------------------------------------------------------------------+
+| OME-TIFF+LZW, zipped      | Good – 134,834 bytes       | Poor – The appropriate OME-TIFF file must be uncompressed from the    |
+|                           |                            | archive, and the plane must be decoded from LZW.                      |
++---------------------------+----------------------------+-----------------------------------------------------------------------+
+| OME-TIFF+LZW, 7-zipped    | Good – 135,014 bytes       | Poor – The appropriate OME-TIFF file must be uncompressed from the    |
+|                           |                            | archive, and the plane must be decoded from LZW.                      |
++---------------------------+----------------------------+-----------------------------------------------------------------------+
+| OME-XML, gzipped          | Great – 124,763 bytes      | Worst – Entire dataset must be uncompressed, then the plane must be   |
+|                           |                            | decoded from base64.                                                  |
++---------------------------+----------------------------+-----------------------------------------------------------------------+
+| OME-XML, zipped           | Great – 124,764 bytes      | Worst – Entire dataset must be uncompressed, then the plane must be   |
+|                           |                            | decoded from base64.                                                  |
++---------------------------+----------------------------+-----------------------------------------------------------------------+
+| OME-XML, 7-zipped         | Great – 125,830 bytes      | Worst – Entire dataset must be uncompressed, then the plane must be   |
+|                           |                            | decoded from base64.                                                  |
++---------------------------+----------------------------+-----------------------------------------------------------------------+
+
+The performance penalty for accessing individual image planes from
+externally compressed formats (zip, gzip, and 7-zip) is high, since the
+data must be decompressed. There is little penalty for accessing them
+from uncompressed OME-XML or OME-TIFF—with OME-XML, file readers can
+build a list of offsets by skipping past the bulk of the BinData
+characters according to the Length attribute values, and with OME-TIFF,
+file readers can seek to the offsets indicated in the IFD entries.
+
+Accessing them from an uncompressed OME-TIFF file, however, is
+efficient. In addition, the TIFF format maintains compatibility with the
+multitude of existing software that works with single- and multi-page
+TIFF files.
+
+Space required on disk
+----------------------
+
+As shown in the table above, and the chart :ref:`figure-tiff-chart`, our 
+figures indicate that the most efficient format for space is OME-TIFF 
+compressed with the `7-zip <http://www.7-zip.org/>`_ utility. Also good are 
+gzipped OME-XML and zipped OME-TIFF.
+
+.. _figure-tiff-chart:
+
+.. figure:: /images/ome-tiff-chart.png
+   :align: center
+   :alt: OME-TIFF space used
+
+   OME-TIFF space used
+
+Uncompressed OME-TIFF format, while the least space-efficient, provides
+its own advantages: it is highly compatible and provides efficient
+access to individual image planes.
+
+OME-TIFF with LZW often performs nearly as well as the externally
+compressed formats (zip, gzip and 7-zip), without the performance
+penalty of searching through a compressed archive. However, LZW is
+noticeably less efficient to decode than uncompressed TIFF is, and LZW
+is an additional requirement for client software—it may be that some
+software supports uncompressed multi-page TIFF, but not LZW. Even more
+unfortunate, the 7-zip algorithm appears to perform less well on
+LZW-compressed OME-TIFFs than on uncompressed OME-TIFFs.
+
+Recommendations
+---------------
+
+In conclusion, we highlight the following formats as most useful,
+depending on your circumstances:
+
+-  **Zipped OME-TIFF** – cuts down on file size while retaining the
+   underlying compatibility of OME-TIFF. Use zipped OME-TIFF for wide
+   distribution of data to colleagues. Zip is a ubiquitous compression
+   format, decodable on all major operating systems. The downside is
+   that it typically does not compress as well as 7-zip does.
+-  **7-zipped OME-TIFF** – minimizes file size. As the most
+   space-efficient format, use 7-zipped OME-TIFF for archival purposes,
+   for transport from one OME database to another, and possibly for
+   online distribution if space is a major concern and your target
+   audience is computer-savvy enough to install 7-zip. The only
+   downsides are that 7-zip is less ubiquitous than zip, and compressing
+   a dataset with 7-zip takes longer than doing so with zip.
+-  **OME-TIFF with LZW** – provides space advantages nearly as good as
+   the externally compressed formats (zip, gzip, 7-zip) without
+   sacrificing the accessibility of TIFF, for the most part. The
+   downsides are that LZW takes somewhat longer to process than
+   uncompressed TIFF, some software does not support LZW compression,
+   and OME-TIFF with LZW does not shrink as much as uncompressed
+   OME-TIFF does with external compression techniques.
+-  **OME-TIFF** – maximizes compatibility. When actively working with
+   data, storing it in uncompressed OME-TIFF format provides many
+   options for efficient analysis and visualization. The downside is
+   that the data takes up more space on disk.
+-  **OME-XML** – provides metadata in a directly human-readable form. In
+   addition, OME-XML maximizes compatibility with XML software. The
+   downside is that very few image software packages support OME-XML.
+
+

--- a/formats/index.txt
+++ b/formats/index.txt
@@ -88,10 +88,11 @@ Developer tools and guidelines
 
     developers/index
     developers/using-ome-xml
-    developers/EnumTool
+    developers/compression
     developers/sample-files
     developers/id-and-lsid
     developers/ome-units
+    developers/EnumTool
 
 ************************
 The Data Model in detail

--- a/formats/ome-tiff/data.txt
+++ b/formats/ome-tiff/data.txt
@@ -191,8 +191,8 @@ files and refer to the master OME-TIFF file as described in the
 
 .. _companion-sample:
 
-Companion OME-TIFF fileset
-""""""""""""""""""""""""""
+Companion OME-XML fileset
+"""""""""""""""""""""""""
 
 For this sample, the full OME-XML metadata describing the whole fileset is
 stored into a separate

--- a/formats/ome-tiff/data.txt
+++ b/formats/ome-tiff/data.txt
@@ -1,256 +1,201 @@
 OME-TIFF sample data
 ====================
 
-
-This section provides some sample data in OME-TIFF format, as well as an
-analysis of several file formats (including :doc:`/ome-xml/index`) and 
-compression techniques. There are also some artificial sample datasets (i.e.
-not produced from an acquisition system) designed for developer testing that
-illustrate some possible data organizations, which should be useful if you are
-interested in implementing support for OME-TIFF within your software.
+This section provides some sample data in OME-TIFF format. They include data
+produced from an acquisition system as well as artificial sample datasets (i.e.
+designed for developer testing that illustrate some possible data
+organizations, which should be useful if you are interested in implementing
+support for OME-TIFF within your software.
 
 All the OME-TIFF sample data discussed below are available from our
-:ometiff_downloads:`OME-TIFF sample images resource <>`. In
-addition, there are examples of modulo data for
-:doc:`/developers/6d-7d-and-8d-storage`.
+:ometiff_downloads:`OME-TIFF sample images resource <>`.
+
+Single file OME-TIFF
+--------------------
+
+This section lists various examples of single file OME-TIFF. For examples of
+OME-TIFF dataset distributed across multiple TIFF files, see
+:ref:`multifile_samples`.
+
+.. _artificial-datasets:
 
 Artificial datasets
--------------------
+^^^^^^^^^^^^^^^^^^^
 
 All datasets in the following table were :source:`artificially
 generated <components/formats-bsd/src/loci/formats/tools/MakeTestOmeTiff.java>`
 with each plane labeled according to its dimensional position for easy
 testing. Each one consists of a single OME-TIFF file (2015-01 schema
-version) containing every constituent image plane. For an example of an
-OME-TIFF dataset distributed across multiple TIFF files, see the
-``tubhiswt`` biological example in the next section.
+version) containing every constituent image plane. 
 
-+----------------------------------------------+-------------------------------------------------------+
-| `single-channel.ome.tif`_                    | 2D (single image)                                     |
-+----------------------------------------------+-------------------------------------------------------+
-| `multi-channel.ome.tif`_                     | 2D (3 channels)                                       |
-+----------------------------------------------+-------------------------------------------------------+
-| `z-series.ome.tif`_                          | 3D (5 focal planes)                                   |
-+----------------------------------------------+-------------------------------------------------------+
-| `multi-channel-z-series.ome.tif`_            | 3D (5 focal planes, 3 channels)                       |
-+----------------------------------------------+-------------------------------------------------------+
-| `time-series.ome.tif`_                       | 3D (7 time points)                                    |
-+----------------------------------------------+-------------------------------------------------------+
-| `multi-channel-time-series.ome.tif`_         | 3D (7 time points, 3 channels)                        |
-+----------------------------------------------+-------------------------------------------------------+
-| `4D-series.ome.tif`_                         | 4D (7 time points, 5 focal planes)                    |
-+----------------------------------------------+-------------------------------------------------------+
-| `multi-channel-4D-series.ome.tif`_           | 4D (7 time points, 5 focal planes, 3 channels)        |
-+----------------------------------------------+-------------------------------------------------------+
+.. list-table::
+  :header-rows: 1
+  :widths: 40, 20, 20, 20
 
+  -  * Sample
+     * Channels
+     * Focal planes
+     * Time points
+  
+  -  * :ometiff_downloads:`single-channel.ome.tif <bioformats-artificial/single-channel.ome.tif>`
+     * 1
+     * 1
+     * 1
 
-.. _single-channel.ome.tif: http://downloads.openmicroscopy.org/images/OME-TIFF/2015-01/bioformats-artificial/single-channel.ome.tif
-.. _multi-channel.ome.tif: http://downloads.openmicroscopy.org/images/OME-TIFF/2015-01/bioformats-artificial/multi-channel.ome.tif
-.. _z-series.ome.tif: http://downloads.openmicroscopy.org/images/OME-TIFF/2015-01/bioformats-artificial/z-series.ome.tif
-.. _multi-channel-z-series.ome.tif: http://downloads.openmicroscopy.org/images/OME-TIFF/2015-01/bioformats-artificial/multi-channel-z-series.ome.tif
-.. _time-series.ome.tif: http://downloads.openmicroscopy.org/images/OME-TIFF/2015-01/bioformats-artificial/time-series.ome.tif
-.. _multi-channel-time-series.ome.tif: http://downloads.openmicroscopy.org/images/OME-TIFF/2015-01/bioformats-artificial/multi-channel-time-series.ome.tif
-.. _4D-series.ome.tif: http://downloads.openmicroscopy.org/images/OME-TIFF/2015-01/bioformats-artificial/4D-series.ome.tif
-.. _multi-channel-4D-series.ome.tif: http://downloads.openmicroscopy.org/images/OME-TIFF/2015-01/bioformats-artificial/multi-channel-4D-series.ome.tif
+  -  * :ometiff_downloads:`multi-channel.ome.tif <bioformats-artificial/multi-channel.ome.tif>`
+     * 3
+     * 1
+     * 1
+
+  -  * :ometiff_downloads:`z-series.ome.tif <bioformats-artificial/z-series.ome.tif>`
+     * 1
+     * 5
+     * 1
+
+  -  * :ometiff_downloads:`time-series.ome.tif <bioformats-artificial/tim-series.ome.tif>`
+     * 1
+     * 1
+     * 7
+
+  -  * :ometiff_downloads:`multi-channel-z-series.ome.tif <bioformats-artificial/multi-channel-z-series.ome.tif>`
+     * 3
+     * 5
+     * 1
+
+  -  * :ometiff_downloads:`multi-channel-time-series.ome.tif <bioformats-artificial/multi-channel-time-series.ome.tif>`
+     * 3
+     * 1
+     * 7
+
+  -  * :ometiff_downloads:`4D-series.ome.tif <bioformats-artificial/4D-series.ome.tif>`
+     * 1
+     * 5
+     * 7
+
+  -  * :ometiff_downloads:`multi-channel-4D-series.ome.tif <bioformats-artificial/multi-channel-4D-series.ome.tif>`
+     * 3
+     * 5
+     * 7
+
+.. _modulo-datasets:
+
+Modulo datasets
+^^^^^^^^^^^^^^^
+
+Sample files implementing the :doc:`/developers/6d-7d-and-8d-storage` are available from the
+:ometiff_downloads:`Modulo <modulo>` folder of the image downloads resource.
+
+SPIM
+""""
+
+- :ometiff_downloads:`SPIM-ModuloAlongZ.ome.tiff <modulo/SPIM-ModuloAlongZ.ome.tiff>` - a 2x2 tile of planes
+  each recorded at 4 angles.
+
+Big lambda
+""""""""""
+
+- :ometiff_downloads:`LAMBDA-ModuloAlongZ-ModuloAlongT.ome.tiff <modulo/LAMBDA-ModuloAlongZ-ModuloAlongT.ome.tiff>` -
+  excitation of 5 wavelength [Λ, big-lambda] each recorded at 10 emission
+  wavelength ranges [λ, lambda].
+
+FLIM
+""""
+
+- :ometiff_downloads:`FLIM-ModuloAlongT-TSCPC.ome.tiff <modulo/FLIM-ModuloAlongT-TSCPC.ome.tiff>` -
+  2 channels and 8 histogram bins each recorded at 2 'real-time' points T,
+  with additional relative-time points (time relative to the
+  excitation pulse) interleaved as ModuloAlongT.
+
+- :ometiff_downloads:`FLIM-ModuloAlongC.ome.tiff <modulo/FLIM-ModuloAlongC.ome.tiff>` -
+  2 real channels and 8 histogram bins each recorded at 2 timepoints, with
+  additional relative-time points interleaved between channels as
+  ModuloAlongC. 
+
+.. _multifile_samples:
+
+Multi-file OME-TIFF filesets
+----------------------------
+
+This section lists various examples of OME-TIFF datasets distributed across multiple TIFF files.
 
 .. _tubhiswt_samples:
 
 Sample biological dataset
--------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The following OME-TIFF datasets consist of tubulin histone GFP
-coexpressing *C. elegans* embryos. Many thanks to `Josh
-Bembenek <http://loci.wisc.edu/people/josh-bembenek>`_ for preparing
+The following OME-TIFF datasets consist of tubulin histone GFP coexpressing 
+*C. elegans* embryos. Many thanks to
+`Josh Bembenek <http://loci.wisc.edu/people/josh-bembenek>`_ for preparing
 and imaging this sample data.
 
 The datasets were acquired on a multiphoton workstation (2.1 GHz Athlon
 XP 3200+ with 1GB of RAM) using
 `WiscScan <http://loci.wisc.edu/software/wiscscan>`_. All image
 planes were collected at 512x512 resolution in 8-bit grayscale, with an
-integration value of 2. The table below also lists the space
-requirements for each dataset with various formats and compression
-types.
+integration value of 2.
 
-.. note::
+The files available for download have been updated to the current schema version since their initial creation.
 
-    The files available for download have been updated to the 2015-01
-    schema version since their initial creation. The figures regarding
-    various storage formats were computed before this update; thus, the
-    byte counts between the downloadable ZIP files and the "zipped
-    OME-TIFF" entry do not precisely match. Unzipped files are also available
-    from our
-    :ometiff_downloads:`OME-TIFF sample images resource <>`.
+.. list-table::
+  :header-rows: 1
+  :widths: 20, 20, 15, 15, 15, 15
 
+  -  * Fileset
+     * Zipped fileset
+     * Channels
+     * Focal planes
+     * Time points
+     * Number of files
+  
+  -  * :ometiff_downloads:`tubhiswt-2D <tubhiswt-2D>`
+     * :ometiff_downloads:`tubhiswt-2D.zip <tubhiswt-2D.zip>`
+     * 2
+     * 1
+     * 1
+     * 2
 
-+-------------------------------------------------------------+-----------------------+-------------------------+--------------------------+
-| Dataset                                                     | `tubhiswt-2D.zip`_    | `tubhiswt-3D.zip`_      | `tubhiswt-4D.zip`_       |
-+-------------------------------------------------------------+-----------------------+-------------------------+--------------------------+
-| Download Size                                               | 238,344 bytes         | 4,502,202 bytes         | 106,787,266 bytes        |
-+=============================================================+=======================+=========================+==========================+
-| **Dimensionality**                                          | | **2D**              | | **3D**                | | **4D**                 |
-|                                                             | | *2 channels*        | | *20 time points*      | | *10 focal planes*      |
-|                                                             |                       | | *2 channels*          | | *43 time points*       |
-|                                                             |                       |                         | | *2 channels*           |
-+-------------------------------------------------------------+-----------------------+-------------------------+--------------------------+
-| **Size (raw pixels only)**                                  | 524,288 bytes         | 10,485,760 bytes        | 225,443,840 bytes        |
-+-------------------------------------------------------------+-----------------------+-------------------------+--------------------------+
-| **Size (OME-XML)**                                          | 314,346 bytes         | 5,964,603 bytes         | 142,498,355 bytes        |
-+-------------------------------------------------------------+-----------------------+-------------------------+--------------------------+
-| **Size (gzipped OME-XML)**                                  | 236,708 bytes         | 4,511,329 bytes         | 107,788,464 bytes        |
-+-------------------------------------------------------------+-----------------------+-------------------------+--------------------------+
-| **Size (zipped OME-XML)**                                   | 236,836 bytes         | 4,511,457 bytes         | 107,788,592 bytes        |
-+-------------------------------------------------------------+-----------------------+-------------------------+--------------------------+
-| **Size (7-zipped OME-XML)**                                 | 239,052 bytes         | 4,551,263 bytes         | 108,708,700 bytes        |
-+-------------------------------------------------------------+-----------------------+-------------------------+--------------------------+
-| **Size (OME-TIFF)**                                         | 531,384 bytes         | 10,499,384 bytes        | 225,874,680 bytes        |
-+-------------------------------------------------------------+-----------------------+-------------------------+--------------------------+
-| **Size (OME-TIFF with LZW)**                                | 273,190 bytes         | 4,998,148 bytes         | 118,517,497 bytes        |
-+-------------------------------------------------------------+-----------------------+-------------------------+--------------------------+
-| **Size (zipped OME-TIFF)**                                  | 235,764 bytes         | 4,446,727 bytes         | 105,389,599 bytes        |
-+-------------------------------------------------------------+-----------------------+-------------------------+--------------------------+
-| **Size (zipped OME-TIFF with LZW)**                         | 264,875 bytes         | 4,937,246 bytes         | 116,418,287 bytes        |
-+-------------------------------------------------------------+-----------------------+-------------------------+--------------------------+
-| **Size (7-zipped OME-TIFF)**                                | 209,593 bytes         | 3,891,846 bytes         | 93,939,055 bytes         |
-+-------------------------------------------------------------+-----------------------+-------------------------+--------------------------+
-| **Size (7-zipped OME-TIFF with LZW)**                       | 264,292 bytes         | 4,950,897 bytes         | 116,567,097 bytes        |
-+-------------------------------------------------------------+-----------------------+-------------------------+--------------------------+
+  -  * :ometiff_downloads:`tubhiswt-3D <tubhiswt-3D>`
+     * :ometiff_downloads:`tubhiswt-3D.zip <tubhiswt-3D.zip>`
+     * 2
+     * 1
+     * 20
+     * 2
 
-.. _tubhiswt-2D.zip: http://downloads.openmicroscopy.org/images/OME-TIFF/2015-01/tubhiswt-2D.zip
-.. _tubhiswt-3D.zip: http://downloads.openmicroscopy.org/images/OME-TIFF/2015-01/tubhiswt-3D.zip
-.. _tubhiswt-4D.zip: http://downloads.openmicroscopy.org/images/OME-TIFF/2015-01/tubhiswt-4D.zip
+  -  * :ometiff_downloads:`tubhiswt-4D <tubhiswt-4D>`
+     * :ometiff_downloads:`tubhiswt-4D.zip <tubhiswt-4D.zip>`
+     * 2
+     * 10
+     * 43
+     * 86
 
-Multi-file image example
-------------------------
+Partial OME-XML metadata datasets
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :ometiff_downloads:`Companion <companion>` OME-TIFF image
-folder contains a set of 18 by 24 pixel images (with black and white text on
-each plane giving its time, z-depth and channel) where each of the five Z
-sections are saved as a separate file and there is a companion file to
-identify them as a single fileset (meaning :OMERO_doc:`OMERO can treat them as
-a single image <developers/ImportFS.html>`).
+.. _binary-only-sample:
 
-Efficiency of planar access
----------------------------
+Binary only OME-TIFF fileset
+""""""""""""""""""""""""""""
 
-The following table compiles our results with average plane size
-computed from the numbers above, and briefly summarizes each format's
-ability to efficiently access individual image planes. We have not
-performed benchmarks involving individual planar access for each
-format—mostly because for many of these formats (especially zip, gzip
-and 7-zip) it is quite impractical to attempt efficient access to
-individual planes.
+The :ometiff_downloads:`binary only OME-TIFF fileset <binary-only>` contains a
+set of 18 by 24 pixel images (with black and white text on each plane giving
+its time, z-depth and channel) where each of the five Z sections are saved as
+a separate file.
 
-+---------------------------+----------------------------+-----------------------------------------------------------------------+
-| **Format**                | **Average plane size**     | **Efficiency of access to individual planes**                         |
-+---------------------------+----------------------------+-----------------------------------------------------------------------+
-| Raw pixels only           | Worst – 262,144 bytes      | Best – Pixels can be ripped directly from disk.                       |
-+---------------------------+----------------------------+-----------------------------------------------------------------------+
-| OME-TIFF                  | Worst – 262,645 bytes      | Great – IFDs identify planar offsets.                                 |
-+---------------------------+----------------------------+-----------------------------------------------------------------------+
-| OME-TIFF+LZW              | Good – 137,238 bytes       | Good – The plane must be decoded from LZW, but IFDs identify planar   |
-|                           |                            | offsets. With clever threading, each plane can be decoded while the   |
-|                           |                            | next is being read from disk.                                         |
-+---------------------------+----------------------------+-----------------------------------------------------------------------+
-| OME-XML                   | Poor – 164,942 bytes       | Good – The plane must be decoded from base64, but the BinData Length  |
-|                           |                            | attributes can be used to derive offsets without scanning the entire  |
-|                           |                            | file. With clever threading, each plane can be decoded while the next |
-|                           |                            | is being read from disk.                                              |
-+---------------------------+----------------------------+-----------------------------------------------------------------------+
-| OME-TIFF, 7-zipped        | Best – 108,692 bytes       | Poor – The appropriate OME-TIFF file must be uncompressed from the    |
-|                           |                            | archive.                                                              |
-+---------------------------+----------------------------+-----------------------------------------------------------------------+
-| OME-TIFF, zipped          | Great – 122,031 bytes      | Poor – The appropriate OME-TIFF file must be uncompressed from the    |
-|                           |                            | archive.                                                              |
-+---------------------------+----------------------------+-----------------------------------------------------------------------+
-| OME-TIFF+LZW, zipped      | Good – 134,834 bytes       | Poor – The appropriate OME-TIFF file must be uncompressed from the    |
-|                           |                            | archive, and the plane must be decoded from LZW.                      |
-+---------------------------+----------------------------+-----------------------------------------------------------------------+
-| OME-TIFF+LZW, 7-zipped    | Good – 135,014 bytes       | Poor – The appropriate OME-TIFF file must be uncompressed from the    |
-|                           |                            | archive, and the plane must be decoded from LZW.                      |
-+---------------------------+----------------------------+-----------------------------------------------------------------------+
-| OME-XML, gzipped          | Great – 124,763 bytes      | Worst – Entire dataset must be uncompressed, then the plane must be   |
-|                           |                            | decoded from base64.                                                  |
-+---------------------------+----------------------------+-----------------------------------------------------------------------+
-| OME-XML, zipped           | Great – 124,764 bytes      | Worst – Entire dataset must be uncompressed, then the plane must be   |
-|                           |                            | decoded from base64.                                                  |
-+---------------------------+----------------------------+-----------------------------------------------------------------------+
-| OME-XML, 7-zipped         | Great – 125,830 bytes      | Worst – Entire dataset must be uncompressed, then the plane must be   |
-|                           |                            | decoded from base64.                                                  |
-+---------------------------+----------------------------+-----------------------------------------------------------------------+
+The header of the :ometiff_downloads:`master OME-TIFF file <binary-only/multifile-Z1.ome.tiff>` 
+contains the complete OME-XML metadata while the OME-XML metadata stored into
+the header of the four other files refer to this master OME-TIFF file using the
+:ref:`partial OME-XML metadata <binary_only>` specification.
 
-The performance penalty for accessing individual image planes from
-externally compressed formats (zip, gzip, and 7-zip) is high, since the
-data must be decompressed. There is little penalty for accessing them
-from uncompressed OME-XML or OME-TIFF—with OME-XML, file readers can
-build a list of offsets by skipping past the bulk of the BinData
-characters according to the Length attribute values, and with OME-TIFF,
-file readers can seek to the offsets indicated in the IFD entries.
+.. _companion-sample:
 
-Accessing them from an uncompressed OME-TIFF file, however, is
-efficient. In addition, the TIFF format maintains compatibility with the
-multitude of existing software that works with single- and multi-page
-TIFF files.
+Companion OME-TIFF fileset
+""""""""""""""""""""""""""
 
-Space required on disk
-----------------------
+The :ometiff_downloads:`companion OME-TIFF fileset<companion>` contains a set 
+of 18 by 24 pixel images (with black and white text on each plane giving its 
+time, z-depth and channel) where each of the five Z sections are saved as a separate file and a companion file.
 
-As shown in the table above, and the chart :ref:`figure-tiff-chart`, our 
-figures indicate that the most efficient format for space is OME-TIFF 
-compressed with the `7-zip <http://www.7-zip.org/>`_ utility. Also good are 
-gzipped OME-XML and zipped OME-TIFF.
-
-.. _figure-tiff-chart:
-
-.. figure:: /images/ome-tiff-chart.png
-   :align: center
-   :alt: OME-TIFF space used
-
-   OME-TIFF space used
-
-Uncompressed OME-TIFF format, while the least space-efficient, provides
-its own advantages: it is highly compatible and provides efficient
-access to individual image planes.
-
-OME-TIFF with LZW often performs nearly as well as the externally
-compressed formats (zip, gzip and 7-zip), without the performance
-penalty of searching through a compressed archive. However, LZW is
-noticeably less efficient to decode than uncompressed TIFF is, and LZW
-is an additional requirement for client software—it may be that some
-software supports uncompressed multi-page TIFF, but not LZW. Even more
-unfortunate, the 7-zip algorithm appears to perform less well on
-LZW-compressed OME-TIFFs than on uncompressed OME-TIFFs.
-
-Recommendations
----------------
-
-In conclusion, we highlight the following formats as most useful,
-depending on your circumstances:
-
--  **Zipped OME-TIFF** – cuts down on file size while retaining the
-   underlying compatibility of OME-TIFF. Use zipped OME-TIFF for wide
-   distribution of data to colleagues. Zip is a ubiquitous compression
-   format, decodable on all major operating systems. The downside is
-   that it typically does not compress as well as 7-zip does.
--  **7-zipped OME-TIFF** – minimizes file size. As the most
-   space-efficient format, use 7-zipped OME-TIFF for archival purposes,
-   for transport from one OME database to another, and possibly for
-   online distribution if space is a major concern and your target
-   audience is computer-savvy enough to install 7-zip. The only
-   downsides are that 7-zip is less ubiquitous than zip, and compressing
-   a dataset with 7-zip takes longer than doing so with zip.
--  **OME-TIFF with LZW** – provides space advantages nearly as good as
-   the externally compressed formats (zip, gzip, 7-zip) without
-   sacrificing the accessibility of TIFF, for the most part. The
-   downsides are that LZW takes somewhat longer to process than
-   uncompressed TIFF, some software does not support LZW compression,
-   and OME-TIFF with LZW does not shrink as much as uncompressed
-   OME-TIFF does with external compression techniques.
--  **OME-TIFF** – maximizes compatibility. When actively working with
-   data, storing it in uncompressed OME-TIFF format provides many
-   options for efficient analysis and visualization. The downside is
-   that the data takes up more space on disk.
--  **OME-XML** – provides metadata in a directly human-readable form. In
-   addition, OME-XML maximizes compatibility with XML software. The
-   downside is that very few image software packages support OME-XML.
-
+The :ometiff_downloads:`companion fileset<companion/multifile.companion.ome>` contains the complete OME-XML metadata
+for the fileset while the five OME-TIFF files refer to this companion file 
+using the :ref:`partial OME-XML metadata<binary_only>` specification.
 

--- a/formats/ome-tiff/data.txt
+++ b/formats/ome-tiff/data.txt
@@ -88,8 +88,7 @@ Sample files implementing the :doc:`/developers/6d-7d-and-8d-storage` are availa
 SPIM
 """"
 
-- :ometiff_downloads:`SPIM-ModuloAlongZ.ome.tiff <modulo/SPIM-ModuloAlongZ.ome.tiff>` - a 2x2 tile of planes
-  each recorded at 4 angles.
+- :ometiff_downloads:`SPIM-ModuloAlongZ.ome.tiff <modulo/SPIM-ModuloAlongZ.ome.tiff>` - 4 tiles each recorded at 4 angles.
 
 Big lambda
 """"""""""

--- a/formats/ome-tiff/data.txt
+++ b/formats/ome-tiff/data.txt
@@ -52,7 +52,7 @@ version) containing every constituent image plane.
      * 5
      * 1
 
-  -  * :ometiff_downloads:`time-series.ome.tif <bioformats-artificial/tim-series.ome.tif>`
+  -  * :ometiff_downloads:`time-series.ome.tif <bioformats-artificial/time-series.ome.tif>`
      * 1
      * 1
      * 7
@@ -176,12 +176,12 @@ Partial OME-XML metadata datasets
 Binary only OME-TIFF fileset
 """"""""""""""""""""""""""""
 
-The :ometiff_downloads:`binary only OME-TIFF fileset <binary-only>` contains a
+The :ometiff_downloads:`binary only OME-TIFF fileset <binaryonly>` contains a
 set of 18 by 24 pixel images (with black and white text on each plane giving
 its time, z-depth and channel) where each of the five Z sections are saved as
 a separate file.
 
-The header of the :ometiff_downloads:`master OME-TIFF file <binary-only/multifile-Z1.ome.tiff>` 
+The header of the :ometiff_downloads:`master OME-TIFF file <binaryonly/multifile-Z1.ome.tiff>` 
 contains the complete OME-XML metadata while the OME-XML metadata stored into
 the header of the four other files refer to this master OME-TIFF file using the
 :ref:`partial OME-XML metadata <binary_only>` specification.

--- a/formats/ome-tiff/data.txt
+++ b/formats/ome-tiff/data.txt
@@ -167,34 +167,36 @@ The files available for download have been updated to the current schema version
      * 43
      * 86
 
-Partial OME-XML metadata datasets
+Partial OME-XML metadata filesets
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. _binary-only-sample:
+The :ometiff_downloads:`master OME-TIFF fileset <binaryonly>` and
+:ometiff_downloads:`companion OME-XML fileset <companion>` both contain a set
+of 18 by 24 pixel images with black and white text on each plane giving
+its time, z-depth and channel. Each of the five focal planes is saved as a
+separate OME-TIFF named :file:`multifile-Zxx.ome.tiff` where `xx` is the index
+of the focal plane.
 
-Binary only OME-TIFF fileset
-""""""""""""""""""""""""""""
+.. _master-sample:
 
-The :ometiff_downloads:`binary only OME-TIFF fileset <binaryonly>` contains a
-set of 18 by 24 pixel images (with black and white text on each plane giving
-its time, z-depth and channel) where each of the five Z sections are saved as
-a separate file.
+Master OME-TIFF fileset
+"""""""""""""""""""""""
 
-The header of the :ometiff_downloads:`master OME-TIFF file <binaryonly/multifile-Z1.ome.tiff>` 
-contains the complete OME-XML metadata while the OME-XML metadata stored into
-the header of the four other files refer to this master OME-TIFF file using the
-:ref:`partial OME-XML metadata <binary_only>` specification.
+For this sample, the full OME-XML metadata describing the whole fileset is
+embedded into a
+:ometiff_downloads:`master OME-TIFF file <binaryonly/multifile-Z1.ome.tiff>`.
+Partial OME-XML metadata blocks are embedded into the four other OME-TIFF
+files and refer to the master OME-TIFF file as described in the
+:ref:`specification <binary_only>`.
 
 .. _companion-sample:
 
 Companion OME-TIFF fileset
 """"""""""""""""""""""""""
 
-The :ometiff_downloads:`companion OME-TIFF fileset<companion>` contains a set 
-of 18 by 24 pixel images (with black and white text on each plane giving its 
-time, z-depth and channel) where each of the five Z sections are saved as a separate file and a companion file.
-
-The :ometiff_downloads:`companion fileset<companion/multifile.companion.ome>` contains the complete OME-XML metadata
-for the fileset while the five OME-TIFF files refer to this companion file 
-using the :ref:`partial OME-XML metadata<binary_only>` specification.
-
+For this sample, the full OME-XML metadata describing the whole fileset is
+stored into a separate
+:ometiff_downloads:`companion OME-XML file<companion/multifile.companion.ome>`.
+Partial OME-XML metadata blocks are embedded into the five OME-TIFF
+files and refer to the companion OME-XML file as described in the
+:ref:`specification <binary_only>`.

--- a/formats/ome-tiff/file-structure.txt
+++ b/formats/ome-tiff/file-structure.txt
@@ -71,8 +71,8 @@ Companion file vs master OME-TIFF file
 Since the :doc:`2011-06 version</schemas/june-2011>` of the OME-XML schema, it
 is possible to store partial OME-XML metadata blocks in some or all of the
 TIFF files pointing to a master file containing the full OME-XML metadata.
-The master file can be either another OME-TIFF file  (see the
-:ref:`binary-only-sample`) or a companion OME-XML file (see the
+The master file can be either a master OME-TIFF file  (see the
+:ref:`master-sample`) or a companion OME-XML file (see the
 :ref:`companion-sample`).
 
 Using a companion OME-XML file allows information that can only be generated

--- a/formats/ome-tiff/file-structure.txt
+++ b/formats/ome-tiff/file-structure.txt
@@ -11,8 +11,8 @@ Splitting a fileset across multiple files can have advantages in terms of
 acquisition but also processing purposes. The OME-TIFF file format can support
 any image organization. However, using one TIFF file per timepoint per channel
 with the focal planes for that timepoint and channel stored sequentially
-within the TIFF makes for very easy creation of :ref:`TiffData` elements (see
-:ref:`tubhiswt_samples`).
+within the TIFF makes for very easy creation of :ref:`TiffData <TiffData>`
+elements (see :ref:`tubhiswt_samples`).
 
 The main downside of splitting OME-TIFF over multiple files is their
 inherent fragility to common file-system operations such as file renaming or
@@ -70,7 +70,9 @@ Companion file vs master OME-TIFF file
 
 Since the :doc:`2011-06 version</schemas/june-2011>` of the OME-XML schema, it
 is possible to store partial OME-XML metadata blocks in some or all of the
-TIFF files pointing to a master file containing the full OME-XML metadata.
+TIFF files pointing to a master file containing the full OME-XML metadata (see
+the :ref:`technical specification<binary_only>` for more details).
+
 The master file can be either a master OME-TIFF file  (see the
 :ref:`master-sample`) or a companion OME-XML file (see the
 :ref:`companion-sample`).
@@ -82,9 +84,6 @@ highlighted above in the sense that this companion file needs to be preserved
 as part of the fileset to prevent metadata loss.
 
 .. seealso::
-
-   :ref:`binary_only`
-      Technical specification about partial OME-XML metadata
 
    :ome-devel:`Proposed tweak to µManager data files in 2.0 <2016-April/003618.html>`
       Community discussion about usage of companion file in OME-TIFF filesets

--- a/formats/ome-tiff/file-structure.txt
+++ b/formats/ome-tiff/file-structure.txt
@@ -11,7 +11,8 @@ Splitting a fileset across multiple files can have advantages in terms of
 acquisition but also processing purposes. The OME-TIFF file format can support
 any image organization. However, using one TIFF file per timepoint per channel
 with the focal planes for that timepoint and channel stored sequentially
-within the TIFF makes for very easy creation of :ref:`TiffData` elements.
+within the TIFF makes for very easy creation of :ref:`TiffData` elements (see
+:ref:`tubhiswt_samples`).
 
 The main downside of splitting OME-TIFF over multiple files is their
 inherent fragility to common file-system operations such as file renaming or
@@ -36,7 +37,8 @@ Metadata redundancy
 -------------------
 
 Storing multiple planes per OME-TIFF file and keeping the OME-XML metadata
-embedded in every file header is recommended but is not always practical.
+embedded in every file header is recommended (see the
+:ometiff_downloads:`binary only OME-TIFF fileset sample <binaryonly>`) but is not always practical.
 Normally, the OME-XML metadata block is small in comparison with the binary
 pixel data in the file, but in some cases, it may be disproportionately
 larger.
@@ -66,8 +68,10 @@ Companion file vs master OME-TIFF file
 Since the :doc:`2011-06 version</schemas/june-2011>` of the OME-XML schema, it
 is possible to store partial OME-XML metadata blocks in some or all of the
 TIFF files pointing to a master file containing the full OME-XML metadata.
-The master file can be either another OME-TIFF file or a companion OME-XML
-file.
+The master file can be either another OME-TIFF file  (see the
+:ometiff_downloads:`binary only OME-TIFF fileset sample <binaryonly>`) or a
+companion OME-XML file (see the
+:ometiff_downloads:`companion fileset sample <companion>`).
 
 Using a companion OME-XML file allows information that can only be generated
 at the end of the acquisition to be easily appended without the need to

--- a/formats/ome-tiff/file-structure.txt
+++ b/formats/ome-tiff/file-structure.txt
@@ -18,6 +18,9 @@ The main downside of splitting OME-TIFF over multiple files is their
 inherent fragility to common file-system operations such as file renaming or
 file copying which have the potential to "break" the fileset.
 
+See :doc:`data` for examples of single OME-TIFF file versus OME-TIFF
+distributed over multiple files.
+
 File size
 ---------
 
@@ -38,7 +41,7 @@ Metadata redundancy
 
 Storing multiple planes per OME-TIFF file and keeping the OME-XML metadata
 embedded in every file header is recommended (see the
-:ometiff_downloads:`binary only OME-TIFF fileset sample <binaryonly>`) but is not always practical.
+:ref:`tubhiswt_samples`) but is not always practical.
 Normally, the OME-XML metadata block is small in comparison with the binary
 pixel data in the file, but in some cases, it may be disproportionately
 larger.
@@ -69,9 +72,8 @@ Since the :doc:`2011-06 version</schemas/june-2011>` of the OME-XML schema, it
 is possible to store partial OME-XML metadata blocks in some or all of the
 TIFF files pointing to a master file containing the full OME-XML metadata.
 The master file can be either another OME-TIFF file  (see the
-:ometiff_downloads:`binary only OME-TIFF fileset sample <binaryonly>`) or a
-companion OME-XML file (see the
-:ometiff_downloads:`companion fileset sample <companion>`).
+:ref:`binary-only-sample`) or a companion OME-XML file (see the
+:ref:`companion-sample`).
 
 Using a companion OME-XML file allows information that can only be generated
 at the end of the acquisition to be easily appended without the need to

--- a/formats/ome-tiff/specification.txt
+++ b/formats/ome-tiff/specification.txt
@@ -432,6 +432,6 @@ should contain the UUID of this master file.
 The master file containing the full OME-XML metadata should be:
 
 - either an OME-XML companion file with the extension :file:`.companion.ome`
-  (see the :ometiff_downloads:`companion fileset sample <companion>`)
+  (see the :ref:`companion-sample`)
 - or an OME-TIFF file containing the full metadata (see the
-  :ometiff_downloads:`binary only OME-TIFF fileset sample <binaryonly>`)
+  :ref:`binary-only-sample`)

--- a/formats/ome-tiff/specification.txt
+++ b/formats/ome-tiff/specification.txt
@@ -433,5 +433,5 @@ The master file containing the full OME-XML metadata should be:
 
 - either an OME-XML companion file with the extension :file:`.companion.ome`
   (see the :ref:`companion-sample`)
-- or an OME-TIFF file containing the full metadata (see the
-  :ref:`binary-only-sample`)
+- or a master OME-TIFF file containing the full metadata (see the
+  :ref:`master-sample`)


### PR DESCRIPTION
Following the last comment in https://github.com/openmicroscopy/ome-documentation/pull/1459#issuecomment-217627466, this PR adds more samples links in the OME-TIFF file structure discussion page.

Additionally, it reviews the content of the OME-TIFF samples page as follows:
- moves the OME-TIFF/OME-XML compression discussion to a separate page
- groups/unifies the description of all OME-TIFF samples under `ome-tiff/data`
- adds missing description for the binary only fileset
- add references that can be linked to from other places in the documentation

To review this PR, check https://www.openmicroscopy.org/site/support/ome-model-staging/ and especially https://www.openmicroscopy.org/site/support/ome-model-staging/ome-tiff/data.html. The goal is to increase the clarity/lisibility/maintenance of the samples section while allowing to link from it from other places.
