### PR TITLE
Add `--style json` to cli/fs docs

### DIFF
--- a/omero/sysadmins/cli/fs.txt
+++ b/omero/sysadmins/cli/fs.txt
@@ -33,11 +33,12 @@ The options available to this subcommand are:
 
     Display the help for this subcommand.
 
-.. option:: --style <{plain,csv,sql}>
+.. option:: --style <{plain,csv,json,sql}>
 
     This option determines the output style, tabular `sql` being the default as
     in the previous example. The `csv` style is comma-separated values with an
     initial header row, `plain` is the same as `csv` but without the header row.
+    `json` returns an array of JSON objects that can be piped to other tools.
 
 .. option:: --managed
 
@@ -83,7 +84,7 @@ The options available to this subcommand are:
 
     Display the help for this subcommand.
 
-.. option:: --style <{plain,csv,sql}>
+.. option:: --style <{plain,csv,json,sql}>
 
     See :option:`omero fs repos --style`.
 
@@ -167,7 +168,7 @@ The options available to this subcommand are:
 
     Display the help for this subcommand.
 
-.. option:: --style {plain,csv,sql}
+.. option:: --style {plain,csv,json,sql}
 
     See :option:`omero fs repos --style`.
 
@@ -304,7 +305,7 @@ The options available to this subcommand are:
 
     Display the help for this subcommand.
 
-.. option:: --style {plain,csv,sql}
+.. option:: --style {plain,csv,json,sql}
 
     See :option:`omero fs repos --style`.
 

--- a/omero/sysadmins/cli/fs.txt
+++ b/omero/sysadmins/cli/fs.txt
@@ -88,17 +88,17 @@ The options available to this subcommand are:
 
     See :option:`omero fs repos --style`.
 
-.. option:: --limit <LIMIT>
+.. option:: --limit LIMIT
 
     This option specifies the maximum number of return values, the default
     is 25.
 
-.. option:: --offset <OFFSET>
+.. option:: --offset OFFSET
 
     This option specifies the number of entries to skip before starting the
     listing, the default, 0, is to skip no entries.
 
-.. option:: --order <{newest,oldest,prefix}>
+.. option:: --order {newest,oldest,prefix}
 
     This option determines the order of the rows returned, `newest` is the
     default.
@@ -108,7 +108,7 @@ The options available to this subcommand are:
     This option lists only those filesets without images, these may be corrupt
     filesets.
 
-.. option:: --with-transfer <WITH_TRANSFER [WITH_TRANSFER ...]>
+.. option:: --with-transfer WITH_TRANSFER [WITH_TRANSFER ...]
 
     This option lists only those filesets imported using the given in-place
     import methods.
@@ -172,15 +172,15 @@ The options available to this subcommand are:
 
     See :option:`omero fs repos --style`.
 
-.. option:: --limit <LIMIT>
+.. option:: --limit LIMIT
 
     See :option:`omero fs sets --limit`.
 
-.. option:: --offset <OFFSET>
+.. option:: --offset OFFSET
 
     See :option:`omero fs sets --offset`
 
-.. option:: --order <{newest,oldest,prefix}>
+.. option:: --order {newest,oldest,prefix}
 
     See :option:`omero fs sets --order`.
 

--- a/omero/sysadmins/cli/fs.txt
+++ b/omero/sysadmins/cli/fs.txt
@@ -33,7 +33,7 @@ The options available to this subcommand are:
 
     Display the help for this subcommand.
 
-.. option:: --style <{plain,csv,json,sql}>
+.. option:: --style {plain,csv,json,sql}
 
     This option determines the output style, tabular `sql` being the default as
     in the previous example. The `csv` style is comma-separated values with an
@@ -84,7 +84,7 @@ The options available to this subcommand are:
 
     Display the help for this subcommand.
 
-.. option:: --style <{plain,csv,json,sql}>
+.. option:: --style {plain,csv,json,sql}
 
     See :option:`omero fs repos --style`.
 


### PR DESCRIPTION
Updates mentions of `--style` in the existing docs to match https://github.com/openmicroscopy/openmicroscopy/pull/4906

As far as I can tell these are the only docs that mention `--style` even though the flag is present on several other commands.

Trello: https://trello.com/c/TKhujUiT/217-document-cli-style-json