### PR TITLE
move model object glossary overview paragraph to separate file

### DIFF
--- a/omero/developers/Model/EveryObject.txt
+++ b/omero/developers/Model/EveryObject.txt
@@ -4,12 +4,7 @@ Glossary of all OMERO Model Objects
 Overview
 --------
 
-In navigating the model objects used by the :doc:`OMERO API
-<../Modules/Api>` and in :omerocmd:`hql` it is often useful to look up
-the names of the object properties and the types of their values. This
-reference document lists every OMERO model object and their more useful
-properties, with an emphasis on enumerating every direct relationship
-among the objects.
+.. include:: EveryObjectOverview.inc
 
 Reference
 ---------

--- a/omero/developers/Model/EveryObjectOverview.inc
+++ b/omero/developers/Model/EveryObjectOverview.inc
@@ -1,0 +1,6 @@
+In navigating the model objects used by the :doc:`OMERO API
+<../Modules/Api>` and in :omerocmd:`hql` it is often useful to look up
+the names of the object properties and the types of their values. This
+reference document lists every OMERO model object and their more useful
+properties, with an emphasis on enumerating every direct relationship
+among the objects.


### PR DESCRIPTION
This PR should have no effect on the rendered output of http://www.openmicroscopy.org/site/support/omero5.3-staging/developers/Model/EveryObject.html as compared with http://www.openmicroscopy.org/site/support/omero5.3/developers/Model/EveryObject.html. Moving the overview paragraph out from the autogenerated remainder of the page makes it easier to rerun autogeneration or adjust the text without the two conflicting.
