### PR TITLE
Add min versions for Java & Postgres & a bunch of sysadmin doc updates (rebased onto dev_5_2)

### DIFF
--- a/omero/conf.py
+++ b/omero/conf.py
@@ -70,6 +70,7 @@ rst_epilog += """
 .. |current_dbver|  replace:: %s
 .. |previous_dbver|  replace:: %s
 .. |iceversion| replace:: 3.5.1
+.. |postgresversion| replace:: 9.4
 """ % (previousversion, conf_autogen.current_dbver,
        conf_autogen.previous_dbver)
 

--- a/omero/conf.py
+++ b/omero/conf.py
@@ -71,6 +71,7 @@ rst_epilog += """
 .. |previous_dbver|  replace:: %s
 .. |iceversion| replace:: 3.5.1
 .. |postgresversion| replace:: 9.4
+.. |javaversion| replace:: 1.7
 """ % (previousversion, conf_autogen.current_dbver,
        conf_autogen.previous_dbver)
 

--- a/omero/sysadmins/troubleshooting.txt
+++ b/omero/sysadmins/troubleshooting.txt
@@ -469,3 +469,8 @@ http://bugs.sun.com/bugdatabase/view\_bug.do?bug\_id=4751177 or this
 :ome-users:`ome-users thread <2009-March/001465.html>` on our mailing list for
 more information.
 
+Data corruption
+^^^^^^^^^^^^^^^
+
+If you are dealing with a data corruption issue, you may find the information
+on :ref:`pixelresolutionorder` useful.

--- a/omero/sysadmins/unix/server-binary-repository.txt
+++ b/omero/sysadmins/unix/server-binary-repository.txt
@@ -3,9 +3,9 @@ OMERO.server binary repository
 
 .. topic:: About
 
-    The OMERO.server binary data repository is a fundamental piece of   
+    The OMERO.server binary data repository is a fundamental piece of
     server-side functionality. It provides optimized and indexed storage of
-    original file, pixel and thumbnail data, attachments and full-text 
+    original file, pixel and thumbnail data, attachments and full-text
     indexes.  The repository's directories contain various files that,
     together with your SQL database, constitute the information about
     your users and their data that OMERO.server relies upon for normal
@@ -33,6 +33,18 @@ The repository is internally laid out as follows:
 -  the directory where your OMERO.client (OMERO.insight or OMERO.importer)
    binaries are
 -  your PostgreSQL data directory
+
+.. _pixelresolutionorder:
+
+PixelService resolution order for locating binary data for images
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When the server is trying to find the binary data for an image, it looks:
+
+-  first under `/OMERO/Pixels` for a :file:`$NUMBER_pyramid` file
+-  then under `/OMERO/Pixels` for a regular :file:`$NUMBER` file
+-  then under `/OMERO/Files` for OMERO 4 files
+-  or under `/OMERO/ManagedRepository` for OMERO 5 files
 
 Locking and remote shares
 -------------------------

--- a/omero/sysadmins/unix/server-installation.txt
+++ b/omero/sysadmins/unix/server-installation.txt
@@ -108,7 +108,7 @@ If possible, install one of the following packages:
 +-----------+---------------------------+
 
 OMERO works with the OpenJDK JRE provided by most systems, or with
-Oracle Java. Version |javaversion| or later is recommended.
+Oracle Java. Version |javaversion| or later is required.
 
 Your system may already provide a suitable JRE, in which case no extra steps
 are necessary. Linux distributions usually provide OpenJDK, and older MacOS X

--- a/omero/sysadmins/unix/server-installation.txt
+++ b/omero/sysadmins/unix/server-installation.txt
@@ -108,7 +108,7 @@ If possible, install one of the following packages:
 +-----------+---------------------------+
 
 OMERO works with the OpenJDK JRE provided by most systems, or with
-Oracle Java. Version 7 or later is recommended.
+Oracle Java. Version |javaversion| or later is recommended.
 
 Your system may already provide a suitable JRE, in which case no extra steps
 are necessary. Linux distributions usually provide OpenJDK, and older MacOS X
@@ -632,12 +632,6 @@ Configuration
     The required permissions will depend on whether you are using
     :doc:`/sysadmins/import-scenarios`.
 
