### PR TITLE
Instructions for win 5.2 to linux 5.3 migration

### DIFF
--- a/omero/sysadmins/index.txt
+++ b/omero/sysadmins/index.txt
@@ -69,6 +69,7 @@ backing-up, and upgrading your server installation.
     server-upgrade
     UpgradeCheck
     repository-move
+    windowsmigration
 
 .. _index-optimizing-server:
 

--- a/omero/sysadmins/index.txt
+++ b/omero/sysadmins/index.txt
@@ -69,7 +69,7 @@ backing-up, and upgrading your server installation.
     server-upgrade
     UpgradeCheck
     repository-move
-    windowsmigration
+    windows-migration
 
 .. _index-optimizing-server:
 

--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -203,6 +203,8 @@ directory, you are safe to follow the following upgrade procedure:
     ``ice3x`` and ``byy`` **need to be replaced** by the appropriate Ice
     version and build number of OMERO.server.
 
+.. _upgradedb:
+
 Upgrade your database
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/omero/sysadmins/whatsnew.txt
+++ b/omero/sysadmins/whatsnew.txt
@@ -8,3 +8,6 @@ What's new for OMERO 5.3 for sysadmins
   Python packages.
 
 - All OMERO web apps can now be installed using ``pip install``.
+
+- Windows support discontinued, see :doc:`/sysadmins/windowsmigration`
+

--- a/omero/sysadmins/whatsnew.txt
+++ b/omero/sysadmins/whatsnew.txt
@@ -9,5 +9,5 @@ What's new for OMERO 5.3 for sysadmins
 
 - All OMERO web apps can now be installed using ``pip install``.
 
-- Windows support discontinued, see :doc:`/sysadmins/windowsmigration`.
+- Windows support discontinued, see :doc:`/sysadmins/windows-migration`.
 

--- a/omero/sysadmins/whatsnew.txt
+++ b/omero/sysadmins/whatsnew.txt
@@ -9,5 +9,5 @@ What's new for OMERO 5.3 for sysadmins
 
 - All OMERO web apps can now be installed using ``pip install``.
 
-- Windows support discontinued, see :doc:`/sysadmins/windowsmigration`
+- Windows support discontinued, see :doc:`/sysadmins/windowsmigration`.
 

--- a/omero/sysadmins/windows-migration.txt
+++ b/omero/sysadmins/windows-migration.txt
@@ -6,8 +6,20 @@ Backup (Windows)
 
 - Create a dump of the OMERO SQL database, either using
   `pgAdmin <https://www.pgadmin.org/>`_ or the :command:`pg_dump` command line
-  program.
-- Backup the OMERO data directory (e.g. :file:`C:\\OMERO`).
+  program::
+
+    pg_dump -Fc -f omero52.pg_dump omero_database
+
+- Please keep a pristine copy of your Windows OMERO server, until you are
+  sure that the new 5.3 installation works flawlessly. That means
+  if you use a network storage system for hosting the OMERO data directory,
+  back it up before mounting it onto the new Linux system.
+
+- Note custom configuration properties you might have set::
+
+    omero config get
+
+- See also :doc:`/sysadmins/server-backup-and-restore`.
 
 
 Install OMERO 5.3 (Linux)
@@ -25,7 +37,7 @@ server installation.
 Restore Data (Linux)
 --------------------
 
-- Restore the previously generated 5.2 database dump::
+- Restore the 5.2 database dump::
 
      sudo -u postgres pg_restore -Fc -d omero_database omero52.pg_dump
 
@@ -37,7 +49,12 @@ Restore Data (Linux)
     UPDATE pixels SET path = regexp_replace(path,'\\','/','g');
 
 - Copy the OMERO data directory from your Windows system (e.g. :file:`C:\\OMERO`) over
-  to the Linux system (e.g. :file:`/OMERO`).
+  to the Linux system (e.g. :file:`/OMERO`), or if you use a network storage
+  system, mount it onto the Linux system (**make sure you have a backup beforehand**)
+
+- Restore custom configuration properties (see Backup step 3)::
+
+    omero config set ...
 
 
 Finally start the OMERO server and check the log files for errors.

