### PR TITLE
Update Homebrew link

### DIFF
--- a/omero/sysadmins/version-requirements.txt
+++ b/omero/sysadmins/version-requirements.txt
@@ -635,7 +635,7 @@ Package lists
     * - Debian
       - `Reference <https://packages.debian.org/search?keywords=foo&searchon=names&suite=all&section=all>`__
     * - Homebrew
-      - `Reference <https://github.com/Homebrew/homebrew/tree/master/Library/Formula>`__
+      - `Reference <https://github.com/Homebrew/homebrew-core/tree/master/Formula>`__
     * - FreeBSD Ports
       - `Reference <http://svnweb.freebsd.org/ports/head/>`__
 


### PR DESCRIPTION
See https://ci.openmicroscopy.org/view/Docs/job/OMERO-DEV-merge-docs/363/warnings3Result/ - this PR updates the Homebrew link after the repo was split out and the old link removed.
