### PR TITLE
Update Figure in CI docs

### DIFF
--- a/contributing/ci-docs.txt
+++ b/contributing/ci-docs.txt
@@ -342,7 +342,7 @@ The repository for the OME help is https://github.com/openmicroscopy/ome-help.
 OMERO.figure website
 ^^^^^^^^^^^^^^^^^^^^
 
-The repository for OMERO.figure is https://github.com/ome/figure.
+The repository for OMERO.figure is https://github.com/ome/omero-figure.
 
 .. glossary::
 
@@ -364,8 +364,8 @@ The repository for OMERO.figure is https://github.com/ome/figure.
 		This job is used to deploy the Figure gh-pages website
 
 		#. Opens a Pull Request from
-		   https://github.com/ome/figure/tree/gh-pages-staging
-		   to https://github.com/ome/figure/tree/gh-pages. If
+		   https://github.com/ome/omero-figure/tree/gh-pages-staging
+		   to https://github.com/ome/omero-figure/tree/gh-pages. If
 		   this PR is merged, the GitHub Pages service updates the content of
 		   http://figure.openmicroscopy.org
 

--- a/contributing/ci-release.txt
+++ b/contributing/ci-release.txt
@@ -227,7 +227,7 @@ Other release jobs
         This job is used to build the OMERO.figure downloads page
 
         #. Download the :envvar:`RELEASE` artifacts from
-           https://github.com/ome/figure
+           https://github.com/ome/omero-figure
         #. Copy the OMERO.figure source zip over SSH to
            :file:`/ome/www/downloads.openmicroscopy.org/figure/RELEASE`
         #. Merge PRs opened against `develop`


### PR DESCRIPTION
See https://trello.com/c/cyoBblgp/200-renaming-of-web-app
This updates the gh repo location for Figure in the contributing docs

Staged at https://www.openmicroscopy.org/site/support/contributing-staging/ci-docs.html and https://www.openmicroscopy.org/site/support/contributing-staging/ci-release.html#other-release-jobs
