### PR TITLE
No Windows support for CLI client

### DIFF
--- a/omero/users/cli/index.txt
+++ b/omero/users/cli/index.txt
@@ -5,6 +5,11 @@ The |CLI| is a set of Python_ based system-administration, deployment and
 advanced user tools. Most of commands work remotely so that the |CLI| can be
 used as a client against an OMERO server.
 
+.. note:: The end of Windows support for OMERO.server means that the CLI is
+    currently unsupported on this platform too. However, we intend to make
+    OMERO.python installable via pip for future releases which would restore
+    Windows support for the CLI.
+
 .. toctree::
     :maxdepth: 1
     :titlesonly:

--- a/omero/users/cli/installation.txt
+++ b/omero/users/cli/installation.txt
@@ -1,6 +1,11 @@
 Installation
 ------------
 
+.. note:: The end of Windows support for OMERO.server means that the CLI is
+    currently unsupported on this platform too. However, we intend to make
+    OMERO.python installable via pip for future releases which would restore
+    Windows support for the CLI.
+
 Check you have Python_ installed by typing::
 
     $ python --version


### PR DESCRIPTION
See https://trello.com/c/QcF8KQZf/63-update-omero-downloads-page-cli-docs-re-no-windows-server-support
Staged at https://www.openmicroscopy.org/site/support/omero5.3-staging/users/cli/index.html and https://www.openmicroscopy.org/site/support/omero5.3-staging/users/cli/installation.html