### PR TITLE
Dev annotation pages renamed & typo fixes

### DIFF
--- a/omero/developers/Model/KeyValuePairs.txt
+++ b/omero/developers/Model/KeyValuePairs.txt
@@ -1,4 +1,4 @@
-Key-value pairs
+Map annotations
 ===============
 
 Ongoing advancements in microscopic techniques, analysis

--- a/omero/developers/Model/StructuredAnnotations.txt
+++ b/omero/developers/Model/StructuredAnnotations.txt
@@ -1,5 +1,5 @@
-Structured annotations
-======================
+Working with annotations
+========================
 
 Structured annotations permit the attachment of data and metadata
 outside the OMERO data model to certain types within the model. The

--- a/omero/developers/Model/StructuredAnnotations.txt
+++ b/omero/developers/Model/StructuredAnnotations.txt
@@ -167,3 +167,6 @@ than IQuery.
 .. seealso::
 
     |ExtendingOmero|
+    
+    :doc:`KeyValuePairs`
+

--- a/omero/developers/Modules/Api.txt
+++ b/omero/developers/Modules/Api.txt
@@ -217,7 +217,7 @@ OMERO annotations for validation
 The server-side implementation of these interfaces makes use of ((JDK5))
 :doc:`/developers/Model/StructuredAnnotations` and an
 :doc:`AOP </developers/Server/Aop>` interceptor to validate all method
-parameters. Calls to ``pojos.findContainerHierarches`` are first caught by a
+parameters. Calls to ``pojos.findContainerHierarchies`` are first caught by a
 method interceptor, which checks for annotations on the parameters and, if
 available, performs the necessary checks. The interceptor also makes proactive
 checks. For a range of parameter types (such as Java Collections) it requires
@@ -227,7 +227,7 @@ An API call of the form:
 
 ::
 
-        pojos.findContainerHierarches(Class,Set,Map)
+        pojos.findContainerHierarchies(Class,Set,Map)
 
 is implemented as
 


### PR DESCRIPTION
See https://trello.com/c/CKngXpGC/41-improve-developer-annotations-documentation and https://trello.com/c/tF1xM4XW/223-minor-api-doc-fix

Two pages renamed to help signal their content more clearly and a couple of typos fixed. Staged at https://www.openmicroscopy.org/site/support/omero5.3-staging/developers/index.html#the-ome-data-model and https://www.openmicroscopy.org/site/support/omero5.3-staging/developers/Modules/Api.html