### PR TITLE
Apache deprecation

### DIFF
--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -68,7 +68,7 @@ there may be fixes which require it.
     :doc:`/sysadmins/version-requirements` page.
     
     Also note that as of OMERO 5.2.6, Apache is deprecated and official
-    support may be dropped in 5.3.
+    support is likely be dropped during the 5.3.x line.
 
 OMERO.web dependencies
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -66,6 +66,9 @@ there may be fixes which require it.
     `Django 1.8`_ (LTS) which requires Python 2.7. For more information
     see :ref:`python-requirements` on the
     :doc:`/sysadmins/version-requirements` page.
+    
+    Also note that as of OMERO 5.2.6, Apache is deprecated and official
+    support may be dropped in 5.3.
 
 OMERO.web dependencies
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -67,8 +67,8 @@ there may be fixes which require it.
     see :ref:`python-requirements` on the
     :doc:`/sysadmins/version-requirements` page.
     
-    Also note that as of OMERO 5.2.6, Apache is deprecated and official
-    support is likely be dropped during the 5.3.x line.
+    Also note that as of OMERO 5.2.6, support for Apache deployment is
+    deprecated and is likely be dropped during the 5.3.x line.
 
 OMERO.web dependencies
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -80,7 +80,7 @@ up to date to ensure that security updates are applied.
 
      $ pip install --upgrade -r share/web/requirements-py27-nginx.txt
 
-- Apache on Unix::
+- Apache (deprecated) on Unix::
 
      $ pip install --upgrade -r share/web/requirements-py27-apache.txt
 

--- a/omero/sysadmins/unix/install-web.txt
+++ b/omero/sysadmins/unix/install-web.txt
@@ -60,11 +60,8 @@ customization options.
 .. note:: Support for Apache deployment is deprecated as of OMERO 5.2.6 and is
     likely be dropped during the 5.3.x line.
     
-    If an Apache HTTP server is the only way to provide internet access to
-    internal clients that are otherwise restricted by a firewall, you should
-    configure the Apache HTTP server as a reverse proxy to Nginx (refer to the
-    `Apache mod_proxy documentation <https://httpd.apache.org/docs/current/mod/mod_proxy.html>`_ for further
-    details).
+    If your organisation's policies only allow Apache to be used as the external-facing web-server you should configure Apache to proxy connections to an Nginx instance running on your OMERO server i.e. use Apache as a reverse proxy. For more details see
+    `Apache mod_proxy documentation <https://httpd.apache.org/docs/current/mod/mod_proxy.html>`_.
 
 Logging in to OMERO.web
 -----------------------

--- a/omero/sysadmins/unix/install-web.txt
+++ b/omero/sysadmins/unix/install-web.txt
@@ -15,8 +15,8 @@ with:
    `nginx <http://nginx.org/>`_ and `gunicorn <http://docs.gunicorn.org/>`_
    (you can also use `Apache 2.2+ <http://httpd.apache.org/>`_ with
    `mod\_wsgi <http://www.modwsgi.org/>`_ enabled but this is not
-   recommended for new installations as it has been deprecated as of OMERO
-   5.2.6 and is likely to be dropped during the 5.3.x line)
+   recommended for new installations as support has been deprecated as of
+   OMERO 5.2.6 and is likely to be dropped during the 5.3.x line)
 -  The built-in Django lightweight development server (for **testing**
    only; see the :doc:`/developers/Web/Deployment` page).
 
@@ -57,8 +57,8 @@ customization options.
     install-web/install-apache
     install-web/install-nginx
 
-.. note:: Apache is deprecated as of OMERO 5.2.6 and official
-    support is likely be dropped during the 5.3.x line.
+.. note:: Support for Apache deployment is deprecated as of OMERO 5.2.6 and is
+    likely be dropped during the 5.3.x line.
     
     If an Apache HTTP server is the only way to provide internet access to
     internal clients that are otherwise restricted by a firewall, you should

--- a/omero/sysadmins/unix/install-web.txt
+++ b/omero/sysadmins/unix/install-web.txt
@@ -60,7 +60,7 @@ customization options.
 .. note:: Support for Apache deployment is deprecated as of OMERO 5.2.6 and is
     likely be dropped during the 5.3.x line.
     
-    If your organisation's policies only allow Apache to be used as the external-facing web-server you should configure Apache to proxy connections to an Nginx instance running on your OMERO server i.e. use Apache as a reverse proxy. For more details see
+    If your organization's policies only allow Apache to be used as the external-facing web-server you should configure Apache to proxy connections to an Nginx instance running on your OMERO server i.e. use Apache as a reverse proxy. For more details see
     `Apache mod_proxy documentation <https://httpd.apache.org/docs/current/mod/mod_proxy.html>`_.
 
 Logging in to OMERO.web

