### PR TITLE
Add ROI folders example

### DIFF
--- a/omero/developers/Java.txt
+++ b/omero/developers/Java.txt
@@ -752,15 +752,15 @@ to an image.
     for (ROIData r : rois) {
         FolderData folder = new FolderData();
         folder.setName("Folder for ROI " + r.getId());
-        roifac.addRoisToFolders(ctx, imageId, Arrays.asList(r),
+        roifac.addRoisToFolders(ctx, image.getId(), Arrays.asList(r),
                 Arrays.asList(folder));
     }
 
     // Get the ROI folders associated with an image
-    Collection<FolderData> folders = roifac.getROIFolders(ctx, imageId);
+    Collection<FolderData> folders = roifac.getROIFolders(ctx, image.getId());
     for (FolderData folder : folders) {
         Collection<ROIResult> result = roifac.loadROIsForFolder(ctx,
-                imageId, folder.getId());
+                image.getId(), folder.getId());
         Collection<ROIData> folderRois = result.iterator().next().getROIs();
         // Do something with the ROIs
     }

--- a/omero/developers/Java.txt
+++ b/omero/developers/Java.txt
@@ -740,6 +740,31 @@ to an image.
       }
     }
 
+-  **Organize ROIs in Folders.**
+
+::
+    
+    ROIFacility roifac = gateway.getFacility(ROIFacility.class);
+    
+    Collection<ROIData> rois = ...
+    
+    // Add each ROI to a different folder
+    for (ROIData r : rois) {
+        FolderData folder = new FolderData();
+        folder.setName("Folder for ROI " + r.getId());
+        roifac.addRoisToFolders(ctx, imageId, Arrays.asList(r),
+                Arrays.asList(folder));
+    }
+
+    // Get the ROI folders associated with an image
+    Collection<FolderData> folders = roifac.getROIFolders(ctx, imageId);
+    for (FolderData folder : folders) {
+        Collection<ROIResult> result = roifac.loadROIsForFolder(ctx,
+                imageId, folder.getId());
+        Collection<ROIData> folderRois = result.iterator().next().getROIs();
+        // Do something with the ROIs
+    }
+
 Delete data
 -----------
 


### PR DESCRIPTION
Adds a brief example for how to organize ROIs in folders.

See also:
* [Trello - Docs, Examples for ROIFolders API : Java,python,matlab](https://trello.com/c/Cqa9ov3p/296-docs-examples-for-roifolders-api-java-python-matlab)
* https://github.com/openmicroscopy/openmicroscopy/pull/5156
