### PR TITLE
Remove broken javadoc links & old content from What's new for devs for m3

### DIFF
--- a/omero/developers/whatsnew.txt
+++ b/omero/developers/whatsnew.txt
@@ -1,11 +1,5 @@
-What's new for OMERO 5.2 for developers
+What's new for OMERO 5.3 for developers
 =======================================
-
-- The :doc:`/sysadmins/version-requirements` section provides extensive
-  details about which operating systems and dependency versions we intend to
-  support for the life of 5.2 and the likely changes to these for the next
-  major release (currently planned to be 5.3). Most notably for development
-  purposes, we have dropped support for Java 1.6.
 
 
 Breaking changes
@@ -14,52 +8,21 @@ Breaking changes
 OMERO.web
 ^^^^^^^^^
 
-OMERO.web has undergone a major upgrade, updating jsTree to version 3.0.8 and
-using json for all tree loading to substantially improve performance.
-
-If you have web code that directly works with the jsTree, you will need to
-update it according to the `jsTree docs <https://www.jstree.com/>`_.
-
-A number of new URLs are available in webclient, with the /api/ prefix that
-provide json data for the jsTree. However, these may soon be moved to a
-different Django app and should not yet be considered stable.
-
-
 Graphs
 ^^^^^^
 
-The API's request operations :javadoc:`Chmod
-<slice2html/omero/cmd/Chmod.html>`, :javadoc:`Chgrp
-<slice2html/omero/cmd/Chgrp.html>`, :javadoc:`Chown
-<slice2html/omero/cmd/Chown.html>`, :javadoc:`Delete
-<slice2html/omero/cmd/Delete.html>`, and their superclass
-:javadoc:`GraphModify <slice2html/omero/cmd/GraphModify.html>`, were
-deprecated in 5.1 and will be removed in 5.3. They are replaced by
-:javadoc:`Chmod2
+The API's request operations ``Chmod``, ``Chgrp``, ``Chown`` and ``Delete``,
+and their superclass GraphModify have been removed in 5.3. They are replaced
+by :javadoc:`Chmod2
 <slice2html/omero/cmd/Chmod2.html>`:javadoc:`Chgrp2
 <slice2html/omero/cmd/Chgrp2.html>`, :javadoc:`Chown2
 <slice2html/omero/cmd/Chown2.html>`, :javadoc:`Delete2
 <slice2html/omero/cmd/Delete2.html>`, and their superclass
 :javadoc:`GraphModify2 <slice2html/omero/cmd/GraphModify2.html>`.
-OMERO developers who have not migrated yet should refer to
-:doc:`Server/GraphsMigration` and take action before the deprecated features
-are removed.
 
 Java Gateway
 ^^^^^^^^^^^^
 
-The Java gateway has undergone a major overhaul which should make the
-development of Java applications much easier.
-As part of this, ``pojos`` has been renamed as ``omero.gateway.model``.
-We do not intend to modify the methods already available but this work should
-still be considered as under development as we move towards the gateway
-becoming a stable public API. Feedback as always is welcome.
-See :doc:`/developers/Java` for more information or follow the example in
-`minimal-omero-client <https://github.com/ome/minimal-omero-client>`_.
-
 OMERO model
 ^^^^^^^^^^^
 
-The :literal:`Rect` class has been renamed to :literal:`Rectangle` to match
-the OME-XML schema. This requires the corresponding change to be made in
-client software that uses the OMERO.blitz server API to work with ROIs.


### PR DESCRIPTION
See https://ci.openmicroscopy.org/view/Docs/job/OMERO-DEV-latest-docs/169/warnings3Result/ - the old graphs javadoc links needed removing from the doc as they are now gone from the code.

I've also removed the old content, leaving just some heading we will likely re-use, so we don't get 5.2 and 5.3 content mixed up when we come to finish updating this page. This is an interim fix to get the m3 build green
