### PR TITLE
Update OmeroPy & OMERO.web test library docs

### DIFF
--- a/omero/developers/Modules/Api.txt
+++ b/omero/developers/Modules/Api.txt
@@ -7,6 +7,8 @@ connection e.g. Python:
 
 ::
 
+    import omero.all
+
     client = omero.client("localhost")
     session = client.createSession("username", "password")   # this is the service factory
     adminService = session.getAdminService()                 # now we can get/create services

--- a/omero/developers/Modules/Api.txt
+++ b/omero/developers/Modules/Api.txt
@@ -7,7 +7,7 @@ connection e.g. Python:
 
 ::
 
-    import omero.all
+    import omero.clients
 
     client = omero.client("localhost")
     session = client.createSession("username", "password")   # this is the service factory

--- a/omero/developers/testing.txt
+++ b/omero/developers/testing.txt
@@ -544,7 +544,7 @@ Additionally, for the ``self.client`` object, different shortcuts are available:
 The example below inherits the ``ITest`` class and would create a read-write
 group by default ::
 
-  from library import ITest
+  from omero.testlib import ITest
 
   class TestExample(ITest):
 
@@ -592,7 +592,7 @@ class creates:
 
 ::
 
-  from weblibrary import IWebTest
+  from omeroweb.testlib import IWebTest
 
   class TestExample(IWebTest):
       def testSimple():

--- a/omero/developers/testing.txt
+++ b/omero/developers/testing.txt
@@ -443,7 +443,7 @@ with `test_` for the tests to be found by `pytest`.
 
 ::
 
-    import omero.all
+    import omero.clients
 
     class TestExample(object)
 

--- a/omero/developers/testing.txt
+++ b/omero/developers/testing.txt
@@ -326,7 +326,7 @@ To make use of the more advanced options available in `pytest` that are not
 accessible using :program:`setup.py test`, the :program:`py.test` script can
 be used directly. To use this :envvar:`PYTHONPATH` must contain the path to
 the OMERO Python libraries, see |BlitzGateway| as well as the  path to the
-:sourcedir:`OMERO Python test library <components/tests/python>`.
+:sourcedir:`OMERO Python test library <components/tools/OmeroPy/src/omero/testlib/>`.
 Alternatively, the `pytest` plugin :pypi:`pytest-pythonpath` can be used to
 add paths to :envvar:`PYTHONPATH` specifically for `pytest`.
 
@@ -515,7 +515,7 @@ There are a small number of custom markers defined:
 Using the Python test library
 """""""""""""""""""""""""""""
 
-The :source:`OMERO Python test library <components/tests/python/library/__init__.py>`
+The :source:`OMERO Python test library <components/tools/OmeroPy/src/omero/testlib/__init__.py>`
 defines an abstract ``ITest`` class that implements the connection set up as
 well as many methods shared amongst all Python integration tests.
 
@@ -578,7 +578,7 @@ Images can be imported using the ``ITest.importSingleImage()`` or
 Writing OMERO.web tests
 """""""""""""""""""""""
 
-For OMERO.web integration tests, the :source:`OMERO.web test library <components/tools/OmeroWeb/test/integration/weblibrary.py>`
+For OMERO.web integration tests, the :source:`OMERO.web test library <components/tools/OmeroWeb/omeroweb/testlib/__init__.py>`
 defines an abstract ``IWebTest`` class that inherits from ``ITest`` and
 also implements Django clients at the class setup using the
 :djangodoc:`Django testing tools <topics/testing/tools>`.

--- a/omero/developers/testing.txt
+++ b/omero/developers/testing.txt
@@ -443,7 +443,7 @@ with `test_` for the tests to be found by `pytest`.
 
 ::
 
-    import omero
+    import omero.all
 
     class TestExample(object)
 


### PR DESCRIPTION
This PR documents https://github.com/openmicroscopy/openmicroscopy/pull/4932 to fix https://ci.openmicroscopy.org/view/Docs/job/OMERO-DEV-merge-docs/532/warnings3Result/ and also addresses https://trello.com/c/vkmeH0Iq/511-omero-py-missing-omero-client-from-examples

Staged at https://www.openmicroscopy.org/site/support/omero5.3-staging/developers/testing.html and https://www.openmicroscopy.org/site/support/omero5.3-staging/developers/Modules/Api.html

Should make merge build green again for now but further content probably required from @aleksandra-tarkowska who will review the docs when she's less busy with IDR.