### PR TITLE
Updating OME-TIFF & XML docs for 2016-06

### DIFF
--- a/formats/developers/compression.txt
+++ b/formats/developers/compression.txt
@@ -38,9 +38,9 @@ types.
 | **Size (7-zipped OME-TIFF with LZW)**                       | 264,292 bytes         | 4,950,897 bytes         | 116,567,097 bytes        |
 +-------------------------------------------------------------+-----------------------+-------------------------+--------------------------+
 
-.. _tubhiswt-2D.zip: http://downloads.openmicroscopy.org/images/OME-TIFF/2015-01/tubhiswt-2D.zip
-.. _tubhiswt-3D.zip: http://downloads.openmicroscopy.org/images/OME-TIFF/2015-01/tubhiswt-3D.zip
-.. _tubhiswt-4D.zip: http://downloads.openmicroscopy.org/images/OME-TIFF/2015-01/tubhiswt-4D.zip
+.. _tubhiswt-2D.zip: http://downloads.openmicroscopy.org/images/OME-TIFF/2016-06/tubhiswt-2D.zip
+.. _tubhiswt-3D.zip: http://downloads.openmicroscopy.org/images/OME-TIFF/2016-06/tubhiswt-3D.zip
+.. _tubhiswt-4D.zip: http://downloads.openmicroscopy.org/images/OME-TIFF/2016-06/tubhiswt-4D.zip
 
 
 Efficiency of planar access

--- a/formats/developers/using-ome-xml.txt
+++ b/formats/developers/using-ome-xml.txt
@@ -247,16 +247,14 @@ example illustrates how to include ``<LightSource>`` and ``<Objective>``:
         </YourNodes>
 
         <!-- Insert a LightSource node from the 2016-06 version of our schema -->
-        <LightSource xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06"
-            xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06
+        <Laser xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06"
+               xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06
                  http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd"
-            ID="LightSource:1">
-            <Laser Type="Dye" FrequencyMultiplication="2" LaserMedium="CoumarinC30"
-                PockelCell="true" Pulse="Single" RepetitionRate="1.3" Tuneable="true"
-                Wavelength="640">
-                <Pump ID="LightSource:4"/>
-            </Laser>
-        </LightSource>
+            ID="LightSource:1" Type="Dye" FrequencyMultiplication="2"
+            LaserMedium="CoumarinC30" PockelCell="true" Pulse="Single"
+            RepetitionRate="1.3" Tuneable="true" Wavelength="640">
+          <Pump ID="LightSource:4"/>
+        </Laser>
         <!-- Finish the LightSource node, and continue with your custom schema -->
 
         <MoreOfYourNodes>

--- a/formats/developers/using-ome-xml.txt
+++ b/formats/developers/using-ome-xml.txt
@@ -7,7 +7,7 @@ This sections explains how to use OME schema elements in your own XML files.
     The correct attribution for work derived from our schema files under the 
     Creative Commons licence is:
     **"This work is derived in part from the OME specification.
-    Copyright (C) 2002-2015 Open Microscopy Environment"**
+    Copyright (C) 2002-2016 Open Microscopy Environment"**
 
 We encourage people to make use of the OME Data Model as a
 whole by using the OME-XML and OME-TIFF formats directly. If you need to
@@ -145,10 +145,10 @@ schema specification:
             <With your="attributes"/>
         </YourNodes>
 
-        <!-- Insert an OME node from the 2015-01 version of our schema -->
-        <OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2015-01"
-            xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2015-01
-                                http://www.openmicroscopy.org/Schemas/OME/2015-01/ome.xsd"
+        <!-- Insert an OME node from the 2016-06 version of our schema -->
+        <OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06"
+            xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06
+                                http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd"
             >
             <Image ID="Image:1">
                 <AcquisitionDate>2010-02-23T12:51:30</AcquisitionDate>
@@ -182,7 +182,7 @@ three things (marked ``****``) to your schema specification document:
 
     <!-- **** Define the OME namespace for your schema on the <schema> node **** -->
     <xs:schema 
-        xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2015-01"
+        xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2016-06"
 
         xmlns="http://www.example.org/SampleThirdPartySchema/2013-01" 
         targetNamespace="http://www.example.org/SampleThirdPartySchema/2013-01" 
@@ -191,16 +191,15 @@ three things (marked ``****``) to your schema specification document:
         elementFormDefault="qualified">
 
         <!-- **** Include the OME namespace to make it accessible from your schema **** -->
-        <xs:import namespace="http://www.openmicroscopy.org/Schemas/OME/2015-01"
-        schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2015-01/ome.xsd"/>
+        <xs:import namespace="http://www.openmicroscopy.org/Schemas/OME/2016-06"
+        schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd"/>
 
         <xs:element name="CustomTag">
             <xs:annotation>
                 <xs:documentation>
                     Open Microscopy Environment
                     OME Sample Third Party
-                    Author: Andrew J Patterson
-                    Copyright 2015 OME.
+                    Copyright 2016 OME.
                 </xs:documentation>
             </xs:annotation>
             <xs:complexType>
@@ -247,10 +246,10 @@ example illustrates how to include ``<LightSource>`` and ``<Objective>``:
             <With your="attributes"/>
         </YourNodes>
 
-        <!-- Insert a LightSource node from the 2015-01 version of our schema -->
-        <LightSource xmlns="http://www.openmicroscopy.org/Schemas/OME/2015-01"
-            xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2015-01
-                 http://www.openmicroscopy.org/Schemas/OME/2015-01/ome.xsd"
+        <!-- Insert a LightSource node from the 2016-06 version of our schema -->
+        <LightSource xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06"
+            xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06
+                 http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd"
             ID="LightSource:1">
             <Laser Type="Dye" FrequencyMultiplication="2" LaserMedium="CoumarinC30"
                 PockelCell="true" Pulse="Single" RepetitionRate="1.3" Tuneable="true"
@@ -262,10 +261,10 @@ example illustrates how to include ``<LightSource>`` and ``<Objective>``:
 
         <MoreOfYourNodes>
 
