### PR TITLE
Add note about restarting OMERO.web (rebased onto dev_5_2)

### DIFF
--- a/omero/sysadmins/customization.txt
+++ b/omero/sysadmins/customization.txt
@@ -4,28 +4,23 @@ Customize OMERO clients
 The OMERO clients offer a flexible user interface that can be customized.
 The sections below describe how to set up these features.
 
-.. Note:: Depending on the deployment choice, OMERO.web will not activate
-    configuration changes until either gunicorn is restarted using
-    ``bin/omero web restart`` (nginx) or the Apache webserver has been
-    reloaded.
-
+Note that depending on the deployment choice, OMERO.web will not activate
+configuration changes until either gunicorn is restarted using ``bin/omero web
+restart`` (nginx) or the Apache webserver has been reloaded.
 
 Index page
 ----------
 
-Create new custom template in /your/path/to/templates/mytemplate/index.html
-and add the following
-
-.. note::
-    Users will no longer be automatically redirected to the login page
-
-::
+Create new custom template in
+:file:`/your/path/to/templates/mytemplate/index.html` and add the following::
 
     $ bin/omero config set omero.web.template_dirs '/your/path/to/templates/'
     $ bin/omero config set omero.web.index_template 'mytemplate/index.html'
 
 .. figure:: /images/indexPage.png
 
+Note that users will no longer be automatically redirected to the login page
+once an index page is added.
 
 Login page
 ----------
@@ -33,9 +28,7 @@ Login page
 :property:`omero.web.login_logo` allows you to customize the webclient login
 page with your own logo. Logo images should ideally be 150 pixels high or
 less and will appear above the OMERO logo. You will need to host the image
-somewhere else and link to it with 
-
-::
+somewhere else and link to it with::
 
     $ bin/omero config set omero.web.login_logo 'http://www.url/to/image.png'
 
@@ -46,20 +39,14 @@ Login redirection
 -----------------
 
 :property:`omero.web.login_redirect` property redirects to the given location
-after logging in.
-
-::
+after logging in::
 
     $ bin/omero config set omero.web.login_redirect '{"redirect": ["webindex"], "viewname": "load_template", "args":["userdata"], "query_string": "experimenter=-1"}'
-
-
 
 Top links menu
 --------------
 
-:property:`omero.web.ui.top_links` adds links to the top header.
-
-::
+:property:`omero.web.ui.top_links` adds links to the top header::
 
     $ bin/omero config append omero.web.ui.top_links '["Figure", "webfigure"]'
     $ bin/omero config set omero.web.ui.top_links '["GRE", "http://lifesci.dundee.ac.uk/gre"]'
@@ -71,9 +58,7 @@ Group and Users in dropdown menu
 --------------------------------
 
 Customize the groups and users dropdown menu by changing the labels or hiding
-the entire list.
-
-::
+the entire list::
 
     $ bin/omero config set omero.client.ui.menu.dropdown.leaders "Owners"
     $ bin/omero config set omero.client.ui.menu.dropdown.colleagues.enabled true
@@ -89,9 +74,7 @@ Orphaned container
 ------------------
 
 :property:`omero.client.ui.tree.orphans.name` allows you to change the name
-of the "Orphaned images" container located in the client data manager tree.
-
-::
+of the "Orphaned images" container located in the client data manager tree::
 
     $ bin/omero config set omero.client.ui.tree.orphans.name "Orphaned images"
 
@@ -102,9 +85,7 @@ Disabling scripts
 -----------------
 
 :property:`omero.client.scripts_to_ignore` hides the scripts that
-the clients should not display
-
-::
+the clients should not display::
 
     $ bin/omero config append omero.client.scripts_to_ignore "/my_scripts/script.py"
 
@@ -118,9 +99,7 @@ Download restrictions
 
 :property:`omero.policy.binary_access` determines whether users can access
 binary files from disk. Binary access includes all attempts to download
