### PR TITLE
Replace non-functional example with a working one

### DIFF
--- a/omero/developers/testing.txt
+++ b/omero/developers/testing.txt
@@ -97,7 +97,7 @@ working on. This can be done using the ``test`` target. For example:
 
 ::
 
-    ./build.py -f components/tools/OmeroJava/build.xml test -DTEST=integration/AdminTest
+    ./build.py -f components/tools/OmeroJava/build.xml test -DTEST=integration/chown/PermissionsTest
     ./build.py -f components/tools/OmeroPy/build.xml test -DTEST=test/integration/test_admin.py
 
 Running Java tests


### PR DESCRIPTION
Just fixing an example in http://www.openmicroscopy.org/site/support/omero5.2/developers/testing.html#individual-test-class-methods. The status at present is that this example does not execute any tests because there are none of the specified name. This PR is replacing the example with more present test, which executes fine with a reasonable output.

Staged at http://www.openmicroscopy.org/site/support/omero5.2-staging/developers/testing.html#individual-test-class-methods 

cc @ximenesuk @mtbc 
