### PR TITLE
Document the hyphen syntax for CLI graph commands

### DIFF
--- a/omero/users/cli/chgrp.txt
+++ b/omero/users/cli/chgrp.txt
@@ -54,9 +54,8 @@ project 51 and datasets 53 and 54 to group 5.
     $ bin/omero chgrp 5 Dataset:54,53 Project:51
     $ bin/omero chgrp 5 Dataset:53 Project:51 Dataset:54
 
-To move a number of objects with sequentially numbered IDs an abbreviated
-form using a hyphen to specify an ID range can be used. This form can also be
-mixed with comma-separated IDs.
+To move a number of objects with sequentially numbered IDs a hyphen can be used
+to specify an ID range. This form can also be mixed with comma-separated IDs.
 ::
 
     $ bin/omero chgrp 5 Project:51 Dataset:53-56

--- a/omero/users/cli/chgrp.txt
+++ b/omero/users/cli/chgrp.txt
@@ -54,6 +54,20 @@ project 51 and datasets 53 and 54 to group 5.
     $ bin/omero chgrp 5 Dataset:54,53 Project:51
     $ bin/omero chgrp 5 Dataset:53 Project:51 Dataset:54
 
+To move a number of objects with sequentially numbered IDs an abbreviated
+form using a hyphen to specify an ID range can be used. This form can also be
+mixed with comma-separated IDs.
+::
+
+    $ bin/omero chgrp 5 Project:51 Dataset:53-56
+    $ bin/omero chgrp 5 Dataset:53-56,65,101-105,201,202
+
+.. note::
+    When moving multiple objects in a single command, if one object cannot
+    be moved then the whole command will fail and none of the specified
+    objects will be moved. The :option:`--dry-run` can be useful as a check
+    before trying to move large numbers of objects.
+
 Moving lower level objects
 ==========================
 

--- a/omero/users/cli/chgrp.txt
+++ b/omero/users/cli/chgrp.txt
@@ -64,8 +64,8 @@ to specify an ID range. This form can also be mixed with comma-separated IDs.
 .. note::
     When moving multiple objects in a single command, if one object cannot
     be moved then the whole command will fail and none of the specified
-    objects will be moved. The :option:`--dry-run` can be useful as a check
-    before trying to move large numbers of objects.
+    objects will be moved. The :option:`--dry-run` option can be useful as a
+    check before trying to move large numbers of objects.
 
 Moving lower level objects
 ==========================

--- a/omero/users/cli/delete.txt
+++ b/omero/users/cli/delete.txt
@@ -54,6 +54,20 @@ project 51 and datasets 53 and 54.
     $ bin/omero delete Dataset:54,53 Project:51
     $ bin/omero delete Dataset:53 Project:51 Dataset:54
 
+To delete a number of objects with sequentially numbered IDs an abbreviated
+form using a hyphen to specify an ID range can be used. This form can also be
+mixed with comma-separated IDs.
+::
+
+    $ bin/omero delete Project:51 Dataset:53-56
+    $ bin/omero delete Dataset:53-56,65,101-105,201,202
+
+.. note::
+    When deleting multiple objects in a single command, if one object cannot
+    be deleted then the whole command will fail and none of the specified
+    objects will be deleted. The :option:`--dry-run` can be useful as a check
+    before trying to delete large numbers of objects.
+
 Deleting lower level objects
 ============================
 

--- a/omero/users/cli/delete.txt
+++ b/omero/users/cli/delete.txt
@@ -54,9 +54,9 @@ project 51 and datasets 53 and 54.
     $ bin/omero delete Dataset:54,53 Project:51
     $ bin/omero delete Dataset:53 Project:51 Dataset:54
 
-To delete a number of objects with sequentially numbered IDs an abbreviated
-form using a hyphen to specify an ID range can be used. This form can also be
-mixed with comma-separated IDs.
+To delete a number of objects with sequentially numbered IDs a hyphen can be
+used to specify an ID range. This form can also be mixed with comma-separated
+IDs.
 ::
 
     $ bin/omero delete Project:51 Dataset:53-56

--- a/omero/users/cli/delete.txt
+++ b/omero/users/cli/delete.txt
@@ -65,8 +65,8 @@ IDs.
 .. note::
     When deleting multiple objects in a single command, if one object cannot
     be deleted then the whole command will fail and none of the specified
-    objects will be deleted. The :option:`--dry-run` can be useful as a check
-    before trying to delete large numbers of objects.
+    objects will be deleted. The :option:`--dry-run` option can be useful as a
+    check before trying to delete large numbers of objects.
 
 Deleting lower level objects
 ============================


### PR DESCRIPTION
This PR adds some information about the hyphen syntax for the currently documented CLI graph commands, `delete` and `chgrp`.