-.. note Windows
-
-   If you would like to move the directory again, see
-   ``bin\winconfig.bat --help``, which gets called automatically on an
-   initial install.
-
 -   Test that you can log in as "root", either with the OMERO.insight
     client or on the command-line::
 
@@ -648,6 +642,11 @@ Configuration
 
     You will be prompted for an OMERO username and password. Use the
     username and password set when running ``bin/omero db script``.
+
+-   If your users are going to be importing many files in one go, for example
+    multiple plates, you should make sure you set the maximum number of open
+    files to a sensible level (i.e. at least 8K for production systems, 16K
+    for bigger machines). See :ref:`ulimit` for more information.
 
 JVM memory settings
 -------------------
@@ -709,11 +708,6 @@ want to watch :snapshot:`the HCS configuration screencast
 :omero_plone:`Feature list <feature-list>` for more advanced features
 you may want to use, and :doc:`/sysadmins/config` on how to get the
 most out of your server.
-
-If your users are going to be importing many files in one go, for example
-multiple plates, you should make sure you set the maximum number of open files
-to a sensible level (i.e. at least 8K for production systems, 16K for bigger
-machines). See :ref:`ulimit` for more information.
 
 Troubleshooting
 ^^^^^^^^^^^^^^^

--- a/omero/sysadmins/unix/server-postgresql.txt
+++ b/omero/sysadmins/unix/server-postgresql.txt
@@ -9,8 +9,8 @@ version and that it is installed and configured correctly.
 Ensuring you have a valid PostgreSQL version
 --------------------------------------------
 
-For OMERO |version|, PostgreSQL version 9.4 or later is required; version 9.4
-is recommended. Make sure you are using a
+For OMERO |version|, PostgreSQL version |postgresversion| or later is
+required. Make sure you are using a
 `supported version <http://www.postgresql.org/support/versioning/>`_.
 
 You can check which version of PostgreSQL you have installed with any of
@@ -25,7 +25,7 @@ the following commands:
        $ createdb -V
        createdb (PostgreSQL) 9.4.1
 
-If your existing PostgreSQL installation is version 9.3 or earlier, it
+If your existing PostgreSQL installation is an earlier version, it
 is recommended that you upgrade to a more up-to-date version.  Before
 upgrading, stop the OMERO server and then perform a full dump of the
 database using :program:`pg_dump`.  See the :ref:`server_backup`

--- a/omero/sysadmins/unix/server-postgresql.txt
+++ b/omero/sysadmins/unix/server-postgresql.txt
@@ -10,7 +10,7 @@ Ensuring you have a valid PostgreSQL version
 --------------------------------------------
 
 For OMERO |version|, PostgreSQL version |postgresversion| or later is
-required. Make sure you are using a
+recommended. Make sure you are using a
 `supported version <http://www.postgresql.org/support/versioning/>`_.
 
 You can check which version of PostgreSQL you have installed with any of

--- a/omero/users/clients-overview.txt
+++ b/omero/users/clients-overview.txt
@@ -17,8 +17,8 @@ and get running.
 
 OMERO.insight and OMERO.importer are desktop applications written in Java
 and require Java |javaversion| (or higher) to be installed on the user's
-computer (automatically installed on most up-to-date OS X and Windows
-systems).
+computer (this can easily be installed from `<http://java.com/>`_ if it is not
+already included in your OS).
 
 Our user assistance :help:`help website<>` provides a series of
 workflow-based guides to performing common actions in the client applications,

--- a/omero/users/clients-overview.txt
+++ b/omero/users/clients-overview.txt
@@ -16,17 +16,18 @@ installations worldwide, OMERO has been shown to be relatively easy to install
 and get running.
 
 OMERO.insight and OMERO.importer are desktop applications written in Java
-and require Java 1.7 (or higher) to be installed on the user's computer
-(automatically installed on most up-to-date OS X and Windows systems).
+and require Java |javaversion| (or higher) to be installed on the user's
+computer (automatically installed on most up-to-date OS X and Windows
+systems).
 
