### PR TITLE
Insight maintenance mode & user update

### DIFF
--- a/omero/developers/Insight/Architecture.txt
+++ b/omero/developers/Insight/Architecture.txt
@@ -1,6 +1,12 @@
 Architecture
 ------------
 
+.. note:: With the release of OMERO 5.3.0, the OMERO.insight desktop client
+    has entered **maintenance mode**, meaning it will only be updated if a
+    major bug is discovered. Instead, the OME team will be focusing on
+    developing the web clients. As a result, coding against this client is no
+    longer recommended.
+
 Logical view
 ~~~~~~~~~~~~
 

--- a/omero/developers/Insight/Configuration.txt
+++ b/omero/developers/Insight/Configuration.txt
@@ -1,6 +1,12 @@
 Configuration
 =============
 
+.. note:: With the release of OMERO 5.3.0, the OMERO.insight desktop client
+    has entered **maintenance mode**, meaning it will only be updated if a
+    major bug is discovered. Instead, the OME team will be focusing on
+    developing the web clients. As a result, coding against this client is no
+    longer recommended.
+
 The container provides a flexible and extensible configuration
 mechanism. Each agent has its own configuration file which is parsed at
 start-up by the container. The configuration entries in this file are

--- a/omero/developers/Insight/DirectoryContents.txt
+++ b/omero/developers/Insight/DirectoryContents.txt
@@ -1,6 +1,12 @@
 Directory contents
 ==================
 
+.. note:: With the release of OMERO 5.3.0, the OMERO.insight desktop client
+    has entered **maintenance mode**, meaning it will only be updated if a
+    major bug is discovered. Instead, the OME team will be focusing on
+    developing the web clients. As a result, coding against this client is no
+    longer recommended.
+
 The repository of the software artifacts is organized as follows:
 
 -  ``build``: This directory contains the tools to compile, run, test,

--- a/omero/developers/Insight/EventBus.txt
+++ b/omero/developers/Insight/EventBus.txt
@@ -1,6 +1,12 @@
 Event bus
 ---------
 
+.. note:: With the release of OMERO 5.3.0, the OMERO.insight desktop client
+    has entered **maintenance mode**, meaning it will only be updated if a
+    major bug is discovered. Instead, the OME team will be focusing on
+    developing the web clients. As a result, coding against this client is no
+    longer recommended.
+
 Interactions among agents are event-driven. Agents communicate by using
 a shared event bus provided by the container. The event bus is an event
 propagation mechanism loosely based on the

--- a/omero/developers/Insight/HowTo/BuildAgent.txt
+++ b/omero/developers/Insight/HowTo/BuildAgent.txt
@@ -1,6 +1,12 @@
 How to build an agent
 =====================
 
+.. note:: With the release of OMERO 5.3.0, the OMERO.insight desktop client
+    has entered **maintenance mode**, meaning it will only be updated if a
+    major bug is discovered. Instead, the OME team will be focusing on
+    developing the web clients. As a result, coding against this client is no
+    longer recommended.
+
 An agent is created and managed by the container. Building an agent is
 done in two steps:
 

--- a/omero/developers/Insight/HowTo/BuildAgentView.txt
+++ b/omero/developers/Insight/HowTo/BuildAgentView.txt
@@ -1,6 +1,12 @@
 How to build an agent's view
 ============================
 
+.. note:: With the release of OMERO 5.3.0, the OMERO.insight desktop client
+    has entered **maintenance mode**, meaning it will only be updated if a
+    major bug is discovered. Instead, the OME team will be focusing on
+    developing the web clients. As a result, coding against this client is no
+    longer recommended.
+
 This section explains how a view of the agent is created. All our
 agents follow the same approach. To see the code while
 reading the notes, go to

--- a/omero/developers/Insight/HowTo/RetrieveData.txt
+++ b/omero/developers/Insight/HowTo/RetrieveData.txt
@@ -1,6 +1,12 @@
 Retrieve data from server
 =========================
 
