### PR TITLE
Add note that test-compile is needed before running tests (rebased onto dev_5_2)

### DIFF
--- a/omero/developers/testing.txt
+++ b/omero/developers/testing.txt
@@ -5,6 +5,14 @@ The following guidelines apply to tests in both the Java and Python test
 components. However, some of the presented options apply to only one or the
 other.
 
+The default build target does not compile all the required testing resources.
+You should run `test-compile` (or `build-dev` if you are using Eclipse) first:
+
+::
+
+    ./build.py build-default test-compile
+
+
 Running tests
 -------------
 

--- a/omero/developers/testing.txt
+++ b/omero/developers/testing.txt
@@ -19,7 +19,7 @@ the Java tests.
 
 .. note::
     The OMERO C++ components and tests are under heavy development, and
-    are not be compiled or run by the targets mentioned on this page.
+    are not compiled or run by the targets mentioned on this page.
 
 
 Running tests

--- a/omero/developers/testing.txt
+++ b/omero/developers/testing.txt
@@ -13,6 +13,15 @@ You should run `test-compile` (or `build-dev` if you are using Eclipse) first:
     ./build.py build-default test-compile
 
 
+You must rebuild the `test-compile` target if you subsequently modify any of
+the Java tests.
+
+
+.. note::
+    The OMERO C++ components and tests are under heavy development, and
+    are not be compiled or run by the targets mentioned on this page.
+
+
 Running tests
 -------------
 


### PR DESCRIPTION
This is the same as gh-1496 but rebased onto dev_5_2.

---

`./build.py` is insufficient for running `openmicroscopy` tests.
