### PR TITLE
Fix link upsetting jenkins

### DIFF
--- a/omero/developers/logging.txt
+++ b/omero/developers/logging.txt
@@ -2,7 +2,7 @@ Omero logging
 =============
 
 All OMERO components written in Java use the
-`SLF4J <http://www.slf4j.org/>`_ logging facade, typically backed
+`SLF4J <http://www.slf4j.org>`_ logging facade, typically backed
 by `Logback <http://logback.qos.ch/>`_; all
 components written in python use the built-in ``logging`` module.
 


### PR DESCRIPTION
See https://ci.openmicroscopy.org/view/Docs/job/OMERO-DEV-latest-docs/201/warnings5Result/ this link is upsetting the build even though it works fine so I thought I'd try this to get it green again.