### PR TITLE
Docs for web 'Open with' configuration

### DIFF
--- a/omero/developers/Web/CreateApp.txt
+++ b/omero/developers/Web/CreateApp.txt
@@ -323,7 +323,7 @@ Users can then configure this on the command line as follows:
 
     $ bin/omero config set omero.web.yourapp.foo '{"userkey": "userval"}'
 
-Linking From Webclient
+Linking from Webclient
 ----------------------
 
 If you want to add links to your app from the webclient, a number of options are

--- a/omero/developers/Web/CreateApp.txt
+++ b/omero/developers/Web/CreateApp.txt
@@ -323,76 +323,8 @@ Users can then configure this on the command line as follows:
 
     $ bin/omero config set omero.web.yourapp.foo '{"userkey": "userval"}'
 
+Linking From Webclient
+----------------------
 
-OMERO.web top links
-^^^^^^^^^^^^^^^^^^^
-
-You can configure :property:`omero.web.ui.top_links` to add links to the list
-of links at the top of the webclient main pages.
-
--  **Name your URL in urls.py** (optional). Preferably we use URL names to
-   refer to URLs.
-   For example, the homepage of your app might be named like this in yourapp/urls.py.
-
-   ::
-
-       url( r'^$', views.index, name='figure_index' ),
-
-
-   You can then refer to the link defined above using this ``name``, or you can simply use a full URL for external links.
-
-
--  **Update configuration** Use the OMERO command line interface to append the link to the ``top_links`` list.
-
-   Links use the format ``["Label", "URL_name"]`` or you can follow this example:
-
-   ::
-
-       $ bin/omero config append omero.web.ui.top_links '["Figure", "figure_index"]'
-
-   From OMERO 5.1, you can add additional attributes to links using the format ``['Link Text', 'link', attrs]``.
-   This can be used to add tool-tips and to open the link in a new "target" tab. For example:
-
-   ::
-
-       $ bin/omero config append omero.web.ui.top_links '["Homepage", "http://myhome.com", {"title": "Homepage", "target": "new"}]'
-
-
-Custom image viewer
-^^^^^^^^^^^^^^^^^^^
-
-If you have created your own image viewer and would like to have it replace the existing image viewer in the
-webclient, this can be configured using :property:`omero.web.viewer.view`.
-
-You will need your :file:`views.py` method to take an Image ID with a parameter named ``iid``. For example, see
-``channel_overlay_viewer`` from the `webtest <https://github.com/openmicroscopy/webtest/>`_ app:
-
-::
-
-    @login_required()
-    def channel_overlay_viewer(request, iid, conn=None, **kwargs):
-
-You can then configure the webclient to use this viewer by providing the full path name to this view method.
-For example, if you have webtest installed you can use the ``channel_overlay_viewer``:
-
-::
-
-    $ bin/omero config set omero.web.viewer.view webtest.views.channel_overlay_viewer
-
-This will now direct the image viewer url at ``webclient/img_detail/<iid>/`` to this viewer.
-However, the existing viewer will still be available under webgateway at ``webgateway/img_detail/<iid>/``.
-
-If you want to use a different viewer for different images, you can conditionally redirect to
-the webgateway viewer or elsewhere.
-For example:
-
-::
-
-    if image.getSizeC() == 1:
-        return HttpResponseRedirect(reverse("webgateway.views.full_viewer", args=(iid,)))
-
-
-OMERO.web plugins
------------------
-
-If you want to display content from your app within the webclient UI, please see :doc:`/developers/Web/WebclientPlugin`.
+If you want to add links to your app from the webclient, a number of options are
+described on :doc:`/developers/Web/LinkingFromWebclient`.