+.. note:: With the release of OMERO 5.3.0, the OMERO.insight desktop client
+    has entered **maintenance mode**, meaning it will only be updated if a
+    major bug is discovered. Instead, the OME team will be focusing on
+    developing the web clients. As a result, coding against this client is no
+    longer recommended.
+
 To retrieve data stored in an OMERO server, Agents can either:
 
 -  directly access a Data service (container service) through their

--- a/omero/developers/Insight/ImplementationView.txt
+++ b/omero/developers/Insight/ImplementationView.txt
@@ -1,6 +1,12 @@
 Organization
 ============
 
+.. note:: With the release of OMERO 5.3.0, the OMERO.insight desktop client
+    has entered **maintenance mode**, meaning it will only be updated if a
+    major bug is discovered. Instead, the OME team will be focusing on
+    developing the web clients. As a result, coding against this client is no
+    longer recommended.
+
 The source code is organized as follows. All classes share a common base
 namespace:
 

--- a/omero/developers/Insight/TaskBar.txt
+++ b/omero/developers/Insight/TaskBar.txt
@@ -1,6 +1,12 @@
 Taskbar
 =======
 
+.. note:: With the release of OMERO 5.3.0, the OMERO.insight desktop client
+    has entered **maintenance mode**, meaning it will only be updated if a
+    major bug is discovered. Instead, the OME team will be focusing on
+    developing the web clients. As a result, coding against this client is no
+    longer recommended.
+
 The container provides a top-level window, the taskbar, to let users
 control some of the container's tasks like the connection to the remote
 service or quitting the application. The taskbar contains a menu bar and

--- a/omero/developers/index.txt
+++ b/omero/developers/index.txt
@@ -123,6 +123,12 @@ Web
 Insight
 *******
 
+.. note:: With the release of OMERO 5.3.0, the OMERO.insight desktop client
+    has entered **maintenance mode**, meaning it will only be updated if a
+    major bug is discovered. Instead, the OME team will be focusing on
+    developing the web clients. As a result, coding against this client is no
+    longer recommended.
+
 .. toctree::
     :maxdepth: 1
     :titlesonly:

--- a/omero/users/clients-overview.txt
+++ b/omero/users/clients-overview.txt
@@ -66,6 +66,11 @@ For more information and guides to using OMERO.web, see our
 OMERO.insight
 -------------
 
+.. note:: With the release of OMERO 5.3.0, the OMERO.insight desktop client
+    has entered **maintenance mode**, meaning it will only be updated if a
+    major bug is discovered. Instead, the OME team will be focusing on
+    developing and extending the web clients.
+
 OMERO.insight provides a number of tools for accessing and using data in an
 OMERO server. Figures :ref:`omero_insight_screenshot_5_2` and
 :ref:`omero_insight_5_2_viewer` present the user interface. To find out more,

--- a/omero/users/whatsnew.txt
+++ b/omero/users/whatsnew.txt
@@ -5,13 +5,15 @@ Updates and new features for OMERO 5.3 include:
 
 - ROI Folders which allow you to organize your ROIs into a hierarchical tree
   structure of folders so they can be sorted e.g. by phenotypes or ontologies
-- support for lookup tables (LUT) and reverse intensity rendering
+- support for lookup tables (LUT) and reverse/inverted intensity rendering
 - annotations can now be added to Wells in the clients and the UI for viewing
   Screen Plate Well data has been redesigned
 - images can now be projected along T
 - the new 'Open With...' functionality allows images to be opened with
   OMERO.figure or other plugins directly from OMERO.web (coming soon is a new
   web-based full image viewer - OMERO.iviewer.)
+- updated Bio-Formats version to the 5.3 line, bringing improved file format
+  support including support for JPEG-XR compressed CZI data
 
 See the :help:`User help website <>` for information on how to incorporate
 these new features into your current workflows.


### PR DESCRIPTION
See https://trello.com/c/jTWIBi0M/278-insight-maintenance-mode
This adds a note to the insight section in the developer docs and all the insight sub-pages and also one on the client overview page. I also added a bit to the 'What's new for users' while it occurred to me.

Possibly we want to add some info to the OMERO.web section of the client overview page, currently insight has a big list of features and web has nothing.