### PR TITLE
Add 5.2.4 history to docs

### DIFF
--- a/omero/users/history.txt
+++ b/omero/users/history.txt
@@ -1,6 +1,19 @@
 OMERO version history
 =====================
 
+5.2.4 (May 2016)
+----------------
+
+This is a security release to fix the cleanse.py script used by the "bin/omero
+admin cleanse" command, which was not properly respecting user permissions and
+may lead to data loss.
+
+See :secvuln:`2016-SV1-cleanse` for details. The script and command have now
+been made admin-only.
+
+It is highly suggested that you upgrade your server or apply the patch
+available from the security page.
+
 5.2.3 (May 2016)
 ----------------
 


### PR DESCRIPTION
Implements https://github.com/openmicroscopy/openmicroscopy/pull/4692 in the docs since we don't have the autogen stuff set up for this branch

Staged at https://www.openmicroscopy.org/site/support/omero5.2-staging/users/history.html
