### PR TITLE
Configuration

### DIFF
--- a/omero/conf.py
+++ b/omero/conf.py
@@ -143,3 +143,5 @@ linkcheck_ignore += [r'http://localhost:\d+/?', 'http://localhost/',
     r'https?://www\.openmicroscopy\.org/site/team/.*',
     r'.*[.]?example\.com/.*',
     r'https://spreadsheets.google.com/.*']
+
+exclude_patterns = ['sysadmins/unix/walkthrough/requirements*']

--- a/omero/conf.py
+++ b/omero/conf.py
@@ -144,4 +144,5 @@ linkcheck_ignore += [r'http://localhost:\d+/?', 'http://localhost/',
     r'.*[.]?example\.com/.*',
     r'https://spreadsheets.google.com/.*']
 
-exclude_patterns = ['sysadmins/unix/walkthrough/requirements*']
+exclude_patterns = ['sysadmins/unix/walkthrough/requirements*',
+                    'downloads/inplace', 'downloads/cli']

--- a/omero/sysadmins/index.txt
+++ b/omero/sysadmins/index.txt
@@ -43,15 +43,6 @@ series of commands.
     unix/install-web
     advanced-install
 
-.. toctree::
-    :maxdepth: 2
-    :hidden:
-
-    unix/walkthrough/requirements
-    unix/walkthrough/requirements_centos6
-    unix/walkthrough/requirements_centos6_py27
-    unix/walkthrough/requirements_centos6_py27_ius
-
 ********************************
 Server Maintenance and Upgrading
 ********************************


### PR DESCRIPTION
Exclude the files that do not need to be converted as html page

To test:
 * Check that https://www.openmicroscopy.org/site/support/omero5.3-staging/sysadmins/unix/walkthrough/requirements.html is no longer found 
(same for ``requirements_centos6``,  ``requirements_centos6_py27``,  ``requirements_centos6_py27_ius``)
 * check that the same is true for ``downloads/cli/`` and ``downloads/inplace/``

cc @hflynn 