### PR TITLE
Add link to new schema contrib page

### DIFF
--- a/formats/developers/index.txt
+++ b/formats/developers/index.txt
@@ -11,10 +11,9 @@ OME Model development process
 -----------------------------
 
 The Model development process is currently being revised but we always aim to
-keep the community informed of major and breaking changes in advance.
-
-For more information about the OME team workflows, see the
-:devs_doc:`Contributing Developer <index.html>` documentation.
+keep the community informed of major and breaking changes in advance. See the
+:devs_doc:`Contributing Developer <data-model-schema.html>` documentation for
+further details on updating and publishing the schema.
 
 Working with the OME Data Model
 -------------------------------


### PR DESCRIPTION
As mentioned on #1530, this adds a link to the new contributing doc page from the Model docs. Staged at https://www.openmicroscopy.org/site/support/ome-model-staging/developers/index.html
