### PR TITLE
M6 history

### DIFF
--- a/omero/users/history.txt
+++ b/omero/users/history.txt
@@ -10,7 +10,7 @@ updating code before the full public release of 5.3.0. Use at your own risk**.
 Changes include:
 
  - bumped Bio-Formats version to 5.3.0-m2. This includes JPEG-XR support for CZI.
-   `See whats-new for more information <https://www.openmicroscopy.org/site/support/bio-formats5.3/about/whats-new.html>`_. 
+   See the `Bio-Formats version history <https://www.openmicroscopy.org/site/support/bio-formats5.3/about/whats-new.html>`_ for more information.
  - fixed numpy-pillow version incompatibility
  - made python testing package public so it can be used by external clients
 

--- a/omero/users/history.txt
+++ b/omero/users/history.txt
@@ -1,6 +1,20 @@
 OMERO version history
 =====================
 
+5.3.0-m6 (November 2016)
+------------------------
+
+Developer preview release - **only intended as a developer preview for
+updating code before the full public release of 5.3.0. Use at your own risk**.
+
+Changes include:
+
+ - bumped Bio-Formats version to 5.3.0-m2. This includes JPEG-XR support for CZI.
+   `See whats-new for more information <https://www.openmicroscopy.org/site/support/bio-formats5.3/about/whats-new.html>`_. 
+ - fixed numpy-pillow version incompatibility
+ - made python testing package public so it can be used by external clients
+
+
 5.3.0-m5 (November 2016)
 ------------------------
 


### PR DESCRIPTION
Replaces #1577 with an additional fix for the BF doc link - sphinx doesn't like you repeating the link text with a different URL. I'll open a corresponding PR on the codebase to make these match again.

Staged at https://www.openmicroscopy.org/site/support/omero5.3-staging/users/history.html

cc @jburel 