### PR TITLE
Improve explanation of advanced scripts workflow

### DIFF
--- a/omero/developers/scripts/advanced.txt
+++ b/omero/developers/scripts/advanced.txt
@@ -54,6 +54,7 @@ openmicroscopy.org.uk and user: will
 You should see an output similar to the one below
 
 ::
+
     Created session afdbba21-35dc-462a-ab6e-15cc94f93957 (user-4@openmicroscopy.org.uk:4064). Idle timeout: 10 min. Current group: read-only-1
     2016-10-03 10:12:45,964 INFO  [                    omero.util.Resources] (Thread-2  ) Starting
     2016-10-03 10:12:45,965 INFO  [              omero.processor.ProcessorI] (MainThread) Registering processor %fOr(Up>[ERUV%B8$.N</omero.scripts.serve-fa53ba-3959-4d85-876a-00e8b932eb -t -e 1.0:tcp -h openmicroscopy.org.uk -p 54385

--- a/omero/developers/scripts/advanced.txt
+++ b/omero/developers/scripts/advanced.txt
@@ -51,6 +51,16 @@ openmicroscopy.org.uk and user: will
     $ bin/omero -s openmicroscopy.org.uk -u will script serve user
     $ password: ......
 
+You should see an output similar to the one below
+
+::
+    Created session afdbba21-35dc-462a-ab6e-15cc94f93957 (user-4@openmicroscopy.org.uk:4064). Idle timeout: 10 min. Current group: read-only-1
+    2016-10-03 10:12:45,964 INFO  [                    omero.util.Resources] (Thread-2  ) Starting
+    2016-10-03 10:12:45,965 INFO  [              omero.processor.ProcessorI] (MainThread) Registering processor %fOr(Up>[ERUV%B8$.N</omero.scripts.serve-fa53ba-3959-4d85-876a-00e8b932eb -t -e 1.0:tcp -h openmicroscopy.org.uk -p 54385
+    Press any key to exit...
+
+Now you need to open a new terminal window in order to continue with your workflow. 
+
 If you want to run scripts belonging to another user in the same
 collaborative group you need to set up your local user processor to
 accept scripts from that user. First, find the ID of the user, then


### PR DESCRIPTION
Add example of output after starting processor for advanced (non-admin) scripting workflow.
See https://www.openmicroscopy.org/site/support/omero5.2-staging/developers/scripts/advanced.html for buit version.

The motivation is also described in [trello card](https://trello.com/c/81ISVYsi/118-cannot-import-script-via-cli#comment-57b59d9982efadf70e294798).

cc @jburel @will-moore 