--- a/omero/developers/Web/LinkingFromWebclient.txt
+++ b/omero/developers/Web/LinkingFromWebclient.txt
@@ -1,0 +1,188 @@
+
+Linking From Webclient
+======================
+
+If you want users to be able to access your app or other resources from the webclient
+there are a number of ways you can add links to the webclient UI.
+
+OMERO.web top links
+-------------------
+
+You can configure :property:`omero.web.ui.top_links` to add links to the list
+of links at the top of the webclient main pages.
+
+-  **Name your URL in urls.py** (optional). Preferably we use URL names to
+   refer to URLs.
+   For example, the homepage of your app might be named like this in yourapp/urls.py.
+
+   ::
+
+       url( r'^$', views.index, name='figure_index' ),
+
+
+   You can then refer to the link defined above using this ``name``, or you can simply use a full URL for external links.
+
+
+-  **Update configuration** Use the OMERO command line interface to append the link to the ``top_links`` list.
+
+   Links use the format ``["Label", "URL_name"]`` or you can follow this example:
+
+   ::
+
+       $ bin/omero config append omero.web.ui.top_links '["Figure", "figure_index"]'
+
+   From OMERO 5.1, you can add additional attributes to links using the format ``['Link Text', 'link', attrs]``.
+   This can be used to add tool-tips and to open the link in a new "target" tab. For example:
+
+   ::
+
+       $ bin/omero config append omero.web.ui.top_links '["Homepage", "http://myhome.com", {"title": "Homepage", "target": "_blank"}]'
+
+
+Custom image viewer
+-------------------
+
+If you have created your own image viewer and would like to have it replace the existing image viewer in the
+webclient, this can be configured using :property:`omero.web.viewer.view`.
+
+You will need your :file:`views.py` method to take an Image ID with a parameter named ``iid``. For example, see
+``channel_overlay_viewer`` from the `webtest <https://github.com/openmicroscopy/webtest/>`_ app:
+
+::
+
+    @login_required()
+    def channel_overlay_viewer(request, iid, conn=None, **kwargs):
+
+You can then configure the webclient to use this viewer by providing the full path name to this view method.
+For example, if you have webtest installed you can use the ``channel_overlay_viewer``:
+
+::
+
+    $ bin/omero config set omero.web.viewer.view webtest.views.channel_overlay_viewer
+
+This will now direct the image viewer url at ``webclient/img_detail/<iid>/`` to this viewer.
+However, the existing viewer will still be available under webgateway at ``webgateway/img_detail/<iid>/``.
+
+If you want to use a different viewer for different images, you can conditionally redirect to
+the webgateway viewer or elsewhere.
+For example:
+
+::
+
+    if image.getSizeC() == 1:
+        return HttpResponseRedirect(reverse("webgateway.views.full_viewer", args=(iid,)))
+
+
+Open with
+---------
+
+The 'Open with' configuration allows users to 'open' data from OMERO in another web page
+using :property:`omero.web.open_with`.
+
+For example:
+
+ - Open images in a custom viewer
+ - Add images to OMERO.figure
+ - Link to external resources, E.g. open Dataset named '000397' with url https://www.ncbi.nlm.nih.gov/protein/000397
+
+Currently, 'Open With' options are shown in the context menu of the left-panel tree
+and are therefore only available for objects shown in the tree.
+
+Open image in viewer
+^^^^^^^^^^^^^^^^^^^^
+
+In the simplest case the minimum needed to add a viewer is "label" and "url_name".
+
+::
+
+    $ bin/omero config append omero.web.open_with '["My viewer", "url_name"]'
+
+We use ``reverse(url_name)`` to resolve a url from the url_name. If the url_name
+is not recognised (E.g. for external urls) the ``url_name`` will be used directly.
+
+By default, the ``Open With > My viewer`` menu option will only be enabled when a
+single image is selected. When the user clicks the image, a new popup window will be opened
+with the specified url, passing the image ID in the query string:
+
+::
+
+    url?image=:id
+
+Further parameters can be specified in an options object, as described below.
+
+Open in new tab
+^^^^^^^^^^^^^^^
+
+If you wish to open in a new browser tab instead of a popup window, you can add a ``target``
+attribute to the options:
+
+::
+
+    $ bin/omero config append omero.web.open_with '["My viewer", "url_name"], {"target":"_blank"}]'
+
+Supported objects
+^^^^^^^^^^^^^^^^^
+
+By default, 'Open with' options are enabled when only a single image is selected.
+This can be configured to support multiple images or other data types by adding a
+``supported_objects`` list to the options.
+Specify data types as E.g. ``project, dataset, image, screen, plate, acquisition``
+or use plurals to indicate that multiple objects are supported.
+E.g. ```images``` will enable the 'Open with' option when 1 or more images are selected.
+In the following example, we support a single ``dataset`` or multiple ``images``.
+
+::
+
+    $ bin/omero config append omero.web.open_with '["My viewer", "url_name"], {"supported_objects":["dataset", "images"]}]'
+
+JavaScript handlers
+^^^^^^^^^^^^^^^^^^^
+
+For complete control over handling of your 'Open with' action, or to specify
+more precise behaviour of the enabled status, you can write JavaScript functions
+that handle these.
+Add one or both of these function calls to a script, E.g. ```openwith.js```
+
+::
+    // Here we set an 'enabled' handler that is passed a list of selected
+    // objects and should return ``true`` if the 'Open with' option should
+    // be enabled.
+    // First argument is the label that we used above to identify the option
+    OME.setOpenWithEnabledHandler("My viewer", function(selected){
+        // selected is a list of objects containing id, name, type
+
+        // E.g. only support single objects
+        if (selected.length !== 1) return false;
+
+        // E.g. only support image with name ending in .svs
+        var obj = selected[0];
+        return (obj.type === 'image' && obj.name.endsWith('.svs'))
+    });
+
+    // Here we set an 'action' handler that is passed the selected objects
+    // and the url that was specified in the 'Open with' configuration
+    OME.setOpenWithActionHandler("My viewer", function(selected, url) {
+
+        // E.g. build a url using data from selected objects
+        url += selected[0].id + "/";
+        window.open(url, '_blank');
+    });
+
+Save the script to a static location, either within an OMERO.web app's static directory
+or make it available at another url.
+Then specify this location using the ``script_url`` option.
+
+::
+
+    # E.g. script is saved at myviewer/static/myviewer/openwith.js
+    $ bin/omero config append omero.web.open_with '["My viewer", "url_name"], {"script_url":"myviewer/openwith.js"}]'
+
+    # E.g. this 'Open with' option will open any object at http://www.ncbi.nlm.nih.gov/protein/:name
+    # and is enabled when the :name of the object is a number (all digits)
+    $ bin/omero config append omero.web.open_with '["GenBank Protein", "http://www.ncbi.nlm.nih.gov/protein/", {"script_url": "http://will-moore.github.io/presentations/2016/OpenWith-Filtering-June-2016/openwith.js"}]'
+
+
+OMERO.web plugins
+-----------------
+
+If you want to display content from your app within the webclient UI, please see :doc:`/developers/Web/WebclientPlugin`.

