### PR TITLE
note mapping of OriginalFile.repo property

### DIFF
--- a/omero/developers/Model/EveryObject.txt
+++ b/omero/developers/Model/EveryObject.txt
@@ -2077,6 +2077,7 @@ Properties:
   | name: ``text``
   | path: ``text``
   | pixelsFileMaps: :ref:`PixelsOriginalFileMap <OMERO model class PixelsOriginalFileMap>` (multiple)
+  | repo: ``string`` (optional)
   | size: ``long`` (optional)
   | version: ``integer`` (optional), see :javadoc:`IMutable <ome/model/IMutable.html>`
 


### PR DESCRIPTION
https://github.com/openmicroscopy/openmicroscopy/pull/5054/commits/2e1c7828455440016fad5411deac3101e09bb2f2 maps the `OriginalFile.repo` property into the OMERO object model so there should be a corresponding update at http://www.openmicroscopy.org/site/support/omero5.3-staging/developers/Model/EveryObject.html#originalfile.