### PR TITLE
Differentiate CL options with same name

### DIFF
--- a/omero/users/cli/chgrp.txt
+++ b/omero/users/cli/chgrp.txt
@@ -9,8 +9,8 @@ available using the :option:`-h` option::
 The :command:`chgrp` command will remove entire graphs of objects based on the
 IDs of the topmost objects. The command can be modified to include the movement
 of objects that would, by default, be excluded or exclude objects that would,
-by default, be included using the :option:`--include` and :option:`--exclude`
-options.
+by default, be included using the :option:`chgrp --include` and
+:option:`chgrp --exclude` options.
 
 It is also possible to move objects lower in the hierarchy by specifying
 the type and ID of a topmost object and the type of the lower object. For
@@ -18,8 +18,8 @@ instance, moving all of the images under a given project.
 
 By default the command confirms the movement of the target objects but
 it can also provide a detailed report of all the moved objects via a
-:option:`--report` option. A :option:`--dry-run` option can be used to report
-on what objects would be moved without actually moving them.
+:option:`chgrp --report` option. A :option:`chgrp --dry-run` option can be
+used to report on what objects would be moved without actually moving them.
 
 Examples
 ^^^^^^^^
@@ -64,8 +64,8 @@ to specify an ID range. This form can also be mixed with comma-separated IDs.
 .. note::
     When moving multiple objects in a single command, if one object cannot
     be moved then the whole command will fail and none of the specified
-    objects will be moved. The :option:`--dry-run` option can be useful as a
-    check before trying to move large numbers of objects.
+    objects will be moved. The :option:`chgrp --dry-run` option can be useful
+    as a check before trying to move large numbers of objects.
 
 Moving lower level objects
 ==========================
@@ -85,6 +85,8 @@ would have the same effect as the call above.
 
 Including and excluding objects
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. program:: chgrp
 
 .. option:: --include
 
@@ -116,6 +118,8 @@ that are not otherwise contained in datasets will be orphaned.
 Further options
 ^^^^^^^^^^^^^^^
 
+.. program:: chgrp
+
 .. option:: --ordered
 
     Move the objects in the order specified.
@@ -141,6 +145,6 @@ Further options
 .. option:: --dry-run
 
     Run the command and report success or failure but does not move the
-    objects. This can be combined with the :option:`--report` to provide
+    objects. This can be combined with the :option:`chgrp --report` to provide
     a detailed confirmation of what would be moved before running the
     move itself.

--- a/omero/users/cli/delete.txt
+++ b/omero/users/cli/delete.txt
@@ -9,8 +9,8 @@ using the :option:`-h` option::
 The :command:`delete` command will remove entire graphs of objects based on
 the IDs of the topmost objects. The command can be modified to include the
 deletion of objects that would, by default, be excluded or exclude objects
-that would, by default, be included using the :option:`--include` and
-:option:`--exclude` options.
+that would, by default, be included using the :option:`delete --include` and
+:option:`delete --exclude` options.
 
 Additionally, objects of the three annotation types, `FileAnnotation`,
 `TagAnnotation` and `TermAnnotation` are not deleted by default when the
@@ -22,8 +22,9 @@ instance, deleting all of the images under a given project.
 
 By default the command confirms the deletion of the target objects but
 it can also provide a detailed report of all the deleted objects via a
-:option:`--report` option. A :option:`--dry-run` option can be used to report
-on what objects would be deleted without actually deleting them.
+:option:`delete --report` option. A :option:`delete --dry-run` option can be
+used to report on what objects would be deleted without actually deleting
+them.
 
 Examples
 ^^^^^^^^
@@ -65,8 +66,8 @@ IDs.
 .. note::
     When deleting multiple objects in a single command, if one object cannot
     be deleted then the whole command will fail and none of the specified
-    objects will be deleted. The :option:`--dry-run` option can be useful as a
-    check before trying to delete large numbers of objects.
+    objects will be deleted. The :option:`delete --dry-run` option can be
+    useful as a check before trying to delete large numbers of objects.
 
 Deleting lower level objects
 ============================
@@ -92,6 +93,8 @@ not also under other datasets.
 
 Including and excluding objects
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. program:: delete
 
 .. option:: --include
 
@@ -130,6 +133,8 @@ For an example on deleting tags directly see :ref:`delete_tags`.
 
 Further options
 ^^^^^^^^^^^^^^^
+
+.. program:: delete
 
 .. option:: --ordered
 


### PR DESCRIPTION
See https://trello.com/c/IG1JLPxA/196-option-markup-and-sphinx - sphinx can't index options properly if they have the same name so I've used the program option to differentiate their context so the links remain on the same page. Hopefully it isn't too confusing to have the command and flag listed after each other given the examples show that text is required between them for actual usage. 

Staged at https://www.openmicroscopy.org/site/support/omero5.3-staging/users/cli/chgrp.html and https://www.openmicroscopy.org/site/support/omero5.3-staging/users/cli/delete.html and also check https://www.openmicroscopy.org/site/support/omero5.3-staging/genindex.html to make sure there are no [1] marked double entries for command line options anymore. 
