### PR TITLE
explicitly say how to migrate to nginx

### DIFF
--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -372,7 +372,7 @@ OMERO.web migrating from Apache to Nginx
 """"""""""""""""""""""""""""""""""""""""
 
 Since OMERO 5.2.6 support for Apache and mod_wsgi deployment is deprecated.
-It is recommended using :doc:`install-nginx` or
+It is recommended using :doc:`/sysadmins/unix/install-web/install-nginx` or
 :doc:`OMERO.web trial deployment </sysadmins/unix/install-web/install-web-trial>`.
 Official support is likely to be dropped during the 5.3.x line.
 

--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -368,6 +368,18 @@ fixes which require it.**
 If necessary ensure you have set up a regular task to clear out any stale
 OMERO.web session files as described in :ref:`omero_web_maintenance`.
 
+OMERO.web migrating from Apache to Nginx
+""""""""""""""""""""""""""""""""""""""""
+
+Since OMERO 5.2.6 support for Apache and mod_wsgi deployment is deprecated.
+It is recomanded using :doc:`install-nginx` or
+:doc:`OMERO.web trial deployment </sysadmins/unix/install-web/install-web-trial>`.
+Official support is likely to be dropped during the 5.3.x line.
+
+.. seealso::
+
+    :ref:`troubleshooting-omeroweb-migrate-to-nginx`
+
 Restart your server
 ^^^^^^^^^^^^^^^^^^^
 

--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -372,7 +372,7 @@ OMERO.web migrating from Apache to Nginx
 """"""""""""""""""""""""""""""""""""""""
 
 Since OMERO 5.2.6 support for Apache and mod_wsgi deployment is deprecated.
-It is recomanded using :doc:`install-nginx` or
+It is recommended using :doc:`install-nginx` or
 :doc:`OMERO.web trial deployment </sysadmins/unix/install-web/install-web-trial>`.
 Official support is likely to be dropped during the 5.3.x line.
 

--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -372,7 +372,7 @@ OMERO.web migrating from Apache to Nginx
 """"""""""""""""""""""""""""""""""""""""
 
 Since OMERO 5.2.6 support for Apache and mod_wsgi deployment is deprecated.
-It is recommended using :doc:`/sysadmins/unix/install-web/install-nginx` or
+It is recommended to use :doc:`/sysadmins/unix/install-web/install-nginx` or
 :doc:`OMERO.web trial deployment </sysadmins/unix/install-web/install-web-trial>`.
 Official support is likely to be dropped during the 5.3.x line.
 

--- a/omero/sysadmins/troubleshooting.txt
+++ b/omero/sysadmins/troubleshooting.txt
@@ -325,7 +325,7 @@ OMERO.web migrating from Apache to Nginx
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Since OMERO 5.2.6 support for Apache and mod_wsgi deployment is deprecated.
-It is recomanded using :doc:`install-nginx` or
+It is recommended using :doc:`install-nginx` or
 :doc:`OMERO.web trial deployment </sysadmins/unix/install-web/install-web-trial>`.
 Official support is likely to be dropped during the 5.3.x line.
 

--- a/omero/sysadmins/troubleshooting.txt
+++ b/omero/sysadmins/troubleshooting.txt
@@ -313,11 +313,34 @@ wrong. See :ref:`search-failures` for more details.
 OMERO.web issues
 ----------------
 
-OMERO.web and Apache
-^^^^^^^^^^^^^^^^^^^^
+OMERO.web and Apache (deprecated)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Do not enable mod_python and mod_wsgi in the same apache process.
 mod_wsgi will deadlock if run in daemon mode while mod_python is enabled
+
+.. _troubleshooting-omeroweb-migrate-to-nginx:
+
+OMERO.web migrating from Apache to Nginx
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Since OMERO 5.2.6 support for Apache and mod_wsgi deployment is deprecated.
+It is recomanded using :doc:`install-nginx` or
+:doc:`OMERO.web trial deployment </sysadmins/unix/install-web/install-web-trial>`.
+Official support is likely to be dropped during the 5.3.x line.
+
+::
+
+    Cannot configure omero web to use nginx:
+    Error running bin/omero  web config nginx - I get the error
+    Configuration mismatch omero.web.application_server=wsgi cannot be used with omero web config nginx.
+
+Make sure :property:`omero.web.application_server` is set to the following:
+
+::
+
+    $bin/omero config set omero.web.application_server "wsgi-tcp"
+
 
 OMERO.web did not start
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/omero/sysadmins/troubleshooting.txt
+++ b/omero/sysadmins/troubleshooting.txt
@@ -325,7 +325,7 @@ OMERO.web migrating from Apache to Nginx
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Since OMERO 5.2.6 support for Apache and mod_wsgi deployment is deprecated.
-It is recommended using :doc:`install-nginx` or
+It is recommended using :doc:`/sysadmins/unix/install-web/install-nginx` or
 :doc:`OMERO.web trial deployment </sysadmins/unix/install-web/install-web-trial>`.
 Official support is likely to be dropped during the 5.3.x line.
 

