### PR TITLE
document extra SQL scripts for OMERO 5.3

### DIFF
--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -134,12 +134,14 @@ below. Please refer to each section for additional details.
 Check ahead for upgrade issues
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-There *may* be a "precheck" SQL script provided that performs various
+There is a "precheck" SQL script provided that performs various
 database checks to verify readiness for upgrade. The precheck script
 works even with the OMERO server running so it may be used before
 downtime for the actual upgrade is scheduled. Issues that the script
 reports will need to be resolved before the upgrade may proceed. The
-precheck script will *not* make any changes to the database.
+precheck script will *not* make any changes to the database: it merely
+performs various precautionary checks also done by the actual upgrade
+script.
 
 .. parsed-literal::
 
@@ -158,9 +160,6 @@ precheck script will *not* make any changes to the database.
                                                                         +
 
     (1 row)
-
-If a precheck script is not included in the OMERO.server distribution
-then no such check need be performed.
 
 
 .. _back-up-the-db:

--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -284,7 +284,7 @@ Delete certain annotations (optional)
 For various reasons production databases may accumulate non-sharable
 annotations that are orphaned. These are :doc:`structured annotations
 </developers/Model/StructuredAnnotations>` that are 'basic' (`Boolean`,
-`TimeStamp`, `Term`), 'numeric' (`Double`, `Long`), or `Comment`, and
+`Timestamp`, `Term`), 'numeric' (`Double`, `Long`), or `Comment`, and
 that are *not* annotating an object. An illustrative example is that
 deleting a rating in OMERO.insight 5.2 may have left behind the
 corresponding `Long` annotation that captured the rating's number of

--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -288,7 +288,10 @@ annotations that are orphaned. These are :doc:`structured annotations
 that are *not* annotating an object. An illustrative example is that
 deleting a rating in OMERO.insight 5.2 may have left behind the
 corresponding `Long` annotation that captured the rating's number of
-stars. The script does *not* delete annotations that have a
+stars. Non-sharable annotations, like comments and ratings, cannot be
+viewed from OMERO.insight or OMERO.web after they have been orphaned
+because they are no longer associated with any model object such as an
+image. The deletion script does *not* delete annotations that have a
 custom/non-OME namespace (ns) set.
 
 .. parsed-literal::

--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -303,7 +303,7 @@ This script may be used during some maintenance window subsequent to the
 actual upgrade as long as it runs on a |current_dbver| database. If at
 upgrade time you have questions about the script then you may perform
 further research before :ref:`backing up the database again
-<back-up-the-db>` then running the script. There is no obligation to
+<back-up-the-db>` then running the script. There is no requirement to
 ever use it.
 
 Optimize an upgraded database (optional)

--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -131,6 +131,38 @@ below. Please refer to each section for additional details.
     :local:
     :depth: 1
 
+Check ahead for upgrade issues
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+There *may* be a "precheck" SQL script provided that performs various
+database checks to verify readiness for upgrade. The precheck script
+works even with the OMERO server running so it may be used before
+downtime for the actual upgrade is scheduled. Issues that the script
+reports will need to be resolved before the upgrade may proceed. The
+precheck script will *not* make any changes to the database.
+
+.. parsed-literal::
+
+    $ cd OMERO.server
+    $ psql -h localhost -U **db_user** **omero_database** < sql/psql/|current_dbver|/|previous_dbver|-precheck.sql
+    Password for user **db_user**:
+    ...
+    ...
+                               status
+    ---------------------------------------------------------------------
+                                                                        +
+                                                                        +
+                                                                        +
+    YOUR DATABASE IS READY FOR UPGRADE TO VERSION |current_dbver|           +
+                                                                        +
+                                                                        +
+
+    (1 row)
+
+If a precheck script is not included in the OMERO.server distribution
+then no such check need be performed.
+
+
 .. _back-up-the-db:
 
 Perform a database backup

--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -280,6 +280,31 @@ intermediate major release.
    connected to the database using **db_user** before running the script. See
    :forum:`this forum thread <viewtopic.php?f=5&t=7778>` for more information.
 
+Delete certain annotations (optional)
+"""""""""""""""""""""""""""""""""""""
+
+For various reasons production databases may accumulate non-sharable
+annotations that are orphaned. These are :doc:`structured annotations
+</developers/Model/StructuredAnnotations>` that are 'basic' (`Boolean`,
+`TimeStamp`, `Term`), 'numeric' (`Double`, `Long`), or `Comment`, and
+that are *not* annotating an object. An illustrative example is that
+deleting a rating in OMERO.insight 5.2 may have left behind the
+corresponding `Long` annotation that captured the rating's number of
+stars. The script does *not* delete annotations that have a
+custom/non-OME namespace (ns) set.
+
+.. parsed-literal::
+
+    $ cd OMERO.server
+    $ psql -h localhost -U **db_user** **omero_database** < sql/psql/|current_dbver|/delete-ns-orphans.sql
+
+This script may be used during some maintenance window subsequent to the
+actual upgrade as long as it runs on a |current_dbver| database. If at
+upgrade time you have questions about the script then you may perform
+further research before :ref:`backing up the database again
+<back-up-the-db>` then running the script. There is no obligation to
+ever use it.
+
 Optimize an upgraded database (optional)
 """"""""""""""""""""""""""""""""""""""""
 

--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -134,14 +134,13 @@ below. Please refer to each section for additional details.
 Check ahead for upgrade issues
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-There is a "precheck" SQL script provided that performs various
-database checks to verify readiness for upgrade. The precheck script
-works even with the OMERO server running so it may be used before
-downtime for the actual upgrade is scheduled. Issues that the script
-reports will need to be resolved before the upgrade may proceed. The
-precheck script will *not* make any changes to the database: it merely
-performs various precautionary checks also done by the actual upgrade
-script.
+There is a "precheck" SQL script provided that performs various database
+checks to verify readiness for upgrade. The precheck script works even
+with the OMERO server running so it may be used before downtime for the
+actual upgrade is scheduled. Issues that the script reports will need to
+be resolved before the upgrade may proceed. The precheck script will
+*not* make any changes to the database: it merely performs various
+precautionary checks also done by the actual upgrade script.
 
 .. parsed-literal::
 


### PR DESCRIPTION
https://github.com/openmicroscopy/openmicroscopy/pull/4732 introduces and describes a couple of SQL utility scripts for OMERO server admins to use. Staged at http://www.openmicroscopy.org/site/support/omero5.3-staging/sysadmins/server-upgrade.html.

cc: @pwalczysko
