### PR TITLE
Update Windows support life links

### DIFF
--- a/omero/sysadmins/version-requirements.txt
+++ b/omero/sysadmins/version-requirements.txt
@@ -271,7 +271,7 @@ Microsoft Windows
       - Dropped
       - Dropped
       - Dropped
-      - `Ref <http://support.microsoft.com/lifecycle/?p1=11737>`__
+      - `Ref <https://support.microsoft.com/en-gb/help/13853>`__
     * - Win 7
       - from Oct 2009
       - to Jan 2015
@@ -279,7 +279,7 @@ Microsoft Windows
       - Recommended
       - Supported
       - Unsupported†
-      - `Ref <http://support.microsoft.com/lifecycle/?p1=14481>`__
+      - `Ref <https://support.microsoft.com/en-gb/help/13853>`__
     * - Server 2008 R2
       - from May 2008
       - to Jan 2018
@@ -295,7 +295,7 @@ Microsoft Windows
       - Supported
       - Recommended
       - Unsupported†
-      - `Ref <http://support.microsoft.com/lifecycle/?p1=16799>`__
+      - `Ref <https://support.microsoft.com/en-gb/help/13853>`__
     * - Server 2012
       - from Oct 2012
       - to Jan 2018
@@ -311,7 +311,7 @@ Microsoft Windows
       - Unsupported
       - Unsupported
       - Unsupported†
-      - `Ref <https://support.microsoft.com/en-gb/lifecycle?C2=18165&forceorigin=esmc>`__
+      - `Ref <https://support.microsoft.com/en-gb/help/13853>`__
 
 †
    Unsupported for OMERO.server and OMERO.web deployment. Client support will


### PR DESCRIPTION
See https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-merge-docs/538/warnings3Result/

Although only the Windows 10 link is broken at the moment, this new link is much more user-friendly than the old life cycle index pages so I've replaced all the references it covers.

Staged at https://www.openmicroscopy.org/site/support/omero5.3-staging/sysadmins/version-requirements.html

Should make the merge build green again.