### PR TITLE
Update due date for 5.3 in docs banner

### DIFF
--- a/omero/conf.py
+++ b/omero/conf.py
@@ -48,7 +48,7 @@ else:
 rst_prolog = """
 .. note:: **This documentation is for OMERO 5.2.** This version is now in
     maintenance mode and will only be updated in the event of critical bugs
-    or security concerns. OMERO 5.3 is expected before the end of 2016.
+    or security concerns. OMERO 5.3 is expected in the first quarter of 2017.
 """
 
 rst_epilog += """


### PR DESCRIPTION
Since we are doing another 5.2.x release, it seemed sensible to update this. Staged at the top of all the pages on https://www.openmicroscopy.org/site/support/omero5.2-staging/