--- a/omero/developers/Web/LinkingFromWebclient.txt
+++ b/omero/developers/Web/LinkingFromWebclient.txt
@@ -82,7 +82,7 @@ using :property:`omero.web.open_with`.
 For example:
 
 - Open images in a custom viewer
-- Add images to OMERO.figure
+- Open images in a new figure with OMERO.figure
 - Link to external resources, e.g. open Dataset named '000397' with url https://www.ncbi.nlm.nih.gov/protein/000397
 
 Currently, 'Open With' options are shown in the context menu of the left-panel tree
@@ -137,9 +137,11 @@ attribute to the options:
 JavaScript handlers
 ^^^^^^^^^^^^^^^^^^^
 
-For complete control over handling of your 'Open with' action, or to specify
-more precise behaviour of the enabled status, you can write JavaScript functions
-that handle these.
+For more control over the enabled status of your plugin or to configure how urls
+are created from selected objects, you can write JavaScript functions
+that handle these steps.
+These functions use the label specified above as an ID for your ``Open with``
+option. In this example it is "My viewer".
 Add one or both of these function calls to a script, for example ```openwith.js```
 
 ::
@@ -160,13 +162,13 @@ Add one or both of these function calls to a script, for example ```openwith.js`
         return (obj.type === 'image' && obj.name.endsWith('.svs'))
     });
 