--- a/omero/sysadmins/troubleshooting.txt
+++ b/omero/sysadmins/troubleshooting.txt
@@ -325,7 +325,7 @@ OMERO.web migrating from Apache to Nginx
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Since OMERO 5.2.6 support for Apache and mod_wsgi deployment is deprecated.
-It is recommended using :doc:`/sysadmins/unix/install-web/install-nginx` or
+It is recommended to use :doc:`/sysadmins/unix/install-web/install-nginx` or
 :doc:`OMERO.web trial deployment </sysadmins/unix/install-web/install-web-trial>`.
 Official support is likely to be dropped during the 5.3.x line.
 
@@ -339,7 +339,7 @@ Make sure :property:`omero.web.application_server` is set to the following:
 
 ::
 
-    $bin/omero config set omero.web.application_server "wsgi-tcp"
+    $ bin/omero config set omero.web.application_server "wsgi-tcp"
 
 
 OMERO.web did not start

--- a/omero/sysadmins/unix/install-web/install-apache.txt
+++ b/omero/sysadmins/unix/install-web/install-apache.txt
@@ -85,13 +85,13 @@ Set the following:
 
 ::
 
-    $bin/omero config set omero.web.application_server "wsgi"
+    $ bin/omero config set omero.web.application_server "wsgi"
 
 Creates symlinks for static media files
 
 ::
 
-    $bin/omero web syncmedia
+    $ bin/omero web syncmedia
 
 To create a site configuration file for inclusion in the main Apache
 configuration redirect the output of the following command into a file:

--- a/omero/sysadmins/unix/install-web/install-nginx.txt
+++ b/omero/sysadmins/unix/install-web/install-nginx.txt
@@ -73,6 +73,12 @@ will depend on your system, please refer to your web server's manual.
 See :ref:`customizing_your_omero_web_installation`
 for additional customization options.
 
+Set the following:
+
+::
+
+    $bin/omero config set omero.web.application_server "wsgi-tcp"
+
 To create a site configuration file for inclusion in a system-wide nginx
 configuration redirect the output of the following command into a file:
 

--- a/omero/sysadmins/unix/install-web/install-nginx.txt
+++ b/omero/sysadmins/unix/install-web/install-nginx.txt
@@ -73,9 +73,7 @@ will depend on your system, please refer to your web server's manual.
 See :ref:`customizing_your_omero_web_installation`
 for additional customization options.
 
-Set the following:
-
-::
+Set the following::
 
     $bin/omero config set omero.web.application_server "wsgi-tcp"
 

--- a/omero/sysadmins/unix/install-web/install-nginx.txt
+++ b/omero/sysadmins/unix/install-web/install-nginx.txt
@@ -75,7 +75,7 @@ for additional customization options.
 
 Set the following::
 
-    $bin/omero config set omero.web.application_server "wsgi-tcp"
+    $ bin/omero config set omero.web.application_server "wsgi-tcp"
 
 To create a site configuration file for inclusion in a system-wide nginx
 configuration redirect the output of the following command into a file:

--- a/omero/sysadmins/unix/install-web/install-web-trial.txt
+++ b/omero/sysadmins/unix/install-web/install-web-trial.txt
@@ -88,7 +88,7 @@ for additional customization options.
 
 Set the following::
 
-    $bin/omero config set omero.web.application_server "wsgi-tcp"
+    $ bin/omero config set omero.web.application_server "wsgi-tcp"
 
 To create a site configuration file for inclusion in a system-wide nginx
 configuration redirect the output of the following command into a file:

--- a/omero/sysadmins/unix/install-web/install-web-trial.txt
+++ b/omero/sysadmins/unix/install-web/install-web-trial.txt
@@ -86,9 +86,7 @@ will depend on your system, please refer to your web server's manual.
 See :ref:`customizing_your_omero_web_installation`
 for additional customization options.
 
-Set the following:
-
-::
+Set the following::
 
     $bin/omero config set omero.web.application_server "wsgi-tcp"
 

--- a/omero/sysadmins/unix/install-web/install-web-trial.txt
+++ b/omero/sysadmins/unix/install-web/install-web-trial.txt
@@ -86,6 +86,12 @@ will depend on your system, please refer to your web server's manual.
 See :ref:`customizing_your_omero_web_installation`
 for additional customization options.
 
+Set the following:
+
+::
+
+    $bin/omero config set omero.web.application_server "wsgi-tcp"
+
 To create a site configuration file for inclusion in a system-wide nginx
 configuration redirect the output of the following command into a file:
 


### PR DESCRIPTION
This PR should clarify that `application_server` must be set to `wsgi-tcp`. I imaging if people migrate from apache to nginx this may be missing and cause more community questions about:

```
    Configuration mismatch omero.web.application_server=wsgi cannot be used with omero web config nginx.
```

to test:

- set `omero.web.application_server=wsgi` try starting omeroweb. at this point it should fail with misconfiguration error.
- set `omero.web.application_server=wsgi-tcp` try starting omeroweb. started
- unset omero.web.application_server try starting omeroweb. started