### PR TITLE
do not suggest DB reindex on upgrade as vacuum full does it

### DIFF
--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -314,7 +314,6 @@ database which can both save disk space and speed up access times.
 
 .. parsed-literal::
 
-    $ psql -h localhost -U **db_user** **omero_database** -c 'REINDEX DATABASE "**omero_database**" FORCE;'
     $ psql -h localhost -U **db_user** **omero_database** -c 'VACUUM FULL VERBOSE ANALYZE;'
 
 .. _upgrademergescript:


### PR DESCRIPTION
Addresses https://trello.com/c/iqUhRNEz/142-db-upgrade-instructions-vacuum-reindex. See https://www.postgresql.org/docs/9.3/static/routine-vacuuming.html --

> ... you will need to use VACUUM FULL ...rewrite an entire new copy of the table and build new indexes for it.

Staged at http://www.openmicroscopy.org/site/support/omero5.3-staging/sysadmins/server-upgrade.html#optimize-an-upgraded-database-optional.
