### PR TITLE
Update section about coupled development builds

### DIFF
--- a/omero/developers/build-system.txt
+++ b/omero/developers/build-system.txt
@@ -268,8 +268,8 @@ Building Bio-Formats
 
 From the top-level folder of the Bio-Formats repository,
 
-#. adjust the version of Bio-Formats which will be built, installed locally
-   and consumed by OMERO e.g. for 5.2.0-SNAPSHOT::
+#. if necessary, adjust the version of Bio-Formats which will be built,
+   installed locally and consumed by OMERO e.g. for 5.2.0-SNAPSHOT::
 
      $ ./tools/bump_maven_version.py 5.2.0-SNAPSHOT
 
@@ -284,11 +284,8 @@ Building OMERO
 From the top-level folder of the OMERO repository,
 
 #. adjust the ``versions.bioformats`` property under
-   :source:`etc/omero.properties` to the version chosen for the Bio-Formats
+   :file:`etc/omero.properties` to the version chosen for the Bio-Formats
    build
-
-#. adjust the ``ome.resolver`` property under :source:`etc/build.properties` to
-   be ``ome-resolver``
 
 #. run the build system as usual::
 


### PR DESCRIPTION
Reported by @mtbc, this PR should document the canonical way to work on coupled Java components locally using exclusively the local Maven repository:

- make the SNAPSHOT bump step optional
- remove the OMERO step updating the resolver to point at the Artifactory repo

NB: I didn't add additional components but we could also choose to include the newly decoupled `ome-model` as a proof of concept.