### PR TITLE
Zip doc

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -6,7 +6,7 @@ Download Apache Ant from http://ant.apache.org/.
 Type "ant -p" for a list of targets.
 -->
 
-<project name="sphinx" default="html" basedir=".">
+<project name="sphinx" default="zip" basedir=".">
   <description>Build file for sphinx documentation</description>
   <property name="root.dir" location="."/>
 

--- a/build.xml
+++ b/build.xml
@@ -10,6 +10,10 @@ Type "ant -p" for a list of targets.
   <description>Build file for sphinx documentation</description>
   <property name="root.dir" location="."/>
 
+  <target name="zip" depends="html">
+    <ant dir="omero" target="zip"/>
+  </target>
+
   <target name="html">
     <ant dir="omero" target="html"/>
     <ant dir="contributing" target="html"/>

--- a/common/rules.xml
+++ b/common/rules.xml
@@ -55,6 +55,15 @@ Type "ant -p" for a list of targets.
   </macrodef>
 
 
+<!-- Change the value to upper case for the zip -->
+  <scriptdef language="javascript" name="upper">
+    <attribute name="string" /> 
+    <attribute name="to" />
+
+    project.setProperty(attributes.get("to"),
+                        attributes.get("string").toUpperCase());
+  </scriptdef>
+
   <target name="sphinx-deps"/>
   <target name="clean-deps"/>
 
@@ -65,6 +74,24 @@ Type "ant -p" for a list of targets.
             opts="${sphinx.opts}"
             warnopts="${sphinx.warnopts}"/>
   </target>
+
+  <target name="zip" depends="html">
+    <basename property="component" file="${basedir}"/>
+    <upper string="${component}" to="upper"/>
+    <property name="output" value="${upper}.doc"/>
+    <delete dir="${sphinx.builddir}/${output}-${omero.release}"/>
+    <copy todir="${sphinx.builddir}/${output}-${omero.release}">
+      <!--
+        include (none) to prevent problems if component.resources-bin is empty
+      -->
+      <fileset dir="${sphinx.builddir}/html"/>
+    </copy>
+    <zip destfile="${sphinx.builddir}/${output}-${omero.release}.zip">
+      <zipfileset dir="${sphinx.builddir}/html" includes="**/*" prefix="${output}-${omero.release}"/>
+    </zip>
+    <delete dir="${sphinx.builddir}/${output}-${omero.release}"/>
+  </target>
+
 
   <target name="linkcheck" depends="sphinx-deps, init">
     <sphinx buildtype="linkcheck" srcdir="."

--- a/common/rules.xml
+++ b/common/rules.xml
@@ -64,17 +64,6 @@ Type "ant -p" for a list of targets.
             destdir="${sphinx.builddir}/html"
             opts="${sphinx.opts}"
             warnopts="${sphinx.warnopts}"/>
-    <delete dir="${sphinx.builddir}/OMERO-${omero.release}"/>
-    <copy todir="${sphinx.builddir}/OMERO-${omero.release}">
-      <!--
-        include (none) to prevent problems if component.resources-bin is empty
-      -->
-      <fileset dir="${sphinx.builddir}/html"/>
-    </copy>
-    <zip destfile="${sphinx.builddir}/OMERO.doc-${omero.release}.zip">
-      <zipfileset dir="${sphinx.builddir}/html" includes="**/*" prefix="OMERO.doc-${omero.release}"/>
-    </zip>
-    <delete dir="${sphinx.builddir}/OMERO-${omero.release}"/>
   </target>
 
   <target name="linkcheck" depends="sphinx-deps, init">

--- a/omero/build.xml
+++ b/omero/build.xml
@@ -6,7 +6,7 @@ Download Apache Ant from http://ant.apache.org/.
 Type "ant -p" for a list of targets.
 -->
 
-<project name="omero" default="html" basedir=".">
+<project name="omero" default="zip" basedir=".">
   <description>Build file for sphinx documentation</description>
   <property name="root.dir" location=".."/>
   <import file="${root.dir}/common/rules.xml"/>


### PR DESCRIPTION
This PR fixes a bug introduced by gh-1601

In this PR, a new ``ant target`` is introduced:
From the top directory:

* ``ant zip  -Domero.release="5.3.0-m8"`` will generate the ``html`` doc for ``omero`` and ``contributing``
and create a ``OMERO.doc-5.3.0-m8.zip`` under ``omero/_build``
*   ``ant  -Domero.release="5.3.0-m8"`` will generate the same output as ``ant zip  -Domero.release="5.3.0-m8"``.  ``zip`` is now the default instead of ``html``
* ``ant html`` will now only create the ``html`` doc i.e. behaviour before gh-1601

From the ``omero`` directory:

* ``ant zip  -Domero.release="5.3.0-m8"`` will generate the ``html`` doc for ``omero`` and create a ``OMERO.doc-5.3.0-m8.zip`` under ``omero/_build``
* ``ant  -Domero.release="5.3.0-m8"`` will generate the same output as ``ant zip  -Domero.release="5.3.0-m8"``.  ``zip`` is now the default instead of ``html``
* ``ant html`` will now only create the ``html`` doc i.e. behaviour before gh-1601

From the ``contributing`` directory:

* ``ant zip  -Domero.release="5.3.0-m8"`` will generate the ``html`` doc for ``contributing`` and create a ``CONTRIBUTING.doc-5.3.0-m8.zip`` under ``contributing/_build``
* ``html`` is kept as the default i.e. ``ant`` and ``ant html`` produce the same output

cc @hflynn 