### PR TITLE
Add contributing section about Java repositories

### DIFF
--- a/contributing/conf.py
+++ b/contributing/conf.py
@@ -65,11 +65,13 @@ graphviz_dot_args = [
 graphviz_output_format = 'svg'
 
 rst_epilog += """
+.. _GitHub: https://github.com
 .. _openmicroscopy.git: https://github.com/openmicroscopy/openmicroscopy
 .. _bioformats.git: https://github.com/openmicroscopy/bioformats
 .. _ome-documentation.git: https://github.com/openmicroscopy/ome-documentation
 .. _ome-cmake-superbuild.git: https://github.com/ome/ome-cmake-superbuild
 .. _scripts.git: https://github.com/ome/scripts
+.. _Sonatype: https://www.sonatype.com/
 ..  |merge| replace:: Merges PRs using :ref:`scc merge`
 ..  |buildOMERO| replace:: Builds the OMERO.server and the clients using :omero_source:`OMERO.sh <docs/hudson/OMERO.sh>`
 ..  |archiveOMEROartifacts| replace:: Archives the build artifacts

--- a/contributing/index.txt
+++ b/contributing/index.txt
@@ -7,20 +7,21 @@ consortium projects. It includes internal developer practices and workflows,
 standard procedures for tasks such as release, and other information which may
 be valuable to a wider audience.
 
-.. only:: html
+.. toctree::
+    :maxdepth: 1
 
-    - :doc:`source-code`
-    - :doc:`using-git`
-    - :doc:`code-contributions`
-    - :doc:`team-communication`
-    - :doc:`team-workflow`
-    - :doc:`development-tools`
-    - :doc:`deployment-tools`
-    - :doc:`continuous-integration`
-    - :doc:`jekyll`
-    - :doc:`data-model-schema`
-    - :doc:`schema-changes`
-
+    source-code
+    using-git
+    code-contributions
+    team-communication
+    team-workflow
+    java-development
+    development-tools
+    deployment-tools
+    continuous-integration
+    jekyll
+    data-model-schema
+    schema-changes
 
 Information specific to developing OMERO, the OME Data Model and file formats,
 and Bio-Formats can be found in their respective developer documentation
@@ -34,20 +35,3 @@ sections:
 
 If you have any questions, please see our :community_plone:`Community page <>`
 for ways to get in touch.
-
-.. toctree::
-    :maxdepth: 1
-    :hidden:
-
-    source-code
-    using-git
-    code-contributions
-    team-communication
-    team-workflow
-    development-tools
-    deployment-tools
-    continuous-integration
-    jekyll
-    data-model-schema
-    schema-changes
-

--- a/contributing/java-development.txt
+++ b/contributing/java-development.txt
@@ -1,7 +1,7 @@
 Java components
 ===============
 
-.. _Central Repository: http://search.maven.org
+.. _Central Repository: https://search.maven.org
 .. _Semantic Versioning: http://semver.org
 .. _Git: https://git-scm.com/
 .. _Maven: http://maven.apache.org/

--- a/contributing/java-development.txt
+++ b/contributing/java-development.txt
@@ -3,7 +3,6 @@ Java components
 
 .. _Central Repository: http://search.maven.org
 .. _Semantic Versioning: http://semver.org
-.. _OME Artifactory: http://artifacts.openmicroscopy.org/
 .. _Git: https://git-scm.com/
 .. _Maven: http://maven.apache.org/
 
@@ -102,7 +101,7 @@ Distribution
 
 For all the repositories listed above, the release should be deployed to the
 `Central repository`_ followed the process described below
-Artifacts that are hosted on the `OME Artifactory`_.
+Artifacts that are hosted on the `OME artifactory`_.
 
 Release process
 ---------------

--- a/contributing/java-development.txt
+++ b/contributing/java-development.txt
@@ -1,0 +1,149 @@
+Java components
+===============
+
+This document describes the workflow used by the OME team for developing,
+maintaining and releasing some of the new Java components.
+The set of rules and procedures described below applies to all the components
+uploaded to the `Central repository <http://search.maven.org/>`__.
+
+The current list
+
+.. list-table::
+    :header-rows: 1
+
+    -   * GitHub URL
+        * Component name
+        * groupId:artifactId
+
+    -   * https://github.com/ome/ome-common-java
+        * OME Common Java libary
+        * `org.openmicroscopy:ome-common`
+
+    -   * https://github.com/ome/ome-model
+        * OME Data model
+        * | `org.openmicroscopy:ome-model`
+            `org.openmicroscopy:ome-xml`
+            `org.openmicroscopy:specification`
+            `org.openmicroscopy:ome-model-doc`
+
+    -   * https://github.com/ome/ome-poi
+        * OME POI
+        * `org.openmicroscopy:ome-poi`
+
+
+    -   * https://github.com/ome/ome-mdbtools
+        * OME Common Java libary
+        * `org.openmicroscopy:ome-common`
+
+
+Release process
+---------------
+
+Maintainer prerequisites
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+It is important to get familiar with the
+`OSSRH guide <http://central.sonatype.org/pages/ossrh-guide.html>`__ and
+especially the
+`Maven section for performing a release deployment <http://central.sonatype.org/pages/apache-maven.html#performing-a-release-deployment>`__.
+
+To be able to maintain a Java component, a developer must:
+
+- have a GitHub_ account and have push rights to the GitHub source code
+  repository
+- have a Sonatype_ account and be registered as a maintainer of the
+  `org.openmicroscopy` repository (JIRA issues should be opened for each
+  developer)
+- have a valid PGP key for signing the tags and the JARs
+
+Release strategies
+^^^^^^^^^^^^^^^^^^
+
+There are different strategies to release Maven component. At the moment we
+are pushing 2 successive commits (or Pull Requests) to the master branch. The
+first commit/Pull Request bumps the version number to the release version and
+is used for generating the release while the second commit bumps the version
+to the next development cycle.
+
+.. seealso::
+    http://imagej.net/Development_Lifecycle
+       A section of the  approaches which OME might be considering.
+
+Release preparation
+^^^^^^^^^^^^^^^^^^^
+
+The first step of the Java component release is to prepare a release
+candidate on the GitHub_ and Sonatype_ repositories.
+
+The first operation to perform a Maven release is to bump the version out of
+SNAPSHOT either via editing the :file:`pom.xml` manually or using the Maven
+versions plugin::
+
+    $ mvn versions:set -DnewVersion=x.y.z -DgenerateBackupPoms=false
+    $ git add .
+    $ git commit -m “Bump release version to x.y.z”
+
+Additionally, a PGP signed tag should be created for the released version e.g.
+using :command:`scc tag-release` or more simply :command:`git tag -s`::
+
+    $ scc tag-release -s x.y.z --prefix v
+
+Push the master branch and the tag to your fork for validation by another
+member of the team::
+
+    $ git push <fork_name> master
+    $ git push <fork_name> vx.y.z
+
+Once you have updated all the versions and ensured that your build passes
+without deployment you can perform the deployment with the usage of the
+release profile with::
+
+    $ mvn clean deploy -P release
+    # Potentially add -D gpg.keyname=keyname if desired.
+
+This will upload the artifacts to a staging Sonatype repository and perform
+all the validation steps. The uploaded artifacts can be examined at
+\https://oss.sonatype.org/content/repositories/orgopenmicroscopy-xxxx/ where
+xxxx is an number incremented for each release.
+
+Release promotion
+^^^^^^^^^^^^^^^^^
+
+At the moment all Java components use the Nexus Staging Maven plugin with the
+`autoReleaseAfterClose` option set to `false`. A separate promotion step is
+necessary for releasing the component to the Sonatype releases repository.
+This promotion can happen either via the Sonatype UI using the Release button
+or using the release phase of the nexus-staging plugin::
+
+    $ mvn nexus-staging:release -P release
+
+See
+http://central.sonatype.org/pages/apache-maven.html#manually-releasing-the-deployment-to-the-central-repository for more instructions
+
+The rsync to Central Maven and the update of Maven search usually happen
+within a couple of hours but the components are accessible beforehand.
+
+Once the tag is validated, the master branch and the tag can also be pushed to
+the organization repository together::
+
+    $ git push origin vx.y.z
+    $ git push origin master
+
+Next development version
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Then finally restore the new development version using e.g. the Maven versions
+plugin again::
+
+    # Where w == z+1
+    $ mvn versions:set -DnewVersion=x.y.w-SNAPSHOT -DgenerateBackupPoms=false
+    $ git add .
+    $ git commit -m “Bump release version to x.y.w-SNAPSHOT”
+    $ git push origin master
+
+Javadoc
+^^^^^^^
+At the moment, we use the service provided http://javadoc.io/ for public
+hosting of the Javadoc. For each release to Maven Central, the new Javadoc
+should be automatically deployed within 24h. It is possible to trigger the
+generation of the Javadoc by visiting the URL.

--- a/contributing/java-development.txt
+++ b/contributing/java-development.txt
@@ -6,35 +6,41 @@ maintaining and releasing some of the new Java components.
 The set of rules and procedures described below applies to all the components
 uploaded to the `Central repository <http://search.maven.org/>`__.
 
-The current list
-
 .. list-table::
     :header-rows: 1
 
-    -   * GitHub URL
-        * Component name
+    -   * Component name
+        * GitHub URL
         * groupId:artifactId
 
-    -   * https://github.com/ome/ome-common-java
-        * OME Common Java libary
+    -   * OME Common Java libary
+        * https://github.com/ome/ome-common-java
         * `org.openmicroscopy:ome-common`
 
-    -   * https://github.com/ome/ome-model
-        * OME Data model
+    -   * OME Data model
+        * https://github.com/ome/ome-model
         * | `org.openmicroscopy:ome-model`
             `org.openmicroscopy:ome-xml`
             `org.openmicroscopy:specification`
             `org.openmicroscopy:ome-model-doc`
 
-    -   * https://github.com/ome/ome-poi
-        * OME POI
+    -   * OME POI
+        * https://github.com/ome/ome-poi
         * `org.openmicroscopy:ome-poi`
 
+    -   * OME MDB Tools
+        * https://github.com/ome/ome-mdbtools
+        * `org.openmicroscopy:ome-mdbtools`
 
-    -   * https://github.com/ome/ome-mdbtools
-        * OME Common Java libary
-        * `org.openmicroscopy:ome-common`
+    -   * OME Stubs
+        * https://github.com/ome/ome-mdbtools
+        * | `org.openmicroscopy:ome-stubs`
+            `org.openmicroscopy:lwf-stubs`
+            `org.openmicroscopy:mipav-stubs`
 
+    -   * OME Metakit
+        * https://github.com/ome/ome-metakit
+        * `org.openmicroscopy:metakit`
 
 Release process
 ---------------

--- a/contributing/java-development.txt
+++ b/contributing/java-development.txt
@@ -48,8 +48,8 @@ Java libraries.
         * `org.openmicroscopy:metakit`
 
 .. note::
-   Some of the historical monolithical Java projects, including Bio-Formats and
-   OMERO, do not strictly comply to these guidelines yet. As the project
+   Some of the historical monolithic Java projects, including Bio-Formats and
+   OMERO, do not strictly comply with these guidelines yet. As the project
    evolves and components are migrated, any new Java repository should follow 
    this set of rules.
 
@@ -63,7 +63,7 @@ The source code of a Java library should be maintained under version control
 using Git_ and hosted on GitHub_.
 
 Maven_ should be used as the primary build system. The directory layout should
-follow the standard Maven layout i.e. in the case of a single module project::
+follow the standard Maven layout i.e. in the case of a single-module project::
 
    pom.xml
    src/
@@ -76,7 +76,7 @@ follow the standard Maven layout i.e. in the case of a single module project::
          <package>
 
 Additionally, the top-level :file:`pom.xml` should be structured according to
-the Maven guidelines.
+the `Maven guidelines <https://maven.apache.org/developers/conventions/code.html>`_.
 
 .. seealso::
    :doc:`using-git`
@@ -99,9 +99,9 @@ Code contributions should follow the guidelines highlighted in :doc:`code-contri
 Distribution
 ^^^^^^^^^^^^
 
-For all the repositories listed above, the release should be deployed to the
-`Central repository`_ followed the process described below
-Artifacts that are hosted on the `OME artifactory`_.
+All the release artifacts for the repositories listed above should be deployed
+to the Central Repository according to the process described in the next
+section.
 
 Release process
 ---------------
@@ -126,7 +126,7 @@ To be able to maintain a Java component, a developer must:
 Release strategies
 ^^^^^^^^^^^^^^^^^^
 
-There are different strategies to release Maven component. At the moment we
+There are different strategies to release a Maven component. At the moment we
 are pushing 2 successive commits (or Pull Requests) to the master branch. The
 first commit/Pull Request bumps the version number to the release version and
 is used for generating the release while the second commit bumps the version
@@ -150,7 +150,7 @@ versions plugin::
     $ git add .
     $ git commit -m “Bump release version to x.y.z”
 
-Additionally, a PGP signed tag should be created for the released version e.g.
+Additionally, a PGP-signed tag should be created for the released version e.g.
 using :command:`scc tag-release` or more simply :command:`git tag -s`::
 
     $ scc tag-release -s x.y.z --prefix v
@@ -162,8 +162,8 @@ member of the team::
     $ git push <fork_name> vx.y.z
 
 Once you have updated all the versions and ensured that your build passes
-without deployment you can perform the deployment with the usage of the
-release profile with::
+without deployment you can perform the deployment by using the release profile
+with::
 
     $ mvn clean deploy -P release
     # Potentially add -D gpg.keyname=keyname if desired.

--- a/contributing/java-development.txt
+++ b/contributing/java-development.txt
@@ -1,10 +1,16 @@
 Java components
 ===============
 
-This document describes the workflow used by the OME team for developing,
-maintaining and releasing some of the new Java components.
-The set of rules and procedures described below applies to all the components
-uploaded to the `Central repository <http://search.maven.org/>`__.
+.. _Central Repository: http://search.maven.org
+.. _Semantic Versioning: http://semver.org
+.. _OME Artifactory: http://artifacts.openmicroscopy.org/
+.. _Git: https://git-scm.com/
+.. _Maven: http://maven.apache.org/
+
+This document describes the conventions and process used by the OME team for developing, maintaining and releasing its Java components.
+
+The set of rules and procedures described below applies to all the following
+Java libraries.
 
 .. list-table::
     :header-rows: 1
@@ -42,6 +48,62 @@ uploaded to the `Central repository <http://search.maven.org/>`__.
         * https://github.com/ome/ome-metakit
         * `org.openmicroscopy:metakit`
 
+.. note::
+   Some of the historical monolithical Java projects, including Bio-Formats and
+   OMERO, do not strictly comply to these guidelines yet. As the project
+   evolves and components are migrated, any new Java repository should follow 
+   this set of rules.
+
+Conventions
+-----------
+
+Source code and build system
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The source code of a Java library should be maintained under version control
+using Git_ and hosted of GitHub_
+
+Maven_ should be used as the primary build system. The directory layout should
+follow the standard Maven layout i.e. in the case of a single module project::
+
+   pom.xml
+   src/
+     main/
+       java/
+         <package>
+   test/
+     main/
+       java/
+         <package>
+
+Additionally, the top-level :file:`pom.xml` should be structured according to
+the Maven guidelines.
+
+.. seealso::
+   :doc:`using-git`
+
+Development
+^^^^^^^^^^^
+
+Java components use `Semantic Versioning`_ i.e. given a version number
+MAJOR.MINOR.PATCH, increment the:
+
+- MAJOR version when you make incompatible API changes,
+- MINOR version when you add functionality in a backwards-compatible manner,
+  and
+- PATCH version when you make backwards-compatible bug fixes.
+
+In between releases the version is bumped to the next SNAPSHOT version.
+
+Code contributions should follow the guidelines highlighted in :doc:`code-contributions`.
+
+Distribution
+^^^^^^^^^^^^
+
+For all the repositories listed above, the release should be deployed to the
+`Central repository`_ followed the process described below
+Artifacts that are hosted on the `OME Artifactory`_.
+
 Release process
 ---------------
 
@@ -73,7 +135,7 @@ to the next development cycle.
 
 .. seealso::
     http://imagej.net/Development_Lifecycle
-       A section of the  approaches which OME might be considering.
+       A section describing approaches which OME might be considering.
 
 Release preparation
 ^^^^^^^^^^^^^^^^^^^

--- a/contributing/java-development.txt
+++ b/contributing/java-development.txt
@@ -61,7 +61,7 @@ Source code and build system
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The source code of a Java library should be maintained under version control
-using Git_ and hosted of GitHub_
+using Git_ and hosted on GitHub_.
 
 Maven_ should be used as the primary build system. The directory layout should
 follow the standard Maven layout i.e. in the case of a single module project::


### PR DESCRIPTION
Following the re-architecture of the Java components during Bio-Formats 5.3.0, a certain number of policies were adopted regarding the development, maintenance and distribution of the low-level Java repositories. This PR codifies these guidelines into the contributing documentation together with a table of the Java libraries following this process.

The top-level index page is also modified to remove the duplicate `..only: html` directive following the dropping of the PDF and uses the `toctree` directly to populate the contributing menu.

