### PR TITLE
Cpp: Document Windows limitations and workarounds

### DIFF
--- a/omero/developers/Cpp.txt
+++ b/omero/developers/Cpp.txt
@@ -22,6 +22,22 @@ Prerequisites
 * :program:`cmake`
 * Google Test (optional; needed to build the unit and integration tests)
 
+.. note::
+
+    Users of :program:`Visual Studio` with :program:`Ice` 3.6 will
+    encounter this error while building OmeroCpp: ``LINK : fatal error
+    LNK1189: library limit of 65535 objects exceeded`` and will be
+    unable to build |OmeroCpp| for Windows as a result of a 16-bit
+    limitation in the Windows PE-COFF executable format used for DLLs,
+    even on 64-bit systems.  Workarounds include:
+
+    - using :program:`Ice` 3.5 (requires building :program:`Ice`
+      against Python 2.7 with the same version of :program:`Visual
+      Studio`
+
+    - it is hoped that :program:`Ice` 3.7 (when released) will resolve
+      the problem since it generates far fewer symbols than 3.6
+
 Restrictions
 ------------
 

--- a/omero/developers/Cpp.txt
+++ b/omero/developers/Cpp.txt
@@ -33,7 +33,7 @@ Prerequisites
 
     - using :program:`Ice` 3.5 (requires building :program:`Ice`
       against Python 2.7 with the same version of :program:`Visual
-      Studio`
+      Studio`)
 
     - it is hoped that :program:`Ice` 3.7 (when released) will resolve
       the problem since it generates far fewer symbols than 3.6


### PR DESCRIPTION
This is to document that OmeroCpp on Windows is not going to work by default on Windows for 5.3, unless work is put in to build all the ice 3.5 bits by hand (same as 5.2 with ice 3.5).
