### PR TITLE
Data model decoupled & new code link

### DIFF
--- a/formats/developers/index.txt
+++ b/formats/developers/index.txt
@@ -1,8 +1,9 @@
 Developer introduction
 ======================
 
-The OME Data Model is currently available as part of the Bio-Formats code
-repository under :sourcedir:`components/specification`.
+The OME Data Model is now decoupled from the Bio-Formats code repository and
+available as a
+`stand-alone ome-model GitHub repository <https://github.com/ome/ome-model>`_.
 
 There are sample files, along with an explanation of their structure, on
 the :doc:`sample-files` page.


### PR DESCRIPTION
As the specification code no longer lives in the BF repo, this link was broken on https://ci.openmicroscopy.org/view/Docs/job/FORMATS-merge-docs/1089/warnings3Result/ and the info out of date.

Staged at http://www.openmicroscopy.org/site/support/ome-model-staging/developers/index.html