--- a/omero/sysadmins/unix/install-web.txt
+++ b/omero/sysadmins/unix/install-web.txt
@@ -15,7 +15,8 @@ with:
    `nginx <http://nginx.org/>`_ and `gunicorn <http://docs.gunicorn.org/>`_
    (you can also use `Apache 2.2+ <http://httpd.apache.org/>`_ with
    `mod\_wsgi <http://www.modwsgi.org/>`_ enabled but this is not
-   recommended for new installations as support is due to be removed in 5.3)
+   recommended for new installations as it has been deprecated as of OMERO
+   5.2.6 and is likely to be dropped during the 5.3.x line)
 -  The built-in Django lightweight development server (for **testing**
    only; see the :doc:`/developers/Web/Deployment` page).
 

--- a/omero/sysadmins/unix/install-web.txt
+++ b/omero/sysadmins/unix/install-web.txt
@@ -56,8 +56,8 @@ customization options.
     install-web/install-apache
     install-web/install-nginx
 
-.. note:: Apache is deprecated as of OMERO 5.2.6 and may not be officially
-    supported for 5.3.
+.. note:: Apache is deprecated as of OMERO 5.2.6 and official
+    support is likely be dropped during the 5.3.x line.
     
     If an Apache HTTP server is the only way to provide internet access to
     internal clients that are otherwise restricted by a firewall, you should

--- a/omero/sysadmins/unix/install-web.txt
+++ b/omero/sysadmins/unix/install-web.txt
@@ -56,8 +56,14 @@ customization options.
     install-web/install-apache
     install-web/install-nginx
 
-.. note:: Apache is deprecated as of OMERO 5.2.6 and will not be supported for
-    5.3.
+.. note:: Apache is deprecated as of OMERO 5.2.6 and may not be officially
+    supported for 5.3.
+    
+    If an Apache HTTP server is the only way to provide internet access to
+    internal clients that are otherwise restricted by a firewall, you should
+    configure the Apache HTTP server as a reverse proxy to Nginx (refer to the
+    `Apache mod_proxy documentation <https://httpd.apache.org/docs/current/mod/mod_proxy.html>`_ for further
+    details).
 
 Logging in to OMERO.web
 -----------------------

--- a/omero/sysadmins/unix/install-web.txt
+++ b/omero/sysadmins/unix/install-web.txt
@@ -12,9 +12,10 @@ with:
 
 -  `WSGI <http://wsgi.readthedocs.org>`_ using a WSGI capable web server
    such as
-   `Apache 2.2+ <http://httpd.apache.org/>`_ (with
-   `mod\_wsgi <http://www.modwsgi.org/>`_ enabled) or 
-   `nginx <http://nginx.org/>`_ and `gunicorn <http://docs.gunicorn.org/>`_,
+   `nginx <http://nginx.org/>`_ and `gunicorn <http://docs.gunicorn.org/>`_
+   (you can also use `Apache 2.2+ <http://httpd.apache.org/>`_ with
+   `mod\_wsgi <http://www.modwsgi.org/>`_ enabled but this is not
+   recommended for new installations as support is due to be removed in 5.3)
 -  The built-in Django lightweight development server (for **testing**
    only; see the :doc:`/developers/Web/Deployment` page).
 
@@ -54,6 +55,9 @@ customization options.
 
     install-web/install-apache
     install-web/install-nginx
+
+.. note:: Apache is deprecated as of OMERO 5.2.6 and will not be supported for
+    5.3.
 
 Logging in to OMERO.web
 -----------------------

--- a/omero/sysadmins/unix/install-web/install-apache.txt
+++ b/omero/sysadmins/unix/install-web/install-apache.txt
@@ -13,8 +13,8 @@ Apache 2.2+ with mod_wsgi configuration (Unix/Linux)
       see :ref:`python-requirements` on the
       :doc:`/sysadmins/version-requirements` page.
       
-      Also note that Apache is deprecated as of OMERO 5.2.6 and official
-      support is likely be dropped during the 5.3.x line.
+      Also note that support for Apache deployment is deprecated as of OMERO
+      5.2.6 and is likely be dropped during the 5.3.x line.
 
 OMERO.web uses the
 `Web Server Gateway Interface (WSGI) <http://wsgi.readthedocs.org/en/latest/learn.html>`_

--- a/omero/sysadmins/unix/install-web/install-apache.txt
+++ b/omero/sysadmins/unix/install-web/install-apache.txt
@@ -13,8 +13,8 @@ Apache 2.2+ with mod_wsgi configuration (Unix/Linux)
       see :ref:`python-requirements` on the
       :doc:`/sysadmins/version-requirements` page.
       
-      Also note that Apache is deprecated as of OMERO 5.2.6 and may not be
-      officially supported for 5.3.
+      Also note that Apache is deprecated as of OMERO 5.2.6 and official
+      support is likely be dropped during the 5.3.x line.
 
 OMERO.web uses the
 `Web Server Gateway Interface (WSGI) <http://wsgi.readthedocs.org/en/latest/learn.html>`_

