### PR TITLE
Define schema documentation alias

### DIFF
--- a/formats/conf.py
+++ b/formats/conf.py
@@ -42,6 +42,7 @@ model_extlinks = {
     # Doc links
     'omero_doc' : (oo_site_root + '/support/omero/%s', ''),
     'bf_doc' : (oo_site_root + '/support/bio-formats/%s', ''),
+    'schema_doc' : (oo_root + '/schema_doc/' + release + '/%s', ''),
     # Downloads
     'bf_downloads' : (downloads_root + '/latest/bio-formats/%s', ''),
     'image_downloads' : (downloads_root + '/images/%s', ''),

--- a/formats/conf.py
+++ b/formats/conf.py
@@ -42,7 +42,7 @@ model_extlinks = {
     # Doc links
     'omero_doc' : (oo_site_root + '/support/omero/%s', ''),
     'bf_doc' : (oo_site_root + '/support/bio-formats/%s', ''),
-    'schema_doc' : (oo_root + '/schema_doc/' + release + '/%s', ''),
+    'schema_doc' : (oo_root + '/Schemas/Documentation/Generated/OME-' + release + '/%s', ''),
     # Downloads
     'bf_downloads' : (downloads_root + '/latest/bio-formats/%s', ''),
     'image_downloads' : (downloads_root + '/images/%s', ''),

--- a/formats/developers/index.txt
+++ b/formats/developers/index.txt
@@ -45,8 +45,8 @@ Working with the OME Data Model
 
 The :doc:`Model Overview collection of diagrams <model-overview>` shows the
 structure and connections between different parts of the OME Model. Generated
-documentation for the :schema_plone:`current version of the entire Schema
-<Documentation/Generated/OME-2015-01/ome.html>` is also available.
+documentation for the :schema_doc:`current version of the entire Schema
+<ome.html>` is also available.
 
 Individual parts of the model are covered in more detail in the following
 sections:

--- a/formats/developers/model-overview.txt
+++ b/formats/developers/model-overview.txt
@@ -3,8 +3,8 @@ Current Data Model overview
 
 The diagrams below illustrate some aspects of the model and further details
 are given on the following pages. Generated documentation for the
-:schema_plone:`current version of the entire Schema
-<Documentation/Generated/OME-2015-01/ome.html>` is also available.
+:schema_doc:`current version of the entire Schema <ome.html>` is also
+available.
 
 .. figure:: /images/Image-Overview.*
    :align: center

--- a/formats/index.txt
+++ b/formats/index.txt
@@ -98,8 +98,8 @@ Developer tools and guidelines
 The Data Model in detail
 ************************
 
-Generated documentation for the :schema_plone:`current version of the entire
-Schema <Documentation/Generated/OME-2015-01/ome.html>` is also available.
+Generated documentation for the :schema_doc:`current version of the entire
+Schema <ome.html>` is also available.
 
 .. toctree::
     :maxdepth: 1

--- a/formats/ome-tiff/specification.txt
+++ b/formats/ome-tiff/specification.txt
@@ -108,7 +108,7 @@ The TiffData element
 
 As the illustration :ref:`figure-tiff-header` shows, all that is needed to 
 indicate that the pixels are located within the enclosing TIFF structure is a
-:schema_plone:`TiffData <Documentation/Generated/OME-2015-01/ome_xsd.html#TiffData>`
+:schema_doc:`TiffData <ome_xsd.html#TiffData>`
 element with no attributes. By default, the first IFD corresponds to
 the first image plane (Z0-T0-C0), and the rasterization order of subsequent
 IFDs is given by the Pixels element's DimensionOrder attribute, as
@@ -117,19 +117,19 @@ described above.
 However, there are several attributes for TiffData elements allowing
 greater control over the dimensional position of each IFD:
 
--  :schema_plone:`IFD <Documentation/Generated/OME-2015-01/ome_xsd.html#TiffData_IFD>`
+-  :schema_doc:`IFD <ome_xsd.html#TiffData_IFD>`
    - gives the IFD(s) for which this element is applicable.
    Indexed from 0. Default is 0 (the first IFD).
--  :schema_plone:`FirstZ <Documentation/Generated/OME-2015-01/ome_xsd.html#TiffData_FirstZ>`
+-  :schema_doc:`FirstZ <ome_xsd.html#TiffData_FirstZ>`
    - gives the Z position of the image plane at the specified
    IFD. Indexed from 0. Default is 0 (the first Z position).
--  :schema_plone:`FirstT <Documentation/Generated/OME-2015-01/ome_xsd.html#TiffData_FirstT>`
+-  :schema_doc:`FirstT <ome_xsd.html#TiffData_FirstT>`
    - gives the T position of the image plane at the specified
    IFD. Indexed from 0. Default is 0 (the first T position).
--  :schema_plone:`FirstC <Documentation/Generated/OME-2015-01/ome_xsd.html#TiffData_FirstC>`
+-  :schema_doc:`FirstC <ome_xsd.html#TiffData_FirstC>`
    - gives the C position of the image plane at the specified
    IFD. Indexed from 0. Default is 0 (the first C position).
--  :schema_plone:`PlaneCount <Documentation/Generated/OME-2015-01/ome_xsd.html#TiffData_PlaneCount>`
+-  :schema_doc:`PlaneCount <ome_xsd.html#TiffData_PlaneCount>`
    - gives the number of IFDs affected. Dimension order of
    IFDs is given by the enclosing Pixels element's DimensionOrder
    attribute. Default is the number of IFDs in the TIFF file, unless an
@@ -308,13 +308,13 @@ define which dimensional positions correspond to which IFDs from which
 files. Each OME-TIFF need not contain the same number of images.
 
 The only difference between the OME-XML metadata block per TIFF file is the
-:schema_plone:`UUID <Documentation/Generated/OME-2015-01/ome_xsd.html#OME_UUID>`
+:schema_doc:`UUID <ome_xsd.html#OME_UUID>`
 attribute of the root OME element. This value should be a distinct
 UUID value for each file, so that each TiffData element can
 unambiguously reference its relevant file using a UUID child element.
 
    .. note::
-     The :schema_plone:`FileName <Documentation/Generated/OME-2015-01/ome_xsd.html#TiffData_TiffData_UUID_FileName>`
+     The :schema_doc:`FileName <ome_xsd.html#TiffData_TiffData_UUID_FileName>`
      attribute of the UUID is optional, but strongly recommended—otherwise,
      the OME-TIFF reader must scan OME-TIFF files in the working directory
      looking for matching UUID signatures.
@@ -329,7 +329,7 @@ In the first case, a nearly identical OME-XML metadata block must be inserted
 into the first IFD of each constituent OME-TIFF file.
 
 The only difference between the OME-XML metadata block per TIFF file is the
-:schema_plone:`UUID <Documentation/Generated/OME-2015-01/ome_xsd.html#OME_UUID>`
+:schema_doc:`UUID <ome_xsd.html#OME_UUID>`
 attribute of the root OME element. This value should be a distinct
 UUID value for each file, so that each TiffData element can
 unambiguously reference its relevant file using a UUID child element.
@@ -407,7 +407,7 @@ Partial OME-XML metadata
 Instead of embedding the full OME-XML metadata into the header of each
 OME-TIFF, partial OME-XML metadata blocks can be stored in some or all of the
 OME-TIFF files using the
-:schema_plone:`Binary-Only <Documentation/Generated/OME-2015-01/ome_xsd.html#OME_BinaryOnly>`
+:schema_doc:`Binary-Only <ome_xsd.html#OME_BinaryOnly>`
 element as illustrated below::
 
     <?xml version="1.0" encoding="UTF-8" standalone="no"?>
@@ -424,9 +424,10 @@ element as illustrated below::
                    UUID="urn:uuid:4978087c-a670-4b12-af53-256c62d8d101"/>
     </OME>
 
-The :schema_plone:`MetadataFile <Documentation/Generated/OME-2015-01/ome_xsd.html#OME_OME_BinaryOnly_MetadataFile>`
+The :schema_doc:`MetadataFile <ome_xsd.html#OME_OME_BinaryOnly_MetadataFile>`
 element should contain the name of the master file containing the full
-OME-XML metadata  block and :schema_plone:`UUID <Documentation/Generated/OME-2015-01/ome_xsd.html#OME_OME_BinaryOnly_UUID>`
+OME-XML metadata  block and
+:schema_doc:`UUID <ome_xsd.html#OME_OME_BinaryOnly_UUID>`
 should contain the UUID of this master file.
 
 The master file containing the full OME-XML metadata should be:

--- a/formats/schemas/index.txt
+++ b/formats/schemas/index.txt
@@ -109,8 +109,8 @@ Auto-generated documentation is available for each release of the
 schema, including information on each attribute and element. These are
 published as :schema_plone:`XSD files <>` on the OME website. They are usually
 read by XML validators and parsers but are viewable as text files.
-Alternatively, you can browse the :schema_plone:`current version of the entire
-Schema <Documentation/Generated/OME-2015-01/ome.html>` online.
+Alternatively, you can browse the
+:schema_doc:`current version of the entire Schema <ome.html>` online.
 
 .. note:: 
     Any schemas and documentation below

--- a/formats/schemas/september-2009.txt
+++ b/formats/schemas/september-2009.txt
@@ -36,9 +36,6 @@ and that the schema file will be located at
 Overview of changes
 -------------------
 
--  Full auto-generated documentation for the schema is available at
-   :schema_plone:`OME-2009-09 <Documentation/Generated/OME-2009-09/ome.html>`
-
 Additional Schema file ROI.xsd
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
As part of the schema release process review, a proposal is to have the oXygen generated documentation served under a more canonical URL. This PR updates the Model and Formats documentation set to define an extlink alias for the schema documentation simplifying future updates.

To test this PR, check the build passes and the link checking is passing

Update: as this discussion turned into a debate about documentation URLs, I proposed to stick to the old URL for testing the [schema release workflow](https://trello.com/c/zkbHhnNO/31-schema-release-process), postpone the new URL decision and give us more time to include all relevant topics including [OME FIles documentation](https://trello.com/c/01I3lWQa/3-discuss-ome-files-docs) and plone migration. 
