### PR TITLE
Update Apache status for 5.3

### DIFF
--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -66,6 +66,9 @@ there may be fixes which require it.
     `Django 1.8`_ (LTS) which requires Python 2.7. For more information
     see :ref:`python-requirements` on the
     :doc:`/sysadmins/version-requirements` page.
+    
+    Also note that Apache is now deprecated and official support is likely to
+    be dropped during the 5.3.x line.
 
 OMERO.web dependencies
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -77,7 +80,7 @@ up to date to ensure that security updates are applied.
 
      $ pip install --upgrade -r share/web/requirements-py27-nginx.txt
 
-- Apache on Unix::
+- Apache (deprecated) on Unix::
 
      $ pip install --upgrade -r share/web/requirements-py27-apache.txt
 

--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -67,8 +67,8 @@ there may be fixes which require it.
     see :ref:`python-requirements` on the
     :doc:`/sysadmins/version-requirements` page.
     
-    Also note that Apache is now deprecated and official support is likely to
-    be dropped during the 5.3.x line.
+    Also note that support for Apache deployment is now deprecated and is
+    likely to be dropped during the 5.3.x line.
 
 OMERO.web dependencies
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/omero/sysadmins/unix/install-web.txt
+++ b/omero/sysadmins/unix/install-web.txt
@@ -53,7 +53,7 @@ customization options.
 .. note:: Support for Apache deployment has been deprecated and is likely to
     be dropped during the 5.3.x line.
     
-    If your organisation's policies only allow Apache to be used as the external-facing web-server you should configure Apache to proxy connections to an Nginx instance running on your OMERO server i.e. use Apache as a reverse proxy. For more details see
+    If your organization's policies only allow Apache to be used as the external-facing web-server you should configure Apache to proxy connections to an Nginx instance running on your OMERO server i.e. use Apache as a reverse proxy. For more details see
     `Apache mod_proxy documentation <https://httpd.apache.org/docs/current/mod/mod_proxy.html>`_.
 
 Logging in to OMERO.web

--- a/omero/sysadmins/unix/install-web.txt
+++ b/omero/sysadmins/unix/install-web.txt
@@ -50,6 +50,14 @@ customization options.
     install-web/walkthrough/omeroweb-install-ubuntu-ice3.5
     install-web/walkthrough/omeroweb-install-osx-ice3.6
 
+.. note:: Apache has been deprecated and official support is likely to be
+    dropped during the 5.3.x line.
+    
+    If an Apache HTTP server is the only way to provide internet access to
+    internal clients that are otherwise restricted by a firewall, you should
+    configure the Apache HTTP server as a reverse proxy to Nginx (refer to the
+    `Apache mod_proxy documentation <https://httpd.apache.org/docs/current/mod/mod_proxy.html>`_ for further
+    details).
 
 Logging in to OMERO.web
 -----------------------

--- a/omero/sysadmins/unix/install-web.txt
+++ b/omero/sysadmins/unix/install-web.txt
@@ -50,8 +50,8 @@ customization options.
     install-web/walkthrough/omeroweb-install-ubuntu-ice3.5
     install-web/walkthrough/omeroweb-install-osx-ice3.6
 
-.. note:: Apache has been deprecated and official support is likely to be
-    dropped during the 5.3.x line.
+.. note:: Support for Apache deployment has been deprecated and is likely to
+    be dropped during the 5.3.x line.
     
     If an Apache HTTP server is the only way to provide internet access to
     internal clients that are otherwise restricted by a firewall, you should

--- a/omero/sysadmins/unix/install-web.txt
+++ b/omero/sysadmins/unix/install-web.txt
@@ -53,11 +53,8 @@ customization options.
 .. note:: Support for Apache deployment has been deprecated and is likely to
     be dropped during the 5.3.x line.
     
