### PR TITLE
omero: cpp: Remove instructions for building via build.py

### DIFF
--- a/omero/developers/Cpp.txt
+++ b/omero/developers/Cpp.txt
@@ -95,41 +95,8 @@ system.
 Building the library
 --------------------
 
-For all build methods, the shared library and examples are always
-built by default. The unit and integration tests are built if Google
-test (gtest) is detected.
-
-Building with :program:`build.py` or :program:`ant`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-::
-
-    export GTEST_ROOT=/path/to/gtest
-    cd /path/to/openmicroscopy
-    ./build.py build-default
-    ./build.py build-cpp [-Dcmake.args="cmake options"]
-
-Set any needed :program:`cmake` options using the :program:`ant`
-``cmake.args`` property, plus any needed environment variables.
-
-For example::
-
-    ./build.py -Dcmake.args="'-DCMAKE_CXX_FLAGS=$CMAKE_CXX_FLAGS' \
-    '-DCMAKE_EXE_LINKER_FLAGS=$CMAKE_LD_FLAGS' \
-    '-DCMAKE_MODULE_LINKER_FLAGS=$CMAKE_LD_FLAGS' \
-    '-DCMAKE_SHARED_LINKER_FLAGS=$CMAKE_LD_FLAGS' \
-    -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
-
-This method is present for backward compatibility with the previous
-:program:`scons` build system. While it is possible to customize the
-build somewhat, some behavior is hardcoded and so this will not be
-suitable for all situations and is not recommended. Parallel building
-is also not supported. If you wish to have full control over the C++
-build or wish to use a :program:`cmake` generator to build within an
-IDE, then running :program:`cmake` directly is recommended.
-
-Building with :program:`cmake` directly
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The shared library and examples are always built by default. The unit
+and integration tests are built if Google test (gtest) is detected.
 
 On Linux, Unix or MacOS X with :program:`make`::
 
@@ -147,11 +114,6 @@ For example::
     "-DCMAKE_SHARED_LINKER_FLAGS=$CMAKE_LD_FLAGS" \
     -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON /path/to/openmicroscopy
     make -j8
-
-Running :program:`cmake` directly allows full use of all command-line
-options and provides complete flexibility for building, e.g. to enable
-parallel building as shown above or to use an IDE of choice with an
-appropriate generator.
 
 If you would like to build the C++ tests, run the above with the
 :envvar:`GTEST_ROOT` environment variable set.
@@ -338,9 +300,9 @@ automatically discovered.
 
 ::
 
-    cmake -G "Visual Studio 10 Win64" [cmake options] /path/to/openmicroscopy
+    cmake -G "Visual Studio 11 Win64" [cmake options] /path/to/openmicroscopy
 
-This is for a 64-bit :program:`Visual Studio 2010` build. Modify appropriately
+This is for a 64-bit :program:`Visual Studio 2012` build. Modify appropriately
 for other versions and compilers. Running
 
 ::


### PR DESCRIPTION
See https://trello.com/c/7rOcKabK/255-clean-up-c-build

- Remove the ant build instructions
- Change the VS2010 sample to use 2012 (the latest supported for Ice 3.5)