--- a/omero/sysadmins/unix/install-web/install-apache.txt
+++ b/omero/sysadmins/unix/install-web/install-apache.txt
@@ -1,5 +1,5 @@
-OMERO.web Apache and mod_wsgi deployment (Unix/Linux)
-======================================================
+DEPRECATED: OMERO.web Apache and mod_wsgi deployment (Unix/Linux)
+=================================================================
 
 .. _apache_wsgi_configuration:
 
@@ -13,8 +13,8 @@ Apache 2.2+ with mod_wsgi configuration (Unix/Linux)
       see :ref:`python-requirements` on the
       :doc:`/sysadmins/version-requirements` page.
       
-      Also note that Apache is deprecated as of OMERO 5.2.6 and will not be
-      supported for 5.3.
+      Also note that Apache is deprecated as of OMERO 5.2.6 and may not be
+      officially supported for 5.3.
 
 OMERO.web uses the
 `Web Server Gateway Interface (WSGI) <http://wsgi.readthedocs.org/en/latest/learn.html>`_

--- a/omero/sysadmins/unix/install-web/install-apache.txt
+++ b/omero/sysadmins/unix/install-web/install-apache.txt
@@ -12,6 +12,9 @@ Apache 2.2+ with mod_wsgi configuration (Unix/Linux)
       `Django 1.8`_ (LTS) which requires Python 2.7. For more information
       see :ref:`python-requirements` on the
       :doc:`/sysadmins/version-requirements` page.
+      
+      Also note that Apache is deprecated as of OMERO 5.2.6 and will not be
+      supported for 5.3.
 
 OMERO.web uses the
 `Web Server Gateway Interface (WSGI) <http://wsgi.readthedocs.org/en/latest/learn.html>`_

--- a/omero/sysadmins/version-requirements.txt
+++ b/omero/sysadmins/version-requirements.txt
@@ -1620,14 +1620,14 @@ Apache
       - from Dec 2005
       - TBA
       - Supported
-      - Supported
-      - Supported
+      - Deprecated
+      - Deprecated
     * - 2.4
       - from Feb 2012
       - TBA
       - Recommended
-      - Recommended
-      - Recommended
+      - Deprecated
+      - Deprecated
 
 Distribution support
 ^^^^^^^^^^^^^^^^^^^^

--- a/omero/sysadmins/version-requirements.txt
+++ b/omero/sysadmins/version-requirements.txt
@@ -172,7 +172,7 @@ The planned changes for 5.2 depend upon our support of
 * Apache
 
   * [5.2] 2.2 deprecated, 2.4 recommended
-  * [5.3] 2.4 recommended
+  * [5.3] deprecated for all versions
   * Rationale: 2.2 is the CentOS/RHEL 6.x and Ubuntu 12.04 version,
     both of which will be dropped in 5.3 if CentOS 6 is dropped,
     otherwise they will remain deprecated.
@@ -218,7 +218,7 @@ nor tested.
       - Version which is regularly tested, confirmed to work correctly, recommended for optimal performance/experience
     * - Deprecated
       - supported/deprecated
-      - Version which is less tested, expected to work correctly, but may not offer optimal performance/experience; official support will be dropped in the next major OMERO release
+      - Version which is less tested, expected to work correctly, but may not offer optimal performance/experience; official support may be dropped in the next major OMERO release
     * - Dropped
       - unsupported/old
       - Old version no longer tested and no longer officially supported; may or may not work (use at own risk)

--- a/omero/sysadmins/version-requirements.txt
+++ b/omero/sysadmins/version-requirements.txt
@@ -171,8 +171,8 @@ The planned changes for 5.2 depend upon our support of
 
 * Apache
 
-  * [5.2] 2.2 deprecated, 2.4 recommended
-  * [5.3] deprecated for all versions
+  * [5.2] deprecated in OMERO 5.2.6
+  * [5.3] deprecated, likely to be dropped during the 5.3.x line
   * Rationale: 2.2 is the CentOS/RHEL 6.x and Ubuntu 12.04 version,
     both of which will be dropped in 5.3 if CentOS 6 is dropped,
     otherwise they will remain deprecated.


### PR DESCRIPTION
Replace PR https://github.com/openmicroscopy/ome-documentation/pull/1531
@hflynn being away

See https://trello.com/b/pdGVgP51/omero-5-2-6 Apache is being deprecated in 5.2.6 with a view to not supporting it for 5.3.

Staged at https://www.openmicroscopy.org/site/support/omero5.2-staging/sysadmins/unix/install-web.html and https://www.openmicroscopy.org/site/support/omero5.2-staging/sysadmins/unix/install-web/install-apache.html

I didn't bother adding it to the Windows web deployment page since we're already warning we're not supporting Windows at all for 5.3.

Last commit: Update the note