--- a/omero/sysadmins/windows-migration.txt
+++ b/omero/sysadmins/windows-migration.txt
@@ -50,7 +50,7 @@ Restore Data (Linux)
 
 - Copy the OMERO data directory from your Windows system (e.g. :file:`C:\\OMERO`) over
   to the Linux system (e.g. :file:`/OMERO`), or if you use a network storage
-  system, mount it onto the Linux system (**make sure you have a backup beforehand**)
+  system then mount it onto the Linux system (**make sure you have a backup beforehand**)
 
 - Restore custom configuration properties (see Backup step 3)::
 

--- a/omero/sysadmins/windows-migration.txt
+++ b/omero/sysadmins/windows-migration.txt
@@ -11,15 +11,17 @@ Backup (Windows)
     pg_dump -Fc -f omero52.pg_dump omero_database
 
 - Please keep a pristine copy of your Windows OMERO server, until you are
-  sure that the new 5.3 installation works flawlessly. That means
-  if you use a network storage system for hosting the OMERO data directory,
-  back it up before mounting it onto the new Linux system.
+  sure that the new 5.3 installation works flawlessly. That means if you use
+  a network storage system for hosting the 
+  :doc:`binary data store <unix/server-binary-repository>`, back it up before
+  mounting it onto the new Linux system.
 
-- Note custom configuration properties you might have set::
+- Save custom configuration properties which might have been set::
 
-    omero config get
+    omero config get > omero.config
 
-- See also :doc:`/sysadmins/server-backup-and-restore`.
+- For more details on the standard backup procedure, 
+  see :doc:`/sysadmins/server-backup-and-restore`.
 
 
 Install OMERO 5.3 (Linux)
@@ -27,7 +29,7 @@ Install OMERO 5.3 (Linux)
 
 Follow the :doc:`/sysadmins/unix/server-installation` documentation to install
 OMERO 5.3 on your Linux system, until (including) step 3 of the Configuration
-part (setting the OMERO binary repository location).
+part (setting the binary repository location).
 
 There is no need to generate the database initialization script, as you are
 going to use the previously generated database backup from your old 5.2 
@@ -48,13 +50,14 @@ Restore Data (Linux)
 
     UPDATE pixels SET path = regexp_replace(path,'\\','/','g');
 
-- Copy the OMERO data directory from your Windows system (e.g. :file:`C:\\OMERO`) over
-  to the Linux system (e.g. :file:`/OMERO`), or if you use a network storage
-  system then mount it onto the Linux system (**make sure you have a backup beforehand**)
+- Copy the :doc:`binary data store <unix/server-binary-repository>` from your
+  Windows system (e.g. :file:`C:\\OMERO`) over to the Linux system 
+  (e.g. :file:`/OMERO`), or if you use a network storage system then mount it
+  onto the Linux system (**make sure you have a backup beforehand**)
 
 - Restore custom configuration properties (see Backup step 3)::
 
-    omero config set ...
+    omero config load omero.config
 
 
 Finally start the OMERO server and check the log files for errors.

--- a/omero/sysadmins/windowsmigration.txt
+++ b/omero/sysadmins/windowsmigration.txt
@@ -4,9 +4,10 @@ Migration from OMERO 5.2 on Windows to OMERO 5.3 on Linux
 Backup (Windows)
 ----------------
 
-- Create a dump of the OMERO SQL database, either using PGAdmin or the pg_dump
-  command line program.
-- Backup the OMERO data directory (e.g. C:\\OMERO ).
+- Create a dump of the OMERO SQL database, either using
+  `pgAdmin <https://www.pgadmin.org/>`_ or the :command:`pg_dump` command line
+  program.
+- Backup the OMERO data directory (e.g. :file:`C:\\OMERO`).
 
 
 Install OMERO 5.3 (Linux)
@@ -31,14 +32,14 @@ Restore Data (Linux)
 - Upgrade the database to 5.3 following the :ref:`upgradedb` documentation
 
 - Adjust the paths stored in the database from Windows style to Unix style, 
-  e. g. using psql command line::
+  e. g. using :command:`psql` command line::
 
     UPDATE pixels SET path = regexp_replace(path,'\\','/','g');
 