-Our user assistance :help:`help website<>` provides a series of 
-workflow-based guides to performing common actions in the client applications, 
-such as importing and viewing data, exporting images and using the measuring 
+Our user assistance :help:`help website<>` provides a series of
+workflow-based guides to performing common actions in the client applications,
+such as importing and viewing data, exporting images and using the measuring
 tool. 
 
-Our partners within the OME consortium are also producing new clients and 
-modules for OMERO, integrating additional functionality, particularly for more 
-complex image analysis. See the :partner_plone:`Partner Projects <>` page for 
+Our partners within the OME consortium are also producing new clients and
+modules for OMERO, integrating additional functionality, particularly for more
+complex image analysis. See the :partner_plone:`Partner Projects <>` page for
 more details.
 
 .. _omero-web:

--- a/omero/users/index.txt
+++ b/omero/users/index.txt
@@ -17,7 +17,7 @@ and a Django-based web application.
 
 The OMERO clients are cross-platform. To run on your computer they require
 Java |javaversion| or higher to be installed. This can easily be installed
-from http://java.com/en if it is not already included in your OS. The
+from `<http://java.com/>`_ if it is not already included in your OS. The
 OMERO.insight client gets all of its information from a remote OMERO.server —
 the location of which is specified at login. Since this connection utilises a
 standard network connection, the client can be run anytime the user is

--- a/omero/users/index.txt
+++ b/omero/users/index.txt
@@ -52,7 +52,7 @@ Additional resources
 
 -   :omero_plone:`About OMERO <>` introduces OMERO for new users, while
     the :omero_plone:`Features List <feature-list>` provides an overview
-    of the platform features with those that are new for OMERO 5.3
+    of the platform features with those that are new for OMERO 5.2
     highlighted.
 
 -   Workflow-based user assistance guides are provided on our

--- a/omero/users/index.txt
+++ b/omero/users/index.txt
@@ -16,19 +16,19 @@ several Java client applications, as well as Python and C++ bindings
 and a Django-based web application.
 
 The OMERO clients are cross-platform. To run on your computer they require
-Java 1.7 or higher to be installed. This can easily be installed from
-http://java.com/en if it is not already included in your OS. The OMERO.insight
-client gets all of its information from a remote OMERO.server — the location
-of which is specified at login. Since this connection utilises a standard
-network connection, the client can be run anytime the user is connected to the
-internet.
+Java |javaversion| or higher to be installed. This can easily be installed
+from http://java.com/en if it is not already included in your OS. The
+OMERO.insight client gets all of its information from a remote OMERO.server —
+the location of which is specified at login. Since this connection utilises a
+standard network connection, the client can be run anytime the user is
+connected to the internet.
 
 .. figure:: /images/omero-overview.png
     :width: 85%
     :align: center
     :alt: The OMERO Platform
 
-This documentation is for the new OMERO 5 Platform. This version is designed
+This documentation is for the OMERO 5 Platform. This version is designed
 to improve our handling of complex multidimensional datasets. It allows you to
 upload your files in their original format, preserving file names and any
 nested directory structure in the server repository. For more technical
@@ -52,7 +52,7 @@ Additional resources
 
 -   :omero_plone:`About OMERO <>` introduces OMERO for new users, while
     the :omero_plone:`Features List <feature-list>` provides an overview
-    of the platform features with those that are new for OMERO 5.2
+    of the platform features with those that are new for OMERO 5.3
     highlighted.
 
 -   Workflow-based user assistance guides are provided on our


### PR DESCRIPTION
This is the same as gh-1485 but rebased onto dev_5_2.

---

This addresses https://trello.com/c/FmCsmVP7/208-pixelsservice-resolution-order-first-pixels-then https://trello.com/c/xuN70hl2/430-sysadmin-docs-should-cover-ulimits-for-files-and-processes and https://trello.com/c/uripejjj/394-add-min-version-for-postgres-etc-to-conf-py to clean up a bunch of sysadmin docs tasks that have been hanging around too long. Also a bit of clean up on the users index page. 

Staged at https://www.openmicroscopy.org/site/support/omero5.3-staging/users/index.html and https://www.openmicroscopy.org/site/support/omero5.3-staging/sysadmins/index.html and various pages linked.