-a file from the UI.
-
-::
+a file from the UI::
 
     $ bin/omero config set omero.policy.binary_access "+read,+write,+image"
 

--- a/omero/sysadmins/customization.txt
+++ b/omero/sysadmins/customization.txt
@@ -4,6 +4,10 @@ Customize OMERO clients
 The OMERO clients offer a flexible user interface that can be customized.
 The sections below describe how to set up these features.
 
+.. Note:: Depending on how your OMERO.web server is deployed, you may need to 
+    restart it for these changes to take effect.
+
+
 Index page
 ----------
 

--- a/omero/sysadmins/customization.txt
+++ b/omero/sysadmins/customization.txt
@@ -4,8 +4,10 @@ Customize OMERO clients
 The OMERO clients offer a flexible user interface that can be customized.
 The sections below describe how to set up these features.
 
-.. Note:: Depending on how your OMERO.web server is deployed, you may need to 
-    restart it for these changes to take effect.
+.. Note:: Depending on the deployment choice, OMERO.web will not activate
+    configuration changes until either gunicorn is restarted using
+    ``bin/omero web restart`` (nginx) or the Apache webserver has been
+    reloaded.
 
 
 Index page

--- a/omero/sysadmins/unix/install-web.txt
+++ b/omero/sysadmins/unix/install-web.txt
@@ -177,6 +177,8 @@ The most popular configuration options include:
 
 -  Enabling a public user see :doc:`/sysadmins/public`.
 
-.. Note:: Depending on how your OMERO.web server is deployed, you may need to
-    restart it for these changes to take effect.
+.. Note:: Depending on the deployment choice, OMERO.web will not activate
+    configuration changes until either gunicorn is restarted using
+    ``bin/omero web restart`` (nginx) or the Apache webserver has been
+    reloaded.
 

--- a/omero/sysadmins/unix/install-web.txt
+++ b/omero/sysadmins/unix/install-web.txt
@@ -176,3 +176,7 @@ The most popular configuration options include:
 -  Customizing index page, see :property:`omero.web.index_template`.
 
 -  Enabling a public user see :doc:`/sysadmins/public`.
+
+.. Note:: Depending on how your OMERO.web server is deployed, you may need to
+    restart it for these changes to take effect.
+

--- a/omero/sysadmins/unix/install-web.txt
+++ b/omero/sysadmins/unix/install-web.txt
@@ -166,19 +166,19 @@ All configuration options can be found on various sections of
 
 	$ bin/omero web -h
 
-The most popular configuration options include:
-
--  Debug mode, see :property:`omero.web.debug`.
-
--  Customize login page with your own logo, see
-   :property:`omero.web.login_logo`.
-
--  Customizing index page, see :property:`omero.web.index_template`.
-
--  Enabling a public user see :doc:`/sysadmins/public`.
-
 .. Note:: Depending on the deployment choice, OMERO.web will not activate
     configuration changes until either gunicorn is restarted using
     ``bin/omero web restart`` (nginx) or the Apache webserver has been
     reloaded.
+
+The most popular configuration options include:
+
+-  Debug mode, see :property:`omero.web.debug`.
+
+-  Customizing OMERO clients e.g to add your own logo to the login page
+   (:property:`omero.web.login_logo`) or use an index page as an alternative
+   landing page for users (:property:`omero.web.index_template`). See
+   :doc:`/sysadmins/customization` for further information.
+
+-  Enabling a public user see :doc:`/sysadmins/public`.
 


### PR DESCRIPTION
This is the same as gh-1500 but rebased onto dev_5_2.

---

In response to QA 17257 where a user commented that it doesn't say you need to restart OMERO.web on the customization page.

Staged at https://www.openmicroscopy.org/site/support/omero5.3-staging/sysadmins/unix/install-web.html#customizing-your-omero-web-installation and https://www.openmicroscopy.org/site/support/omero5.3-staging/sysadmins/customization.html
