### PR TITLE
Add ome-files-cpp staging URL to CI docs

### DIFF
--- a/contributing/ci-ome-files.txt
+++ b/contributing/ci-ome-files.txt
@@ -129,6 +129,7 @@ The branch for the development series of OME Files is develop.
                 This job builds the documentation for merge branches of OME Files components
 
                 #. |buildFilesSB|
+                #. Updates https://www.openmicroscopy.org/site/support/ome-files-cpp-staging/
 
                 See :jenkinsjob:`the build graph <OME-FILES-CPP-DEV-merge-docs/lastSuccessfulBuild/BuildGraph>`
 


### PR DESCRIPTION
As suggested on https://github.com/ome/ome-cmake-superbuild/pull/94 this PR adds the staging URL to the OME Files C++ CI docs.

Staged at https://www.openmicroscopy.org/site/support/contributing-staging/ci-ome-files.html

@rleigh-codelibre not sure how this deployment happens, can expand if needed
