### PR TITLE
5.2.6 history

### DIFF
--- a/omero/users/history.txt
+++ b/omero/users/history.txt
@@ -1,7 +1,7 @@
 OMERO version history
 =====================
 
-5.2.6 (September 2016)
+5.2.6 (October 2016)
 ----------------------
 
 This is a bug-fix release focusing on services closure and a DB upgrade fix.
@@ -11,7 +11,7 @@ Improvements include:
 - fixed memory leak where services were not correctly closed
 - added a DB upgrade patch to fix errors only affecting DBs that have been
   upgraded from OMERO 4.4
-- fixed a MATLAB regression introduced in 5.2.2
+- fixed a MATLAB regression introduced in 5.2.2, casting error.
 - fixed error in logs on getProjectedThumbnail
 
  Support for OMERO.web deployment using Apache has also been deprecated and is

--- a/omero/users/history.txt
+++ b/omero/users/history.txt
@@ -1,6 +1,22 @@
 OMERO version history
 =====================
 
+5.2.6 (September 2016)
+----------------------
+
+This is a bug-fix release focusing on services closure and a DB upgrade fix.
+Improvements include:
+
+- fixed closure of session in Java when using Ice 3.5
+- fixed memory leak where services were not correctly closed
+- added a DB upgrade patch to fix errors only affecting DBs that have been
+  upgraded from OMERO 4.4
+- fixed a MATLAB regression introduced in 5.2.2
+- fixed error in logs on getProjectedThumbnail
+
+ Support for OMERO.web deployment using Apache has also been deprecated and is
+ likely to be removed during the 5.3.x line.
+
 5.2.5 (August 2016)
 -------------------
 

--- a/omero/users/history.txt
+++ b/omero/users/history.txt
@@ -14,8 +14,8 @@ Improvements include:
 - fixed a MATLAB regression introduced in 5.2.2, casting error.
 - fixed error in logs on getProjectedThumbnail
 
- Support for OMERO.web deployment using Apache has also been deprecated and is
- likely to be removed during the 5.3.x line.
+Support for OMERO.web deployment using Apache has also been deprecated and is
+likely to be removed during the 5.3.x line.
 
 5.2.5 (August 2016)
 -------------------


### PR DESCRIPTION
Implements https://github.com/openmicroscopy/openmicroscopy/pull/4851 in the docs since we don't have the autogen stuff set up for this branch

Staged at https://www.openmicroscopy.org/site/support/omero5.2-staging/users/history.html

cc @sbesson 
