### PR TITLE
Path to folder

### DIFF
--- a/omero/autogen_docs
+++ b/omero/autogen_docs
@@ -46,7 +46,7 @@ echo "Generating omeroweb install walkthrough"
 (cd $WORKSPACE/omeroweb-install && ansible-playbook ./.travis/../ansible/omeroweb-install-doc.yml -i ./.travis/../ansible/hosts/ubuntu-ice3.5 --extra-vars '{"os": "ubuntu", "ice_version": "3.5", "clean": True}')
 (cd $WORKSPACE/omeroweb-install && ansible-playbook ./.travis/../ansible/omeroweb-install-doc.yml -i ./.travis/../ansible/hosts/osx-ice3.6 --extra-vars '{"os": "osx", "ice_version": "3.6", "clean": True}')
 
-mv $WORKSPACE/omeroweb-install/doc/* $WORKSPACE/src/omero/sysadmins/unix/install-web/walkthrough
+mv $WORKSPACE/omeroweb-install/ansible/doc/* $WORKSPACE/src/omero/sysadmins/unix/install-web/walkthrough
 
 echo "Copying omero-install Linux scripts"
 DIRECTORY=omero/sysadmins/unix/walkthrough/


### PR DESCRIPTION
Fix path to doc folder.

This should fix the autogen job failures 
The version of ansible installed on spider-5 is 2.2.0, the relative path used in omeroweb-install implies that the folder is now created under ``ansible``

An omeroweb-install will follow so we have the same outcome with ansible version 2.2 and 2.1