### PR TITLE
Breaking changes for devs

### DIFF
--- a/omero/developers/whatsnew.txt
+++ b/omero/developers/whatsnew.txt
@@ -23,6 +23,28 @@ by :javadoc:`Chmod2
 Java Gateway
 ^^^^^^^^^^^^
 
-OMERO model
+OMERO Model
 ^^^^^^^^^^^
 
+-  Added ``Folder``, ``FolderImageLink`` and ``FolderRoiLink``
+-  Added ``ProjectionDef`` to ``RenderingDef``
+-  Added "Arrow" ``markerStart`` and ``markerEnd`` to ``Line`` and
+   ``Polyline``
+-  Added `ReverseIntensityMapContext` for ROMIO
+-  Moved ``CodomainMapContext`` from ``RenderingDef`` to ``ChannelBinding``
+-  Removed ``g``, ``vectorEffect``, ``visibility`` and various stroke and font
+   properties from ``Shape`` (considering removing ``fontFamily`` in future)
+-  Removed various ``Label`` properties and ``Rectangle.rx``
+-  Removed ``keywords`` and ``namespaces`` from ``Roi``
+-  Adjusted ``Shape.transform`` from string to six separate numerical
+   properties using ``AffineTransform``
+-  Renamed ``Ellipse`` and ``Point`` properties
+-  ``Units.PASCAL`` is now wholly capitalized
+
+Deprecations
+------------
+
+-  ``Ishare``
+-  Enumeration getters in ``IPixels`` in favor of ``ITypes``
+-  ``DiskUsage`` in favor of ``DiskUsage2``
+-  Analysis namespace ``openmicroscopy.org/omero/analysis/flim``

--- a/omero/developers/whatsnew.txt
+++ b/omero/developers/whatsnew.txt
@@ -26,7 +26,8 @@ Java Gateway
 OMERO Model
 ^^^^^^^^^^^
 
--  Added ``Folder``, ``FolderImageLink`` and ``FolderRoiLink``
+-  Added ``Folder``, ``FolderImageLink`` and ``FolderRoiLink`` (see this
+   `blog post <http://blog.openmicroscopy.org/data-model/future-plans/2016/05/23/folders-upcoming/>`_ for further information)
 -  Added ``ProjectionDef`` to ``RenderingDef``
 -  Added "Arrow" ``markerStart`` and ``markerEnd`` to ``Line`` and
    ``Polyline``

--- a/omero/developers/whatsnew.txt
+++ b/omero/developers/whatsnew.txt
@@ -46,6 +46,7 @@ Deprecations
 
 -  ``Ishare``
 -  Search bridges
+-  OMERO reader
 -  Enumeration getters in ``IPixels`` in favor of ``ITypes``
 -  ``DiskUsage`` in favor of ``DiskUsage2``
 -  Analysis namespace ``openmicroscopy.org/omero/analysis/flim``

--- a/omero/developers/whatsnew.txt
+++ b/omero/developers/whatsnew.txt
@@ -30,7 +30,6 @@ OMERO Model
 -  Added ``ProjectionDef`` to ``RenderingDef``
 -  Added "Arrow" ``markerStart`` and ``markerEnd`` to ``Line`` and
    ``Polyline``
--  Added `ReverseIntensityMapContext` for ROMIO
 -  Moved ``CodomainMapContext`` from ``RenderingDef`` to ``ChannelBinding``
 -  Removed ``g``, ``vectorEffect``, ``visibility`` and various stroke and font
    properties from ``Shape`` (considering removing ``fontFamily`` in future)
@@ -45,6 +44,7 @@ Deprecations
 ------------
 
 -  ``Ishare``
+-  Search bridges
 -  Enumeration getters in ``IPixels`` in favor of ``ITypes``
 -  ``DiskUsage`` in favor of ``DiskUsage2``
 -  Analysis namespace ``openmicroscopy.org/omero/analysis/flim``


### PR DESCRIPTION
See https://trello.com/c/BBPKCqxP/39-check-code-for-breaking-changes

Everything from card listed except the client config property as we currently document customizing the clients mostly under sysadmins and I've already included customizing the tree in web in the version history (assuming they are the same issue).

Possibly we want to remove some as unimportant clutter?

Staged at http://www.openmicroscopy.org/site/support/omero5.3-staging/developers/whatsnew.html