### PR TITLE
Replace GH help link for PRs

### DIFF
--- a/contributing/using-git.txt
+++ b/contributing/using-git.txt
@@ -831,7 +831,7 @@ then the target user need only click on a button. If not, then there may
 be some back-and-forth on the work done, similar to the code reviews of
 a deliverable branch. For background, see
 
--  `Using Pull Requests <http://help.github.com/articles/using-pull-requests>`_
+-  `GitHub Help entries on managing projects  <https://help.github.com/categories/managing-projects-on-github/>`_
 -  `Pull Requests 2.0 <https://github.com/blog/712-pull-requests-2-0>`_
 
 If you have discovered that something in the proposed branch needs

--- a/contributing/using-git.txt
+++ b/contributing/using-git.txt
@@ -831,7 +831,7 @@ then the target user need only click on a button. If not, then there may
 be some back-and-forth on the work done, similar to the code reviews of
 a deliverable branch. For background, see
 
--  `GitHub Help entries on managing projects  <https://help.github.com/categories/managing-projects-on-github/>`_
+-  `About Pull Requests <https://help.github.com/articles/about-pull-requests/>`_
 -  `Pull Requests 2.0 <https://github.com/blog/712-pull-requests-2-0>`_
 
 If you have discovered that something in the proposed branch needs

--- a/omero/index.txt
+++ b/omero/index.txt
@@ -53,7 +53,7 @@ file contents and propose your file changes to the OME team using
 `Pull Requests`_. Alternatively, click on "Edit on GitHub" in the
 menu.
 
-.. _Pull Requests: http://help.github.com/articles/using-pull-requests
+.. _Pull Requests: https://help.github.com/categories/managing-projects-on-github
 
 .. toctree::
     :maxdepth: 1

--- a/omero/index.txt
+++ b/omero/index.txt
@@ -53,7 +53,7 @@ file contents and propose your file changes to the OME team using
 `Pull Requests`_. Alternatively, click on "Edit on GitHub" in the
 menu.
 
-.. _Pull Requests: https://help.github.com/categories/managing-projects-on-github
+.. _Pull Requests: https://help.github.com/articles/about-pull-requests/
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
This link is broken in both the OMERO & contributing docs and when I poked around, it seems GH now have a bunch of different entries mentioning PRs rather than one definitive article, so I've replaced the link with the relevant help category instead.

Staged at http://www.openmicroscopy.org/site/support/omero5.3-staging/ (bottom of landing page) and  http://www.openmicroscopy.org/site/support/contributing-staging/using-git.html 
