### PR TITLE
Update BF C++ ref to OME Files

### DIFF
--- a/common/conf.py
+++ b/common/conf.py
@@ -161,6 +161,7 @@ extlinks = {
     'secvuln' : (oo_root + '/info/vulnerabilities/%s', ''),
     'bf_plone' : (oo_site_root + '/products/bio-formats/%s', ''),
     'partner_plone' : (oo_site_root + '/products/partner/%s', ''),
+    'cpp_plone' : (oo_site_root + '/products/ome-files-cpp/%s', ''),
     # One branch only doc links. Branched docs links in conf.py files for
     # individual doc sets
     'model_doc' : (oo_site_root + '/support/ome-model/%s', ''),

--- a/formats/conf.py
+++ b/formats/conf.py
@@ -45,6 +45,7 @@ model_extlinks = {
     'schema_doc' : (oo_root + '/Schemas/Documentation/Generated/OME-' + release + '/%s', ''),
     # Downloads
     'bf_downloads' : (downloads_root + '/latest/bio-formats/%s', ''),
+    'cpp_downloads' : (downloads_root + '/latest/ome-files-cpp/%s', ''),
     'image_downloads' : (downloads_root + '/images/%s', ''),
     'ometiff_downloads' : (downloads_root + '/images/OME-TIFF/' + release + '/%s', ''),
     'omexml_downloads' : (downloads_root + '/images/OME-XML/' + release + '/%s', ''),

--- a/formats/index.txt
+++ b/formats/index.txt
@@ -17,7 +17,7 @@ TIFF-compatible program, and the metadata to be extracted with any OME-aware
 application. Our `paper describing the design and implementation of the OME-XML file 
 <http://genomebiology.com/2005/6/5/R47>`_ appeared in Genome Biology.
 
-The OME consortium currently provides two major tools capable of working
+The OME consortium currently provides three major tools capable of working
 with OME-XML and OME-TIFF:
 
 -  The :bf_plone:`Bio-Formats <>` library is a full-featured library with many
@@ -25,9 +25,12 @@ with OME-XML and OME-TIFF:
    format metadata into OME-XML structures. It can write image data to the
    OME-TIFF format.
 
+-  :cpp_plone:`OME Files C++ <>` is a reference implementation of the OME
+   data model and OME-TIFF for C++ developers wishing to support these in 
+   their own software. It can read and write OME-TIFF data.
+
 -  The :omero_plone:`OMERO server <>` works directly with OME-XML. It can
    import data from OME-XML and OME-TIFF, as well as export to OME-TIFF.
-
 
 
 If you have used OME-XML, OME-TIFF, Bio-Formats or OMERO in your work please

--- a/formats/ome-tiff/tools.txt
+++ b/formats/ome-tiff/tools.txt
@@ -22,7 +22,7 @@ line:
 
 If you are working in C/C++, we recommend the open source
 `LibTIFF <http://www.libtiff.org/>`_ library or the
-`OME Files C++ implementation <http://downloads.openmicroscopy.org/latest/ome-files-cpp/>`_.
+:cpp_downloads:`OME Files C++ implementation <>`.
 
 If you are looking for a solution in Java, there are several options.
 Bio-Formats can read OME-TIFF files, as well as convert from many

--- a/formats/ome-tiff/tools.txt
+++ b/formats/ome-tiff/tools.txt
@@ -22,7 +22,7 @@ line:
 
 If you are working in C/C++, we recommend the open source
 `LibTIFF <http://www.libtiff.org/>`_ library or the
-:bf_doc:`Bio-Formats native C++ implementation <developers/cpp/overview.html>`.
+`OME Files C++ implementation <http://downloads.openmicroscopy.org/latest/ome-files-cpp/>`_.
 
 If you are looking for a solution in Java, there are several options.
 Bio-Formats can read OME-TIFF files, as well as convert from many


### PR DESCRIPTION
See https://ci.openmicroscopy.org/view/Docs/job/FORMATS-merge-docs/1034/warnings3Result/
Although this URL is now being redirected, the reference in the docs was still described as Bio-Formats C++ so I've updated it anyway.

Once we have the web navigation etc properly sorted for the new docs, this can get a proper `:ome-files:` ref link in both these docs and the BF docs.