-    If an Apache HTTP server is the only way to provide internet access to
-    internal clients that are otherwise restricted by a firewall, you should
-    configure the Apache HTTP server as a reverse proxy to Nginx (refer to the
-    `Apache mod_proxy documentation <https://httpd.apache.org/docs/current/mod/mod_proxy.html>`_ for further
-    details).
+    If your organisation's policies only allow Apache to be used as the external-facing web-server you should configure Apache to proxy connections to an Nginx instance running on your OMERO server i.e. use Apache as a reverse proxy. For more details see
+    `Apache mod_proxy documentation <https://httpd.apache.org/docs/current/mod/mod_proxy.html>`_.
 
 Logging in to OMERO.web
 -----------------------

--- a/omero/sysadmins/unix/install-web/install-apache.txt
+++ b/omero/sysadmins/unix/install-web/install-apache.txt
@@ -1,7 +1,8 @@
 DEPRECATED: OMERO.web Apache and mod_wsgi deployment
 ====================================================
 
-.. note:: Since OMERO 5.2.6 the Apache and mod_wsgi deployment is deprecated.
+.. note:: Since OMERO 5.2.6 support for Apache and mod_wsgi deployment is
+      deprecated.
       Please consider using :doc:`install-nginx` or
       :doc:`OMERO.web trial deployment </sysadmins/unix/install-web/install-web-trial>`. Official support is likely
       to be dropped during the 5.3.x line.

--- a/omero/sysadmins/unix/install-web/install-apache.txt
+++ b/omero/sysadmins/unix/install-web/install-apache.txt
@@ -1,9 +1,10 @@
 DEPRECATED: OMERO.web Apache and mod_wsgi deployment
 ====================================================
 
-.. note:: Since OMERO 5.3 the Apache and mod_wsgi deployment is deprecated.
+.. note:: Since OMERO 5.2.6 the Apache and mod_wsgi deployment is deprecated.
       Please consider using :doc:`install-nginx` or
-      :doc:`OMERO.web trial deployment </sysadmins/unix/install-web/install-web-trial>`.
+      :doc:`OMERO.web trial deployment </sysadmins/unix/install-web/install-web-trial>`. Official support is likely
+      to be dropped during the 5.3.x line.
 
 Prerequisites
 -------------

--- a/omero/sysadmins/version-requirements.txt
+++ b/omero/sysadmins/version-requirements.txt
@@ -1620,14 +1620,14 @@ Apache
       - from Dec 2005
       - TBA
       - Supported
-      - Supported
-      - Supported
+      - Deprecated
+      - Deprecated
     * - 2.4
       - from Feb 2012
       - TBA
       - Recommended
-      - Recommended
-      - Recommended
+      - Deprecated
+      - Deprecated
 
 Distribution support
 ^^^^^^^^^^^^^^^^^^^^

--- a/omero/sysadmins/version-requirements.txt
+++ b/omero/sysadmins/version-requirements.txt
@@ -171,8 +171,8 @@ The planned changes for 5.2 depend upon our support of
 
 * Apache
 
-  * [5.2] 2.2 deprecated, 2.4 recommended
-  * [5.3] 2.4 recommended
+  * [5.2] deprecated in OMERO 5.2.6
+  * [5.3] deprecated, likely to be dropped during the 5.3.x line
   * Rationale: 2.2 is the CentOS/RHEL 6.x and Ubuntu 12.04 version,
     both of which will be dropped in 5.3 if CentOS 6 is dropped,
     otherwise they will remain deprecated.
@@ -218,7 +218,7 @@ nor tested.
       - Version which is regularly tested, confirmed to work correctly, recommended for optimal performance/experience
     * - Deprecated
       - supported/deprecated
-      - Version which is less tested, expected to work correctly, but may not offer optimal performance/experience; official support will be dropped in the next major OMERO release
+      - Version which is less tested, expected to work correctly, but may not offer optimal performance/experience; official support may be dropped in the next major OMERO release
     * - Dropped
       - unsupported/old
       - Old version no longer tested and no longer officially supported; may or may not work (use at own risk)


### PR DESCRIPTION
Following the discussion on #1531, this PR manually ports the appropriate updates to the develop branch for 5.3.

Staged at https://www.openmicroscopy.org/site/support/omero5.3-staging/sysadmins/unix/install-web.html etc