-            <!-- Insert an Objective node from the 2015-01 version of our schema -->
-            <Objective xmlns="http://www.openmicroscopy.org/Schemas/OME/2015-01"
-                xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2015-01
-                     http://www.openmicroscopy.org/Schemas/OME/2015-01/ome.xsd"
+            <!-- Insert an Objective node from the 2016-06 version of our schema -->
+            <Objective xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06"
+                xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06
+                     http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd"
                 ID="Objective:1" CalibratedMagnification="0.3" Correction="UV" 
                 Immersion="Air" Iris="true" LensNA="1.3" NominalMagnification="2"
                 WorkingDistance="2.3" Manufacturer="OME-Sample" Model="Mk II"
@@ -280,9 +279,9 @@ example illustrates how to include ``<LightSource>`` and ``<Objective>``:
 sample-third-party-pieces.xsd
 '''''''''''''''''''''''''''''
 
-In order to define this sample-third-party-pieces.xml structure, you need to 
-add four lines (marked ``****``) to your schema specification document. The 
-first two lines are the same as the previous schema specification, then add 
+In order to define this sample-third-party-pieces.xml structure, you need to
+add four lines (marked ``****``) to your schema specification document. The
+first two lines are the same as the previous schema specification, then add
 one line for each of the two included nodes:
 
 ::
@@ -291,7 +290,7 @@ one line for each of the two included nodes:
 
     <!-- **** Define the OME namespace for your schema on the <schema> node **** -->
     <xs:schema 
-        xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2015-01"
+        xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2016-06"
 
         xmlns="http://www.example.org/SampleThirdPartySchemaPieces/2013-01" 
         targetNamespace="http://www.example.org/SampleThirdPartySchemaPieces/2013-01" 
@@ -300,16 +299,15 @@ one line for each of the two included nodes:
         elementFormDefault="qualified">
 
         <!-- **** Include the OME namespace to make it accessible from your schema **** -->
-        <xs:import namespace="http://www.openmicroscopy.org/Schemas/OME/2015-01"
-        schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2015-01/ome.xsd"/>
+        <xs:import namespace="http://www.openmicroscopy.org/Schemas/OME/2016-06"
+        schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd"/>
 
         <xs:element name="CustomTag">
             <xs:annotation>
                 <xs:documentation>
                     Open Microscopy Environment
                     OME Sample Third Party
-                    Author: Andrew J Patterson
-                    Copyright 2015 OME.
+                    Copyright 2016 OME.
                 </xs:documentation>
             </xs:annotation>
             <xs:complexType>

--- a/formats/ome-tiff/data.txt
+++ b/formats/ome-tiff/data.txt
@@ -25,7 +25,7 @@ Artificial datasets
 All datasets in the following table were :source:`artificially
 generated <components/formats-bsd/src/loci/formats/tools/MakeTestOmeTiff.java>`
 with each plane labeled according to its dimensional position for easy
-testing. Each one consists of a single OME-TIFF file (2015-01 schema
+testing. Each one consists of a single OME-TIFF file (2016-06 schema
 version) containing every constituent image plane. 
 
 .. list-table::
@@ -133,7 +133,8 @@ XP 3200+ with 1GB of RAM) using
 planes were collected at 512x512 resolution in 8-bit grayscale, with an
 integration value of 2.
 
-The files available for download have been updated to the current schema version since their initial creation.
+The files available for download have been updated to the current schema
+version since their initial creation.
 
 .. list-table::
   :header-rows: 1

--- a/formats/ome-tiff/specification.txt
+++ b/formats/ome-tiff/specification.txt
@@ -361,9 +361,9 @@ example the identifiers could be distributed as follows:
             </UUID>
           </TiffData>
     ...
-          <TiffData FirstC="0" FirstT="0" FirstZ="1" IFD="1" PlaneCount="1">
-            <UUID FileName="tubhiswt_C0_TP0.ome.tif">
-              urn:uuid:45c8bf18-6aa2-478c-9080-e0b0d3eb1f70
+          <TiffData FirstC="0" FirstT="1" FirstZ="1" IFD="1" PlaneCount="1">
+            <UUID FileName="tubhiswt_C0_TP1.ome.tif">
+              urn:uuid:743275b7-6726-46bd-b7bb-aca3085f429a
             </UUID>
           </TiffData>
     ...

--- a/formats/ome-tiff/specification.txt
+++ b/formats/ome-tiff/specification.txt
@@ -351,8 +351,8 @@ example the identifiers could be distributed as follows:
          xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06
          http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd">
     ...
-        <Pixels BigEndian="false" DimensionOrder="XYZTC" ID="Pixels:0" 
-                Interleaved="false" SignificantBits="8" SizeC="2" SizeT="43" 
+        <Pixels BigEndian="false" DimensionOrder="XYZTC" ID="Pixels:0"
+                Interleaved="false" SignificantBits="8" SizeC="2" SizeT="43"
                 SizeX="512" SizeY="512" SizeZ="10" Type="uint8">
     ...
           <TiffData FirstC="0" FirstT="0" FirstZ="0" IFD="0" PlaneCount="1">
@@ -375,7 +375,7 @@ example the identifiers could be distributed as follows:
     <OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          Creator="OME Bio-Formats 5.2.0-m4" 
-         UUID="urn:uuid:743275b7-6726-46bd-b7bb-aca3085f429a" 
+         UUID="urn:uuid:743275b7-6726-46bd-b7bb-aca3085f429a"
          xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06
          http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd"
     ...
@@ -418,7 +418,7 @@ element as illustrated below::
          xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06
-            http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd">
+         http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd">
        <BinaryOnly MetadataFile="multifile.companion.ome"
                    UUID="urn:uuid:07504f88-7bc3-11e0-b937-2faf67bc00b3"/>
     </OME>

--- a/formats/ome-tiff/specification.txt
+++ b/formats/ome-tiff/specification.txt
@@ -314,11 +314,11 @@ attribute of the root OME element. This value should be a distinct
 UUID value for each file, so that each TiffData element can
 unambiguously reference its relevant file using a UUID child element.
 
-   .. note::
-     The :schema_doc:`FileName <ome_xsd.html#TiffData_TiffData_UUID_FileName>`
-     attribute of the UUID is optional, but strongly recommended—otherwise,
-     the OME-TIFF reader must scan OME-TIFF files in the working directory
-     looking for matching UUID signatures.
+.. note::
+    The :schema_doc:`FileName <ome_xsd.html#TiffData_TiffData_UUID_FileName>`
+    attribute of the UUID is optional, but strongly recommended—otherwise,
+    the OME-TIFF reader must scan OME-TIFF files in the working directory
+    looking for matching UUID signatures.
 
 When splitting an OME-TIFF across multiple files, the OME-XML metadata must
 either be embedded into each TIFF file or use partial metadata blocks.
@@ -340,15 +340,44 @@ distributed across multiple files. Each of the files in the set has identical
 metadata apart from the `UUID`, the unique identifier in each file. For
 example the identifiers could be distributed as follows:
 
-**tubhiswt_C0_TP0.ome.tif** with ID 69bfd94f-2d95-41ae-887d-26e0c11fd606
+**tubhiswt_C0_TP0.ome.tif** with ID 45c8bf18-6aa2-478c-9080-e0b0d3eb1f70
 
 ::
 
-    <OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2015-01"
+    <OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         UUID="urn:uuid:69bfd94f-2d95-41ae-887d-26e0c11fd606"
-         xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2015-01
-                             http://www.openmicroscopy.org/Schemas/OME/2015-01/ome.xsd">
+         Creator="OME Bio-Formats 5.2.0-m4"
+         UUID="urn:uuid:45c8bf18-6aa2-478c-9080-e0b0d3eb1f70"
+         xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06
+         http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd">
+    ...
+        <Pixels BigEndian="false" DimensionOrder="XYZTC" ID="Pixels:0" 
+                Interleaved="false" SignificantBits="8" SizeC="2" SizeT="43" 
+                SizeX="512" SizeY="512" SizeZ="10" Type="uint8">
+    ...
+          <TiffData FirstC="0" FirstT="0" FirstZ="0" IFD="0" PlaneCount="1">
+            <UUID FileName="tubhiswt_C0_TP0.ome.tif">
+              urn:uuid:45c8bf18-6aa2-478c-9080-e0b0d3eb1f70
+            </UUID>
+          </TiffData>
+    ...
+          <TiffData FirstC="0" FirstT="0" FirstZ="1" IFD="1" PlaneCount="1">
+            <UUID FileName="tubhiswt_C0_TP0.ome.tif">
+              urn:uuid:45c8bf18-6aa2-478c-9080-e0b0d3eb1f70
+            </UUID>
+          </TiffData>
+    ...
+
+**tubhiswt_C0_TP1.ome.tif** with ID 743275b7-6726-46bd-b7bb-aca3085f429a
+
+::
+
+    <OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         Creator="OME Bio-Formats 5.2.0-m4" 
+         UUID="urn:uuid:743275b7-6726-46bd-b7bb-aca3085f429a" 
+         xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06
+         http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd"
     ...
         <Pixels BigEndian="false" DimensionOrder="XYZTC" ID="Pixels:0"
                 Interleaved="false" SignificantBits="8" SizeC="2" SizeT="43"
@@ -356,48 +385,21 @@ example the identifiers could be distributed as follows:
     ...
           <TiffData FirstC="0" FirstT="0" FirstZ="0" IFD="0" PlaneCount="1">
             <UUID FileName="tubhiswt_C0_TP0.ome.tif">
-              urn:uuid:69bfd94f-2d95-41ae-887d-26e0c11fd606
+              urn:uuid:45c8bf18-6aa2-478c-9080-e0b0d3eb1f70
             </UUID>
           </TiffData>
     ...
           <TiffData FirstC="0" FirstT="1" FirstZ="0" IFD="0" PlaneCount="1">
             <UUID FileName="tubhiswt_C0_TP1.ome.tif">
-              urn:uuid:16093e77-8531-43c5-83df-c71efbd212d0
-            </UUID>
-          </TiffData>
-    ...
-
-**tubhiswt_C0_TP1.ome.tif** with ID 16093e77-8531-43c5-83df-c71efbd212d0
-
-::
-
-    <OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2015-01"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         UUID="urn:uuid:16093e77-8531-43c5-83df-c71efbd212d0"
-         xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2015-01
-                             http://www.openmicroscopy.org/Schemas/OME/2015-01/ome.xsd">
-    ...
-        <Pixels BigEndian="false" DimensionOrder="XYZTC" ID="Pixels:0"
-                Interleaved="false" SignificantBits="8" SizeC="2" SizeT="43"
-                SizeX="512" SizeY="512" SizeZ="10" Type="uint8">
-    ...
-          <TiffData FirstC="0" FirstT="0" FirstZ="0" IFD="0" PlaneCount="1">
-            <UUID FileName="tubhiswt_C0_TP0.ome.tif">
-              urn:uuid:69bfd94f-2d95-41ae-887d-26e0c11fd606
-            </UUID>
-          </TiffData>
-    ...
-          <TiffData FirstC="0" FirstT="1" FirstZ="0" IFD="0" PlaneCount="1">
-            <UUID FileName="tubhiswt_C0_TP1.ome.tif">
-              urn:uuid:16093e77-8531-43c5-83df-c71efbd212d0
+              urn:uuid:743275b7-6726-46bd-b7bb-aca3085f429a
             </UUID>
           </TiffData>
     ...
 
 And so on for files:
 
-- **tubhiswt_C0_TP2.ome.tif** with ID 6d56fc81-8529-4804-bedd-0161435a00b6
-- **tubhiswt_C0_TP3.ome.tif** with ID be825495-1923-4ecd-9ed8-5d5e327cb90b
+- **tubhiswt_C0_TP2.ome.tif** with ID 1f462b60-b508-446e-b42a-c4e6fa2a44e8
+- **tubhiswt_C0_TP3.ome.tif** with ID a023901d-43fd-44f2-b4be-159afa1e985c
 - ...
 
 .. _binary_only:
@@ -411,18 +413,14 @@ OME-TIFF files using the
 :schema_doc:`Binary-Only <ome_xsd.html#OME_BinaryOnly>`
 element as illustrated below::
 
-    <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-    <OME UUID="urn:uuid:f2307570-bede-47a7-aa2b-4e23231ac295"
-         xmlns="http://www.openmicroscopy.org/Schemas/OME/2015-01"
-         xmlns:Bin="http://www.openmicroscopy.org/Schemas/BinaryFile/2015-01"
-         xmlns:SPW="http://www.openmicroscopy.org/Schemas/SPW/2015-01"
-         xmlns:SA="http://www.openmicroscopy.org/Schemas/SA/2015-01"
-         xmlns:ROI="http://www.openmicroscopy.org/Schemas/ROI/2015-01"
+    <?xml version="1.0" encoding="UTF-8"?>
+    <OME UUID="urn:uuid:4978087c-a670-4b12-af53-256c62d8d101"
+         xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2015-01
-                             http://www.openmicroscopy.org/Schemas/OME/2015-01/ome.xsd">
-       <BinaryOnly MetadataFile="multifile-Z1.ome.tiff"
-                   UUID="urn:uuid:4978087c-a670-4b12-af53-256c62d8d101"/>
+         xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06
+            http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd">
+       <BinaryOnly MetadataFile="multifile.companion.ome"
+                   UUID="urn:uuid:07504f88-7bc3-11e0-b937-2faf67bc00b3"/>
     </OME>
 
 The :schema_doc:`MetadataFile <ome_xsd.html#OME_OME_BinaryOnly_MetadataFile>`

--- a/formats/ome-tiff/tools.txt
+++ b/formats/ome-tiff/tools.txt
@@ -21,10 +21,8 @@ line:
     $ identify -verbose
 
 If you are working in C/C++, we recommend the open source
-`LibTIFF <http://www.libtiff.org/>`_ library, the
-:bf_doc:`JACE C++ bindings <developers/jace/overview.html>` for Bio-Formats or
-the new Bio-Formats
-:bf_doc:`native C++ implementation <developers/cpp/overview.html>`.
+`LibTIFF <http://www.libtiff.org/>`_ library or the
+:bf_doc:`Bio-Formats native C++ implementation <developers/cpp/overview.html>`.
 
 If you are looking for a solution in Java, there are several options.
 Bio-Formats can read OME-TIFF files, as well as convert from many

--- a/formats/schemas/index.txt
+++ b/formats/schemas/index.txt
@@ -35,18 +35,18 @@ released. The format for the new URI for the namespace will be
 
     http://www.openmicroscopy.org/Schemas/[NameSpaceTitle]/[YearAsFourDigits]-[MonthAsTwoDigits]
 
-This means the January 2015 major release for the OME schema uses the
+This means the June 2016 major release for the OME schema uses the
 namespace
 
 ::
 
-    http://www.openmicroscopy.org/Schemas/OME/2015-01/
+    http://www.openmicroscopy.org/Schemas/OME/2016-06/
 
 and that the schema file will be located at
 
 ::
 
-    http://www.openmicroscopy.org/Schemas/OME/2015-01/ome.xsd
+    http://www.openmicroscopy.org/Schemas/OME/2016-006/ome.xsd
 
 There will be a consultation period before each major release. Major releases
 may include breaking changes.
@@ -58,7 +58,7 @@ In the schema element of the XSD file, there is a version attribute:
 
 ::
 
-    <xsd:schema xmlns="http://www.openmicroscopy.org/Schemas/OME/2015-01"
+    <xsd:schema xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06"
         …
         version="1" 
         … >

--- a/formats/specifications/compliant-hcs.txt
+++ b/formats/specifications/compliant-hcs.txt
@@ -20,10 +20,10 @@ OME Compliant File Specification
 
 Alternative valid forms:
 
--  would have a ``ome:TiffData`` block instead of the ``bf:BinData`` block 
+-  would have a ``TiffData`` block instead of the ``BinData`` block
    (this would be used in the header of an OME-TIFF file)
--  would have a ``ome:MetadataOnly`` block instead of the ``bf:BinData`` 
-   block (this would be used as a companion to one or more ``ome:BinaryOnly``
+-  would have a ``MetadataOnly`` block instead of the ``BinData`` 
+   block (this would be used as a companion to one or more ``BinaryOnly``
    OME-TIFF files)
 
 .. note:: A units system was added in January 2015. This sample assumes the

--- a/formats/specifications/compliant-hcs.txt
+++ b/formats/specifications/compliant-hcs.txt
@@ -3,8 +3,8 @@ Compliant HCS specification
 
 
 OME compliant HCS file specification. This was developed in conjunction
-with the June 2010 release of the OME-XML Model and has been updated to the 
-January 2015 release.
+with the June 2010 release of the OME-XML Model and has been updated to the
+June 2016 release.
 
 A compliant specification for HCS OME files has been defined. This is
 not the minimum required for the display of an image, that is the

--- a/formats/specifications/deltavision.ome.xml
+++ b/formats/specifications/deltavision.ome.xml
@@ -1,76 +1,44 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<OME:OME xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2016-06"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06
-                        http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd">
+<?xml version="1.0"?>
+<OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xmlns:str="http://exslt.org/strings"
+     xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06                              http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd">
 
-    <OME:Instrument ID="Instrument:0">
-        <OME:Detector ID="Detector:0:0" Model="COOLSNAP_HQ / ICX285" Type="CCD"/>
-        <OME:Objective ID="Objective:10002" Immersion="Oil" LensNA="1.4" Manufacturer="Olympus"
-            NominalMagnification="100"/>
-    </OME:Instrument>
-    <OME:Image ID="Image:1" Name="example_R3D_D3D.dv">
-        <OME:AcquisitionDate>2005-01-28T13:50:08</OME:AcquisitionDate>
-        <OME:Description>An example OME compliant file, 
-            based on a wide-field microscope image</OME:Description>
-        <OME:ObjectiveSettings ID="Objective:10002" Medium="Oil" RefractiveIndex="1.52" 
-            CorrectionCollar="7"/>
-        <OME:Pixels DimensionOrder="XYCZT" ID="Pixels:1" PhysicalSizeX="0.06631"
-            PhysicalSizeY="0.06631" PhysicalSizeZ="0.2" 
-            SizeC="3" SizeT="1" SizeX="480" SizeY="480" SizeZ="5"
-            Type="int16">
-            <OME:Channel EmissionWavelength="457" ExcitationWavelength="360" ID="Channel:1:0"
-                NDFilter="0.5" Name="DAPI" SamplesPerPixel="1" Fluor="DAPI"
-                IlluminationType="Epifluorescence" ContrastMethod="Fluorescence"
-                AcquisitionMode="WideField" Color="65535">
-                <OME:DetectorSettings Binning="1x1" Gain="0.5" ID="Detector:0:0" 
-                    ReadOutRate="10.0"/>
-            </OME:Channel>
-            <OME:Channel EmissionWavelength="528" ExcitationWavelength="490" ID="Channel:1:1"
-                NDFilter="0.0" Name="FITC" SamplesPerPixel="1" Fluor="GFP"
-                IlluminationType="Epifluorescence" ContrastMethod="Fluorescence"
-                AcquisitionMode="WideField" Color="16711935">
-                <OME:DetectorSettings Binning="1x1" Gain="0.5" ID="Detector:0:0" 
-                    ReadOutRate="10.0"/>
-            </OME:Channel>
-            <OME:Channel EmissionWavelength="617" ExcitationWavelength="555" ID="Channel:1:2"
-                NDFilter="0.0" Name="RD-TR-PE" SamplesPerPixel="1" Fluor="TRITC"
-                IlluminationType="Epifluorescence" ContrastMethod="Fluorescence"
-                AcquisitionMode="WideField" Color="-16776961">
-                <OME:DetectorSettings Binning="1x1" Gain="0.5" ID="Detector:0:0"
-                    ReadOutRate="10.0"/>
-            </OME:Channel>
-            <BIN:BinData BigEndian="false" Length="0"/>
-            <OME:Plane DeltaT="0.0" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46"
-                PositionZ="-21.496" TheC="0" TheT="0" TheZ="0"/>
-            <OME:Plane DeltaT="0.294" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46"
-                PositionZ="-21.696" TheC="0" TheT="0" TheZ="1"/>
-            <OME:Plane DeltaT="0.587" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46"
-                PositionZ="-21.896" TheC="0" TheT="0" TheZ="2"/>
-            <OME:Plane DeltaT="0.881" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46"
-                PositionZ="-22.096" TheC="0" TheT="0" TheZ="3"/>
-            <OME:Plane DeltaT="1.174" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46"
-                PositionZ="-22.296" TheC="0" TheT="0" TheZ="4"/>
-            <OME:Plane DeltaT="9.625" ExposureTime="0.3" PositionX="3316.37" PositionY="-646.46"
-                PositionZ="-21.496" TheC="1" TheT="0" TheZ="0"/>
-            <OME:Plane DeltaT="10.12" ExposureTime="0.3" PositionX="3316.37" PositionY="-646.46"
-                PositionZ="-21.696" TheC="1" TheT="0" TheZ="1"/>
-            <OME:Plane DeltaT="10.613" ExposureTime="0.3" PositionX="3316.37" PositionY="-646.46"
-                PositionZ="-21.896" TheC="1" TheT="0" TheZ="2"/>
-            <OME:Plane DeltaT="11.106" ExposureTime="0.3" PositionX="3316.37" PositionY="-646.46"
-                PositionZ="-22.096" TheC="1" TheT="0" TheZ="3"/>
-            <OME:Plane DeltaT="11.599" ExposureTime="0.3" PositionX="3316.37" PositionY="-646.46"
-                PositionZ="-22.296" TheC="1" TheT="0" TheZ="4"/>
-            <OME:Plane DeltaT="25.447" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46"
-                PositionZ="-21.496" TheC="2" TheT="0" TheZ="0"/>
-            <OME:Plane DeltaT="25.739" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46"
-                PositionZ="-21.696" TheC="2" TheT="0" TheZ="1"/>
-            <OME:Plane DeltaT="26.033" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46"
-                PositionZ="-21.896" TheC="2" TheT="0" TheZ="2"/>
-            <OME:Plane DeltaT="26.326" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46"
-                PositionZ="-22.096" TheC="2" TheT="0" TheZ="3"/>
-            <OME:Plane DeltaT="26.619" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46"
-                PositionZ="-22.296" TheC="2" TheT="0" TheZ="4"/>
-        </OME:Pixels>
-    </OME:Image>        
-</OME:OME>
+  <Instrument ID="Instrument:0">
+    <Detector ID="Detector:0:0" Model="COOLSNAP_HQ / ICX285" Type="CCD"/>
+    <Objective ID="Objective:10002" Immersion="Oil" LensNA="1.4" Manufacturer="Olympus" NominalMagnification="100"/>
+  </Instrument>
+  <Image ID="Image:1" Name="example_R3D_D3D.dv">
+    <AcquisitionDate>2005-01-28T13:50:08</AcquisitionDate>
+    <Description>An example OME compliant file, 
+            based on a wide-field microscope image</Description>
+    <ObjectiveSettings ID="Objective:10002" Medium="Oil" RefractiveIndex="1.52" CorrectionCollar="7"/>
+    <Pixels DimensionOrder="XYCZT" ID="Pixels:1" PhysicalSizeX="0.06631" PhysicalSizeY="0.06631" PhysicalSizeZ="0.2" SizeC="3" SizeT="1" SizeX="480" SizeY="480" SizeZ="5" Type="int16">
+      <Channel EmissionWavelength="457" ExcitationWavelength="360" ID="Channel:1:0" NDFilter="0.5" Name="DAPI" SamplesPerPixel="1" Fluor="DAPI" IlluminationType="Epifluorescence" ContrastMethod="Fluorescence" AcquisitionMode="WideField" Color="65535">
+        <DetectorSettings Binning="1x1" Gain="0.5" ID="Detector:0:0" ReadOutRate="10.0"/>
+      </Channel>
+      <Channel EmissionWavelength="528" ExcitationWavelength="490" ID="Channel:1:1" NDFilter="0.0" Name="FITC" SamplesPerPixel="1" Fluor="GFP" IlluminationType="Epifluorescence" ContrastMethod="Fluorescence" AcquisitionMode="WideField" Color="16711935">
+        <DetectorSettings Binning="1x1" Gain="0.5" ID="Detector:0:0" ReadOutRate="10.0"/>
+      </Channel>
+      <Channel EmissionWavelength="617" ExcitationWavelength="555" ID="Channel:1:2" NDFilter="0.0" Name="RD-TR-PE" SamplesPerPixel="1" Fluor="TRITC" IlluminationType="Epifluorescence" ContrastMethod="Fluorescence" AcquisitionMode="WideField" Color="-16776961">
+        <DetectorSettings Binning="1x1" Gain="0.5" ID="Detector:0:0" ReadOutRate="10.0"/>
+      </Channel>
+      <BinData BigEndian="false" Length="0"/>
+      <Plane DeltaT="0.0" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46" PositionZ="-21.496" TheC="0" TheT="0" TheZ="0"/>
+      <Plane DeltaT="0.294" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46" PositionZ="-21.696" TheC="0" TheT="0" TheZ="1"/>
+      <Plane DeltaT="0.587" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46" PositionZ="-21.896" TheC="0" TheT="0" TheZ="2"/>
+      <Plane DeltaT="0.881" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46" PositionZ="-22.096" TheC="0" TheT="0" TheZ="3"/>
+      <Plane DeltaT="1.174" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46" PositionZ="-22.296" TheC="0" TheT="0" TheZ="4"/>
+      <Plane DeltaT="9.625" ExposureTime="0.3" PositionX="3316.37" PositionY="-646.46" PositionZ="-21.496" TheC="1" TheT="0" TheZ="0"/>
+      <Plane DeltaT="10.12" ExposureTime="0.3" PositionX="3316.37" PositionY="-646.46" PositionZ="-21.696" TheC="1" TheT="0" TheZ="1"/>
+      <Plane DeltaT="10.613" ExposureTime="0.3" PositionX="3316.37" PositionY="-646.46" PositionZ="-21.896" TheC="1" TheT="0" TheZ="2"/>
+      <Plane DeltaT="11.106" ExposureTime="0.3" PositionX="3316.37" PositionY="-646.46" PositionZ="-22.096" TheC="1" TheT="0" TheZ="3"/>
+      <Plane DeltaT="11.599" ExposureTime="0.3" PositionX="3316.37" PositionY="-646.46" PositionZ="-22.296" TheC="1" TheT="0" TheZ="4"/>
+      <Plane DeltaT="25.447" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46" PositionZ="-21.496" TheC="2" TheT="0" TheZ="0"/>
+      <Plane DeltaT="25.739" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46" PositionZ="-21.696" TheC="2" TheT="0" TheZ="1"/>
+      <Plane DeltaT="26.033" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46" PositionZ="-21.896" TheC="2" TheT="0" TheZ="2"/>
+      <Plane DeltaT="26.326" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46" PositionZ="-22.096" TheC="2" TheT="0" TheZ="3"/>
+      <Plane DeltaT="26.619" ExposureTime="0.1" PositionX="3316.37" PositionY="-646.46" PositionZ="-22.296" TheC="2" TheT="0" TheZ="4"/>
+    </Pixels>
+  </Image>        
+</OME>

--- a/formats/specifications/deltavision.ome.xml
+++ b/formats/specifications/deltavision.ome.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<OME:OME xmlns:ROI="http://www.openmicroscopy.org/Schemas/ROI/2015-01"
-    xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2015-01"
-    xmlns:BIN="http://www.openmicroscopy.org/Schemas/BinaryFile/2015-01"
+<OME:OME xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2016-06"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2015-01
-                        http://www.openmicroscopy.org/Schemas/OME/2015-01/ome.xsd">
+    xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06
+                        http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd">
 
     <OME:Instrument ID="Instrument:0">
         <OME:Detector ID="Detector:0:0" Model="COOLSNAP_HQ / ICX285" Type="CCD"/>

--- a/formats/specifications/hcs.ome.xml
+++ b/formats/specifications/hcs.ome.xml
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<OME:OME xmlns:ROI="http://www.openmicroscopy.org/Schemas/ROI/2015-01"
-    xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2015-01"
-    xmlns:BIN="http://www.openmicroscopy.org/Schemas/BinaryFile/2015-01"
-    xmlns:SPW="http://www.openmicroscopy.org/Schemas/SPW/2015-01"
+<OME:OME xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2016-06"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2015-01
-                        http://www.openmicroscopy.org/Schemas/OME/2015-01/ome.xsd">
+    xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06
+                        http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd">
 
     <SPW:Plate 
         ID="Plate:1" 

--- a/formats/specifications/hcs.ome.xml
+++ b/formats/specifications/hcs.ome.xml
@@ -1,54 +1,54 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<OME:OME xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2016-06"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06
-                        http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd">
+<OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06
+                         http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd">
 
-    <SPW:Plate 
-        ID="Plate:1" 
-        Name="Control Plate" 
-        ColumnNamingConvention="letter" 
-        RowNamingConvention="number" 
-        Columns="12" 
-        Rows="8"
-        >
-        <SPW:Description></SPW:Description>
+  <Plate
+     ID="Plate:1"
+     Name="Control Plate"
+     ColumnNamingConvention="letter"
+     RowNamingConvention="number"
+     Columns="12"
+     Rows="8"
+     >
+    <Description></Description>
 
-        <!-- repeat SPW:Well for # of wells in the plate that contain images -->
-        <SPW:Well ID="Well:1" Column="0" Row="0">
-            <!-- repeat SPW:WellSample for # of images taken in the well -->
-            <SPW:WellSample ID="WellSample:1" Index="0">
-                <!-- 
-                        if there is an image associated with this SPW:WellSample
-                        it is linked using an SPW:ImageRef
-                    -->
-                <OME:ImageRef ID="Image:0"/>
-            </SPW:WellSample>
-        </SPW:Well>
-    </SPW:Plate>
-    <!-- plus one more Plate for each Plate in this set -->
+    <!-- repeat Well for # of wells in the plate that contain images -->
+    <Well ID="Well:1" Column="0" Row="0">
+      <!-- repeat WellSample for # of images taken in the well -->
+      <WellSample ID="WellSample:1" Index="0">
+        <!--
+             if there is an image associated with this SPW:WellSample
+             it is linked using an ImageRef
+          -->
+        <ImageRef ID="Image:0"/>
+      </WellSample>
+    </Well>
+  </Plate>
+  <!-- plus one more Plate for each Plate in this set -->
 
-    <!-- SPW:Screen is not required -->
+  <!-- Screen is not required -->
 
-    <!-- The OME:Image element follows the structure for the OME Compliant File Specification -->
-    <OME:Image ID="Image:0" Name="Series 1">
-        <OME:AcquisitionDate>2008-02-06T13:43:19</OME:AcquisitionDate>
-        <OME:Description>An example OME compliant file, based on Olympus.oib</OME:Description>
-        <OME:Pixels DimensionOrder="XYCZT" ID="Pixels:0" 
-            PhysicalSizeX="0.207" PhysicalSizeY="0.207" 
-            SizeC="3" SizeT="16" SizeX="1024" SizeY="1024" SizeZ="1"
-            TimeIncrement="120.1302" Type="uint16">
-            <OME:Channel EmissionWavelength="523" ExcitationWavelength="488" ID="Channel:0:0"
-                IlluminationType="Epifluorescence" Name="CH1" SamplesPerPixel="1"
-                PinholeSize="103.5" AcquisitionMode="LaserScanningConfocalMicroscopy"/>
-            <OME:Channel EmissionWavelength="578" ExcitationWavelength="561" ID="Channel:0:1"
-                IlluminationType="Epifluorescence" Name="CH3" SamplesPerPixel="1"
-                PinholeSize="127.24" AcquisitionMode="LaserScanningConfocalMicroscopy"/>
-            <OME:Channel ExcitationWavelength="488" ID="Channel:0:2" 
-                IlluminationType="Transmitted"
-                ContrastMethod="DIC" Name="TD1" SamplesPerPixel="1"  
-                AcquisitionMode="LaserScanningConfocalMicroscopy"/>
-            <BIN:BinData BigEndian="false" Length="0"/>
-        </OME:Pixels>
-    </OME:Image>
-</OME:OME>
+  <!-- The Image element follows the structure for the OME Compliant File Specification -->
+  <Image ID="Image:0" Name="Series 1">
+    <AcquisitionDate>2008-02-06T13:43:19</AcquisitionDate>
+    <Description>An example OME compliant file, based on Olympus.oib</Description>
+    <Pixels DimensionOrder="XYCZT" ID="Pixels:0"
+                PhysicalSizeX="0.207" PhysicalSizeY="0.207"
+                SizeC="3" SizeT="16" SizeX="1024" SizeY="1024" SizeZ="1"
+                TimeIncrement="120.1302" Type="uint16">
+      <Channel EmissionWavelength="523" ExcitationWavelength="488" ID="Channel:0:0"
+                   IlluminationType="Epifluorescence" Name="CH1" SamplesPerPixel="1"
+                   PinholeSize="103.5" AcquisitionMode="LaserScanningConfocalMicroscopy"/>
+      <Channel EmissionWavelength="578" ExcitationWavelength="561" ID="Channel:0:1"
+                   IlluminationType="Epifluorescence" Name="CH3" SamplesPerPixel="1"
+                   PinholeSize="127.24" AcquisitionMode="LaserScanningConfocalMicroscopy"/>
+      <Channel ExcitationWavelength="488" ID="Channel:0:2"
+                   IlluminationType="Transmitted"
+                   ContrastMethod="DIC" Name="TD1" SamplesPerPixel="1"
+                   AcquisitionMode="LaserScanningConfocalMicroscopy"/>
+      <BinData BigEndian="false" Length="0"/>
+    </Pixels>
+  </Image>
+</OME>

--- a/formats/specifications/index.txt
+++ b/formats/specifications/index.txt
@@ -41,10 +41,10 @@ Sample structure two:
 
 Alternative valid forms:
 
--  would have a ``OME:TiffData`` block instead of the ``BIN:BinData`` block
+-  would have a ``TiffData`` block instead of the ``BinData`` block
    (this would be used in the header of an OME-TIFF file)
--  would have a ``OME:MetadataOnly`` block instead of the ``BIN:BinData``
-   block (this would be used as a companion to one or more ``OME:BinaryOnly``
+-  would have a ``MetadataOnly`` block instead of the ``BinData``
+   block (this would be used as a companion to one or more ``BinaryOnly``
    OME-TIFF files)
 
 .. note:: A units system was added in January 2015. This sample assumes the

--- a/formats/specifications/index.txt
+++ b/formats/specifications/index.txt
@@ -3,8 +3,7 @@ Compliant file specification
 
 
 This was developed in conjunction with the April 2010 release of the
-OME-XML Model and the samples have been updated to the January 2015 release.
-
+OME-XML Model and the samples have been updated to the June 2016 release.
 
 A "compliant" specification OME file has been defined. This is not the
 minimum required for the display of an image (for this, see :doc:`Minimum

--- a/formats/specifications/minimum-specification.ome.xml
+++ b/formats/specifications/minimum-specification.ome.xml
@@ -1,24 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ome:OME xmlns:bf="http://www.openmicroscopy.org/Schemas/OME/2016-06"
-    xmlns:ome="http://www.openmicroscopy.org/Schemas/OME/2016-06"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06
-                        http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd">
-    <ome:Image ID="Image:1" Name="Name92">
-        <ome:Pixels 
-            ID="Pixels:1" 
-            DimensionOrder="XYZCT" 
-            Type="int8" 
-            SizeX="2" 
-            SizeY="2" 
-            SizeZ="2"
-            SizeC="2" 
-            SizeT="2">
-            <bf:BinData 
-                BigEndian="false" 
-                Compression="none" 
-                Length="12"
-                >ZGVmYXVsdA==</bf:BinData>
-        </ome:Pixels>
-    </ome:Image>
-</ome:OME>
+<OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06
+                         http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd">
+  <Image ID="Image:1" Name="Name92">
+    <Pixels
+       ID="Pixels:1"
+       DimensionOrder="XYZCT"
+       Type="int8"
+       SizeX="2"
+       SizeY="2"
+       SizeZ="2"
+       SizeC="2"
+       SizeT="2">
+      <BinData
+         BigEndian="false"
+         Compression="none"
+         Length="12"
+         >ZGVmYXVsdA==</BinData>
+    </Pixels>
+  </Image>
+</OME>

--- a/formats/specifications/minimum-specification.ome.xml
+++ b/formats/specifications/minimum-specification.ome.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ome:OME xmlns:bf="http://www.openmicroscopy.org/Schemas/BinaryFile/2015-01"
-    xmlns:ome="http://www.openmicroscopy.org/Schemas/OME/2015-01"
+<ome:OME xmlns:bf="http://www.openmicroscopy.org/Schemas/OME/2016-06"
+    xmlns:ome="http://www.openmicroscopy.org/Schemas/OME/2016-06"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2015-01
-                        http://www.openmicroscopy.org/Schemas/OME/2015-01/ome.xsd">
+    xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06
+                        http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd">
     <ome:Image ID="Image:1" Name="Name92">
-        <ome:AcquisitionDate>2009-03-16T15:41:51.0Z</ome:AcquisitionDate>
         <ome:Pixels 
             ID="Pixels:1" 
             DimensionOrder="XYZCT" 

--- a/formats/specifications/minimum.txt
+++ b/formats/specifications/minimum.txt
@@ -13,10 +13,10 @@ the structure is:
 
 Alternative valid forms:
 
--  would have a ``<ome:TiffData/>`` block instead of the ``bf:BinData``
+-  would have a ``<TiffData/>`` block instead of the ``BinData``
    block (this would be used in the header of an OME-TIFF file)
--  would have a ``<ome:MetadataOnly/>`` block instead of the ``bf:BinData``
-   block (this would be used as a companion to one or more ``ome:BinaryOnly``
+-  would have a ``<MetadataOnly/>`` block instead of the ``BinData``
+   block (this would be used as a companion to one or more ``BinaryOnly``
    OME-TIFF files)
 
 .. note:: A units system was added in January 2015. This sample assumes the

--- a/formats/specifications/minimum.txt
+++ b/formats/specifications/minimum.txt
@@ -3,7 +3,7 @@ Minimum specification
 
 
 This was developed in conjunction with the September 2009 release of the
-OME-XML Model and has been updated to the January 2015 release.
+OME-XML Model and has been updated to the June 2016 release.
 
 A minimum specification OME file has been defined. This is best viewed
 as being the minimum required for the display of an image. A sample of

--- a/formats/specifications/olympus.ome.xml
+++ b/formats/specifications/olympus.ome.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<OME:OME xmlns:ROI="http://www.openmicroscopy.org/Schemas/ROI/2015-01"
-    xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2015-01"
-    xmlns:BIN="http://www.openmicroscopy.org/Schemas/BinaryFile/2015-01"
+<OME:OME xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2016-06"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2015-01
-                        http://www.openmicroscopy.org/Schemas/OME/2015-01/ome.xsd">
+    xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06
+                        http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd">
 
     <OME:Image ID="Image:0" Name="Series 1">
         <OME:AcquisitionDate>2008-02-06T13:43:19</OME:AcquisitionDate>

--- a/formats/specifications/olympus.ome.xml
+++ b/formats/specifications/olympus.ome.xml
@@ -1,28 +1,17 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<OME:OME xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2016-06"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06
-                        http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd">
+<?xml version="1.0"?>
+<OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06" 
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+     xmlns:str="http://exslt.org/strings" 
+     xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06                              http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd">
 
-    <OME:Image ID="Image:0" Name="Series 1">
-        <OME:AcquisitionDate>2008-02-06T13:43:19</OME:AcquisitionDate>
-        <OME:Description>An example OME compliant file, based on Olympus.oib</OME:Description>
-        <OME:Pixels DimensionOrder="XYCZT" ID="Pixels:0" 
-            PhysicalSizeX="0.207" PhysicalSizeY="0.207"
-            SizeC="3" SizeT="16" SizeX="1024" SizeY="1024" SizeZ="1"
-            TimeIncrement="120.1302" Type="uint16">
-            <OME:Channel EmissionWavelength="523" ExcitationWavelength="488" ID="Channel:0:0"
-                IlluminationType="Epifluorescence" Name="CH1" SamplesPerPixel="1"
-                PinholeSize="103.5" AcquisitionMode="LaserScanningConfocalMicroscopy"/>
-            <OME:Channel EmissionWavelength="578" ExcitationWavelength="561" ID="Channel:0:1"
-                IlluminationType="Epifluorescence" Name="CH3" SamplesPerPixel="1"
-                PinholeSize="127.24" AcquisitionMode="LaserScanningConfocalMicroscopy"/>
-            <OME:Channel ExcitationWavelength="488" ID="Channel:0:2"
-                IlluminationType="Transmitted"
-                ContrastMethod="DIC" Name="TD1" SamplesPerPixel="1"  
-                AcquisitionMode="LaserScanningConfocalMicroscopy"/>
-            <BIN:BinData BigEndian="false" Length="0"/>
-        </OME:Pixels>
-    </OME:Image>
-
-</OME:OME>
+  <Image ID="Image:0" Name="Series 1">
+    <AcquisitionDate>2008-02-06T13:43:19</AcquisitionDate>
+    <Description>An example OME compliant file, based on Olympus.oib</Description>
+    <Pixels DimensionOrder="XYCZT" ID="Pixels:0" PhysicalSizeX="0.207" PhysicalSizeY="0.207" SizeC="3" SizeT="16" SizeX="1024" SizeY="1024" SizeZ="1" TimeIncrement="120.1302" Type="uint16">
+      <Channel EmissionWavelength="523" ExcitationWavelength="488" ID="Channel:0:0" IlluminationType="Epifluorescence" Name="CH1" SamplesPerPixel="1" PinholeSize="103.5" AcquisitionMode="LaserScanningConfocalMicroscopy"/>
+      <Channel EmissionWavelength="578" ExcitationWavelength="561" ID="Channel:0:1" IlluminationType="Epifluorescence" Name="CH3" SamplesPerPixel="1" PinholeSize="127.24" AcquisitionMode="LaserScanningConfocalMicroscopy"/>
+      <Channel ExcitationWavelength="488" ID="Channel:0:2" IlluminationType="Transmitted" ContrastMethod="DIC" Name="TD1" SamplesPerPixel="1" AcquisitionMode="LaserScanningConfocalMicroscopy"/>
+      <BinData BigEndian="false" Length="0"/>
+    </Pixels>
+  </Image>
+</OME>


### PR DESCRIPTION
This attempts to update all the sample OME-XML from the Model & Formats docs. The sample files info is copied from https://github.com/sbesson/samples/tree/2016-06_samples but I've guessed the compliant file changes so please check them properly (i.e the whole file not just my changes)! Also, the samples on https://www.openmicroscopy.org/site/support/ome-model-staging/developers/using-ome-xml.html will need more work because I notice one is about LightSource (see https://www.openmicroscopy.org/site/support/ome-model-staging/developers/using-ome-xml.html#sample-third-party-pieces-xml) and also, again I've made an educated guess at how to update them.
