### PR TITLE
Minor search docs tidy (rebased onto dev_5_2)

### DIFF
--- a/omero/developers/Modules/Search.txt
+++ b/omero/developers/Modules/Search.txt
@@ -2,7 +2,7 @@ OMERO search
 ============
 
 OMERO.server uses `Lucene <http://lucene.apache.org>`_ to index all string and
-timestamp information in the database, as well as all ``OriginalFiles`` which
+timestamp information in the database, as well as all ``OriginalFile`` which
 can be parsed to simple text (see :doc:`/developers/Search/FileParsers` for
 more information). The index is stored under :file:`/OMERO/FullText` or the
 :file:`FullText` subdirectory of your :property:`omero.data.dir`, and can be

--- a/omero/developers/Modules/Search.txt
+++ b/omero/developers/Modules/Search.txt
@@ -4,7 +4,7 @@ OMERO search
 OMERO.server uses `Lucene <http://lucene.apache.org>`_ to index all string and
 timestamp information in the database, as well as all ``OriginalFiles`` which
 can be parsed to simple text (see :doc:`/developers/Search/FileParsers` for
-more information). The index is stored under :file:`/OMERO/FullText` (or the
+more information). The index is stored under :file:`/OMERO/FullText` or the
 :file:`FullText` subdirectory of your :property:`omero.data.dir`, and can be
 searched with Google-like queries.
 

--- a/omero/developers/Modules/Search.txt
+++ b/omero/developers/Modules/Search.txt
@@ -1,10 +1,9 @@
 OMERO search
 ============
 
-Beginning with 3.0-Beta3, the OMERO server will use
-`Lucene <http://lucene.apache.org>`_ to index all string and timestamp
-information in the database, as well as all ``OriginalFiles`` which can
-be parsed to simple text (see :doc:`/developers/Search/FileParsers` for
+OMERO.server uses `Lucene <http://lucene.apache.org>`_ to index all string and
+timestamp information in the database, as well as all ``OriginalFiles`` which
+can be parsed to simple text (see :doc:`/developers/Search/FileParsers` for
 more information). The index is stored under :file:`/OMERO/FullText` (or the
 :file:`FullText` subdirectory of your :property:`omero.data.dir`, and can be
 searched with Google-like queries.

--- a/omero/developers/Modules/searchfieldnames.tsv
+++ b/omero/developers/Modules/searchfieldnames.tsv
@@ -11,7 +11,7 @@ details.updateEvent.id	Id of the Event of this objects last modification
 details.updateEvent.time	When that Event took place
 details.permissions	Permissions in the form `rwrwrw` or `rw-`
 tag	Contents from a ``TagAnnotation``.
-annotation	Contents from any annotations, including ``TagAnnotation`` and any ``TextAnnotation`` on another ``TextAnnotation`` (a.k.a. a `description`). Non-string annotations like file annotations are not covered by this definition and are handled separately. See below.
+annotation	Contents from annotations, including ``TagAnnotation`` and any ``TextAnnotation`` on another ``TextAnnotation`` (a.k.a. a `description`). Non-string annotations like ``FileAnnotations`` are not covered by this definition and are handled separately. See below.
 annotation.ns	Namespace (if present) for any annotations on an object
 annotation.type	Short type name, e.g. ``TextAnnotation`` or ``FileAnnotation`` for any annotations on an object
 file.name	For ``FileAnnotations`` and objects they are attached to, the name of the ``OriginalFile``

--- a/omero/developers/Modules/searchfieldnames.tsv
+++ b/omero/developers/Modules/searchfieldnames.tsv
@@ -11,15 +11,15 @@ details.updateEvent.id	Id of the Event of this objects last modification
 details.updateEvent.time	When that Event took place
 details.permissions	Permissions in the form `rwrwrw` or `rw-`
 tag	Contents from a ``TagAnnotation``.
-annotation	Contents from annotations, including ``TagAnnotation`` and any ``TextAnnotation`` on another ``TextAnnotation`` (a.k.a. a `description`). Non-string annotations like ``FileAnnotations`` are not covered by this definition and are handled separately. See below.
+annotation	Contents from annotations, including ``TagAnnotation`` and any ``TextAnnotation`` on another ``TextAnnotation`` (a.k.a. a `description`). Non-string annotations like ``FileAnnotation`` are not covered by this definition and are handled separately. See below.
 annotation.ns	Namespace (if present) for any annotations on an object
 annotation.type	Short type name, e.g. ``TextAnnotation`` or ``FileAnnotation`` for any annotations on an object
-file.name	For ``FileAnnotations`` and objects they are attached to, the name of the ``OriginalFile``
-file.format	For ``FileAnnotations`` and objects they are attached to, the format of the ``OriginalFile``
-file.path	For ``FileAnnotations`` and objects they are attached to, the path of the ``OriginalFile``
-file.sha1	For ``FileAnnotations`` and objects they are attached to, the sha1 of the ``OriginalFile``
-file.contents	For ``FileAnnotations`` and objects they are attached to as well as the ``OriginalFile`` itself, the file contents themselves if their Format is configured with the File parsers.
-${NAME}	For ``MapAnnotations`` and objects they are attached to, dynamic fields are generated for each of the NamedValue entries in the annotation. For example, if ``NamedValue('temperature', '37')`` is one such value, a field named ``temperature`` will exist.
+file.name	For ``FileAnnotation`` and objects they are attached to, the name of the ``OriginalFile``
+file.format	For ``FileAnnotation`` and objects they are attached to, the format of the ``OriginalFile``
+file.path	For ``FileAnnotation`` and objects they are attached to, the path of the ``OriginalFile``
+file.sha1	For ``FileAnnotation`` and objects they are attached to, the sha1 of the ``OriginalFile``
+file.contents	For ``FileAnnotation`` and objects they are attached to as well as the ``OriginalFile`` itself, the file contents themselves if their Format is configured with the File parsers.
+${NAME}	For ``MapAnnotation`` and objects they are attached to, dynamic fields are generated for each of the NamedValue entries in the annotation. For example, if ``NamedValue('temperature', '37')`` is one such value, a field named ``temperature`` will exist.
 has_key	As ``${NAME}``, but a single field of name ``has_key`` is generated for each ``NamedValue`` entry with a value of the key such that a search for ``has_key:temperature`` in the example above is possible.
 **Internal**	
 combined_fields	The default field prefix.


### PR DESCRIPTION

This is the same as gh-1567 but rebased onto dev_5_2.

----

See https://trello.com/c/Hq7F0yrm/190-rewrite-developer-documentation-for-search
Quick PR to try and clean up main nitpicks, if anyone has further suggestions for improvements or spots other out-of-date content, please comment and I'll do a wider edit.

Staged at https://www.openmicroscopy.org/site/support/omero5.2-staging/developers/Modules/Search.html

                    