### PR TITLE
Rename docs.zip

### DIFF
--- a/common/rules.xml
+++ b/common/rules.xml
@@ -71,7 +71,7 @@ Type "ant -p" for a list of targets.
       -->
       <fileset dir="${sphinx.builddir}/html"/>
     </copy>
-    <zip destfile="${sphinx.builddir}/OMERO-${omero.release}.zip">
+    <zip destfile="${sphinx.builddir}/OMERO-doc-${omero.release}.zip">
       <zipfileset dir="${sphinx.builddir}/html" includes="**/*" prefix="OMERO-${omero.release}"/>
     </zip>
     <delete dir="${sphinx.builddir}/OMERO-${omero.release}"/>

--- a/common/rules.xml
+++ b/common/rules.xml
@@ -72,7 +72,7 @@ Type "ant -p" for a list of targets.
       <fileset dir="${sphinx.builddir}/html"/>
     </copy>
     <zip destfile="${sphinx.builddir}/OMERO-doc-${omero.release}.zip">
-      <zipfileset dir="${sphinx.builddir}/html" includes="**/*" prefix="OMERO-${omero.release}"/>
+      <zipfileset dir="${sphinx.builddir}/html" includes="**/*" prefix="OMERO-doc-${omero.release}"/>
     </zip>
     <delete dir="${sphinx.builddir}/OMERO-${omero.release}"/>
   </target>

--- a/common/rules.xml
+++ b/common/rules.xml
@@ -71,8 +71,8 @@ Type "ant -p" for a list of targets.
       -->
       <fileset dir="${sphinx.builddir}/html"/>
     </copy>
-    <zip destfile="${sphinx.builddir}/OMERO-doc-${omero.release}.zip">
-      <zipfileset dir="${sphinx.builddir}/html" includes="**/*" prefix="OMERO-doc-${omero.release}"/>
+    <zip destfile="${sphinx.builddir}/OMERO.doc-${omero.release}.zip">
+      <zipfileset dir="${sphinx.builddir}/html" includes="**/*" prefix="OMERO.doc-${omero.release}"/>
     </zip>
     <delete dir="${sphinx.builddir}/OMERO-${omero.release}"/>
   </target>


### PR DESCRIPTION
As per discussion on #1601 and https://trello.com/c/SnUesylG/505-ditching-docs-pdfs, this renames the OMERO docs html zip bundle from 'OMERO-x.y.z.zip' to 'OMERO-doc-x.y.z.zip'

Can be tested locally using `ant html -Domero.release="5.3.0-m6"` or similar and build should remain green.

Corresponding changes needed to https://github.com/openmicroscopy/ome-release/pull/211 and I'll also open a PR on the code base to rename javadoc bundle to avoid confusion.