-    // Here we set an 'action' handler that is passed the selected objects
-    // and the url that was specified in the 'Open with' configuration
-    OME.setOpenWithActionHandler("My viewer", function(selected, url) {
+    // Here we configure a url provider. This function will be passed the selected
+    // objects and the base url that was specified in the 'Open with' configuration above.
+    OME.setOpenWithUrlProvider("My viewer", function(selected, url) {
 
-        // E.g. build a url using data from selected objects
+        // E.g. build a url using id from selected objects
         url += selected[0].id + "/";
-        window.open(url, '_blank');
+        return url;
     });
 
 Save the script to a static location, either within an OMERO.web app's static directory
@@ -178,7 +180,8 @@ Then specify this location using the ``script_url`` option.
     # E.g. script is saved at myviewer/static/myviewer/openwith.js
     $ bin/omero config append omero.web.open_with '["My viewer", "url_name"], {"script_url": "myviewer/openwith.js"}]'
 
-    # E.g. this 'Open with' option loads a script that will open any object at http://www.ncbi.nlm.nih.gov/protein/:name
+    # E.g. this 'Open with' option loads a script from the specified url.
+    # The script will open any object with url http://www.ncbi.nlm.nih.gov/protein/:name
     # and is enabled when the :name of the object is a number (all digits)
     $ bin/omero config append omero.web.open_with '["GenBank Protein", "http://www.ncbi.nlm.nih.gov/protein/", {"script_url": "http://will-moore.github.io/presentations/2016/OpenWith-Filtering-June-2016/openwith.js"}]'
 

--- a/omero/developers/Web/LinkingFromWebclient.txt
+++ b/omero/developers/Web/LinkingFromWebclient.txt
@@ -175,6 +175,11 @@ Save the script to a static location, either within an OMERO.web app's static di
 or make it available at another url.
 Then specify this location using the ``script_url`` option.
 
+.. note::
+
+    Once you've added a script and updated the config, you will need to restart OMERO.web.
+    This will ``syncmedia`` to copy the script to the static files location.
+
 ::
 
     # E.g. script is saved at myviewer/static/myviewer/openwith.js

--- a/omero/developers/Web/LinkingFromWebclient.txt
+++ b/omero/developers/Web/LinkingFromWebclient.txt
@@ -144,6 +144,7 @@ that handle these.
 Add one or both of these function calls to a script, E.g. ```openwith.js```
 
 ::
+
     // Here we set an 'enabled' handler that is passed a list of selected
     // objects and should return ``true`` if the 'Open with' option should
     // be enabled.

--- a/omero/developers/Web/LinkingFromWebclient.txt
+++ b/omero/developers/Web/LinkingFromWebclient.txt
@@ -142,7 +142,7 @@ are created from selected objects, you can write JavaScript functions
 that handle these steps.
 These functions use the label specified above as an ID for your ``Open with``
 option. In this example it is "My viewer".
-Add one or both of these function calls to a script, for example ```openwith.js```
+Add one or both of these function calls to a script, for example ``openwith.js``
 
 ::
 

--- a/omero/developers/Web/LinkingFromWebclient.txt
+++ b/omero/developers/Web/LinkingFromWebclient.txt
@@ -46,7 +46,7 @@ If you have created your own image viewer and would like to have it replace the 
 webclient, this can be configured using :property:`omero.web.viewer.view`.
 
 You will need your :file:`views.py` method to take an Image ID with a parameter named ``iid``. For example, see
-``channel_overlay_viewer`` from the `webtest <https://github.com/openmicroscopy/webtest/>`_ app:
+``channel_overlay_viewer`` from the `OMERO.webtest <https://github.com/openmicroscopy/omero-webtest/>`_ app:
 
 ::
 

--- a/omero/developers/Web/LinkingFromWebclient.txt
+++ b/omero/developers/Web/LinkingFromWebclient.txt
@@ -1,5 +1,5 @@
 
-Linking From Webclient
+Linking from Webclient
 ======================
 
 If you want users to be able to access your app or other resources from the webclient
@@ -81,9 +81,9 @@ using :property:`omero.web.open_with`.
 
 For example:
 
- - Open images in a custom viewer
- - Add images to OMERO.figure
- - Link to external resources, E.g. open Dataset named '000397' with url https://www.ncbi.nlm.nih.gov/protein/000397
+- Open images in a custom viewer
+- Add images to OMERO.figure
+- Link to external resources, e.g. open Dataset named '000397' with url https://www.ncbi.nlm.nih.gov/protein/000397
 
 Currently, 'Open With' options are shown in the context menu of the left-panel tree
 and are therefore only available for objects shown in the tree.
@@ -103,7 +103,7 @@ This will create a menu option named "My viewer" that is only enabled when a
 single "image" is selected.
 
 We use ``reverse(url_name)`` to resolve a url from the url_name. If the url_name
-is not recognised (E.g. for external urls) the ``url_name`` will be used directly.
+is not recognised (for external urls) the ``url_name`` will be used directly.
 
 When the "My viewer" option is clicked, a new window will be opened with the
 selected object(s) added to the url as a query string
@@ -140,7 +140,7 @@ JavaScript handlers
 For complete control over handling of your 'Open with' action, or to specify
 more precise behaviour of the enabled status, you can write JavaScript functions
 that handle these.
-Add one or both of these function calls to a script, E.g. ```openwith.js```
+Add one or both of these function calls to a script, for example ```openwith.js```
 
 ::
 

--- a/omero/developers/Web/LinkingFromWebclient.txt
+++ b/omero/developers/Web/LinkingFromWebclient.txt
@@ -88,27 +88,41 @@ For example:
 Currently, 'Open With' options are shown in the context menu of the left-panel tree
 and are therefore only available for objects shown in the tree.
 
-Open image in viewer
-^^^^^^^^^^^^^^^^^^^^
+Label, name and supported objects
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In the simplest case the minimum needed to add a viewer is "label" and "url_name".
+In the simplest case the minimum needed to add an ``Open with`` option is "label",
+"url_name", and a list of the types of objects that are supported by your app.
+For example:
 
 ::
 
-    $ bin/omero config append omero.web.open_with '["My viewer", "url_name"]'
+    $ bin/omero config append omero.web.open_with '["My viewer", "url_name", {"supported_objects": ["image"]}]'
+
+This will create a menu option named "My viewer" that is only enabled when a
+single "image" is selected.
 
 We use ``reverse(url_name)`` to resolve a url from the url_name. If the url_name
 is not recognised (E.g. for external urls) the ``url_name`` will be used directly.
 
-By default, the ``Open With > My viewer`` menu option will only be enabled when a
-single image is selected. When the user clicks the image, a new popup window will be opened
-with the specified url, passing the image ID in the query string:
+When the "My viewer" option is clicked, a new window will be opened with the
+selected object(s) added to the url as a query string
 
 ::
 
     url?image=:id
 
-Further parameters can be specified in an options object, as described below.
+Supported objects can be configured to support multiple images or other data types.
+Data types are ``project, dataset, image, screen, plate, acquisition``
+or use plurals to indicate that multiple objects are supported.
+For example, ```images``` will enable the 'Open with' option when 1 or more images are selected.
+In the following example, we support a single ``dataset`` or multiple ``images``.
+
+::
+
+    "supported_objects": ["dataset", "images"]
+
+Further parameters can be specified in the options object, as described below.
 
 Open in new tab
 ^^^^^^^^^^^^^^^
@@ -118,22 +132,7 @@ attribute to the options:
 
 ::
 
-    $ bin/omero config append omero.web.open_with '["My viewer", "url_name"], {"target":"_blank"}]'
-
-Supported objects
-^^^^^^^^^^^^^^^^^
-
-By default, 'Open with' options are enabled when only a single image is selected.
-This can be configured to support multiple images or other data types by adding a
-``supported_objects`` list to the options.
-Specify data types as E.g. ``project, dataset, image, screen, plate, acquisition``
-or use plurals to indicate that multiple objects are supported.
-E.g. ```images``` will enable the 'Open with' option when 1 or more images are selected.
-In the following example, we support a single ``dataset`` or multiple ``images``.
-
-::
-
-    $ bin/omero config append omero.web.open_with '["My viewer", "url_name"], {"supported_objects":["dataset", "images"]}]'
+    $ bin/omero config append omero.web.open_with '["My viewer", "url_name"], {"supported_objects": ["image"], "target": "_blank"}]'
 
 JavaScript handlers
 ^^^^^^^^^^^^^^^^^^^
@@ -148,6 +147,7 @@ Add one or both of these function calls to a script, E.g. ```openwith.js```
     // Here we set an 'enabled' handler that is passed a list of selected
     // objects and should return ``true`` if the 'Open with' option should
     // be enabled.
+    // The ``supported_objects`` parameter will not be needed.
     // First argument is the label that we used above to identify the option
     OME.setOpenWithEnabledHandler("My viewer", function(selected){
         // selected is a list of objects containing id, name, type
@@ -176,9 +176,9 @@ Then specify this location using the ``script_url`` option.
 ::
 
     # E.g. script is saved at myviewer/static/myviewer/openwith.js
-    $ bin/omero config append omero.web.open_with '["My viewer", "url_name"], {"script_url":"myviewer/openwith.js"}]'
+    $ bin/omero config append omero.web.open_with '["My viewer", "url_name"], {"script_url": "myviewer/openwith.js"}]'
 
-    # E.g. this 'Open with' option will open any object at http://www.ncbi.nlm.nih.gov/protein/:name
+    # E.g. this 'Open with' option loads a script that will open any object at http://www.ncbi.nlm.nih.gov/protein/:name
     # and is enabled when the :name of the object is a number (all digits)
     $ bin/omero config append omero.web.open_with '["GenBank Protein", "http://www.ncbi.nlm.nih.gov/protein/", {"script_url": "http://will-moore.github.io/presentations/2016/OpenWith-Filtering-June-2016/openwith.js"}]'
 

--- a/omero/developers/index.txt
+++ b/omero/developers/index.txt
@@ -108,6 +108,7 @@ Web
     Web
     Web/Deployment
     Web/CreateApp
+    Web/LinkingFromWebclient
     Web/WebclientPlugin
     Web/EditingOmeroWeb
     Web/WebGateway


### PR DESCRIPTION
Documentation for using new "Open with" options.
PR open but not yet merged at https://github.com/openmicroscopy/openmicroscopy/pull/4630

To test, configure 'Open with' using all the different options described.