-- Copy the OMERO data directory from your Windows system (e.g. C:\\OMERO) over
-  to the Linux system (e.g. /OMERO).
+- Copy the OMERO data directory from your Windows system (e.g. :file:`C:\\OMERO`) over
+  to the Linux system (e.g. :file:`/OMERO`).
 
 
-Finally startup the OMERO server and check the log files for errors.
+Finally start the OMERO server and check the log files for errors.
 
 

--- a/omero/sysadmins/windowsmigration.txt
+++ b/omero/sysadmins/windowsmigration.txt
@@ -30,8 +30,7 @@ Restore Data (Linux)
 
      sudo -u postgres pg_restore -Fc -d omero_database omero52.pg_dump
 
-- Upgrade the database to 5.3 following
-  :doc:`/sysadmins/server-upgrade#upgrade-your-database` documentation
+- Upgrade the database to 5.3 following the :ref:`upgradedb` documentation
 
 - Adjust the paths stored in the database from Windows style to Unix style, 
   e. g. using psql command line

--- a/omero/sysadmins/windowsmigration.txt
+++ b/omero/sysadmins/windowsmigration.txt
@@ -1,0 +1,48 @@
+Migration from OMERO 5.2 on Windows to OMERO 5.3 on Linux
+=========================================================
+
+Backup (Windows)
+----------------
+
+- Create a dump of the OMERO SQL database, either using PGAdmin or the pg_dump
+  command line program.
+- Backup the OMERO data directory (e.g. C:\\OMERO ).
+
+
+Install OMERO 5.3 (Linux)
+-------------------------
+
+Follow the :doc:`/sysadmins/unix/server-installation` documentation to install
+OMERO 5.3 on your Linux system, until (including) step 3 of the Configuration
+part (setting the OMERO binary repository location)
+
+There is no need to generate the database initialization script, as you are
+going to use the previously generated database backup from your old 5.2 
+server installation
+
+
+Restore Data (Linux)
+--------------------
+
+- Restore the previously generated 5.2 database dump
+
+::
+
+     sudo -u postgres pg_restore -Fc -d omero_database omero52.pg_dump
+
+- Upgrade the database to 5.3 following
+  :doc:`/sysadmins/server-upgrade#upgrade-your-database` documentation
+
+- Adjust the paths stored in the database from Windows style to Unix style, 
+  e. g. using psql command line
+
+::
+
+    UPDATE pixels SET path = regexp_replace(path,'\\','/','g');
+
+- Copy the OMERO data directory from your Windows system (e.g. C:\\OMERO) over
+  to the Linux system (e.g. /OMERO).
+  
+- Finally startup OMERO server and check the log files for errors.
+
+

--- a/omero/sysadmins/windowsmigration.txt
+++ b/omero/sysadmins/windowsmigration.txt
@@ -14,34 +14,31 @@ Install OMERO 5.3 (Linux)
 
 Follow the :doc:`/sysadmins/unix/server-installation` documentation to install
 OMERO 5.3 on your Linux system, until (including) step 3 of the Configuration
-part (setting the OMERO binary repository location)
+part (setting the OMERO binary repository location).
 
 There is no need to generate the database initialization script, as you are
 going to use the previously generated database backup from your old 5.2 
-server installation
+server installation.
 
 
 Restore Data (Linux)
 --------------------
 
-- Restore the previously generated 5.2 database dump
-
-::
+- Restore the previously generated 5.2 database dump::
 
      sudo -u postgres pg_restore -Fc -d omero_database omero52.pg_dump
 
 - Upgrade the database to 5.3 following the :ref:`upgradedb` documentation
 
 - Adjust the paths stored in the database from Windows style to Unix style, 
-  e. g. using psql command line
-
-::
+  e. g. using psql command line::
 
     UPDATE pixels SET path = regexp_replace(path,'\\','/','g');
 
 - Copy the OMERO data directory from your Windows system (e.g. C:\\OMERO) over
   to the Linux system (e.g. /OMERO).
-  
-- Finally startup OMERO server and check the log files for errors.
+
+
+Finally startup the OMERO server and check the log files for errors.
 
 


### PR DESCRIPTION
This PR just adds a brief summary of how to migrate from a OMERO 5.2 installation on Windows to 5.3.0 on Linux.

Staged at: http://www.openmicroscopy.org/site/support/omero5.3-staging/sysadmins/windows-migration.html