### PR TITLE
Add whatsnew for sysadmins content for 5.3

### DIFF
--- a/omero/sysadmins/whatsnew.txt
+++ b/omero/sysadmins/whatsnew.txt
@@ -37,5 +37,5 @@ What's new for OMERO 5.3 for sysadmins
 
 - The default output when importing data via the |CLI| has been updated to
   give an Image or Plate ID list in the form of ``Image:1,2,3,4`` or
-  ``Plate:101`` to be more usable by scripts etc. The previous behaviour can
+  ``Plate:101`` to be more usable by scripts etc. The previous behavior can
   be restored by using ``--output legacy``.

--- a/omero/sysadmins/whatsnew.txt
+++ b/omero/sysadmins/whatsnew.txt
@@ -28,3 +28,6 @@ What's new for OMERO 5.3 for sysadmins
   to Wells which you may wish to run server-side when upgrading. These
   annotations will be reindexed during upgrade so your users can search Wells
   by annotations in the new clients UI for Screen Plate Well data.
+
+- New options have been added for customizing the tree in the clients, see
+  :ref:`client configuration properties <client_configuration>`.

--- a/omero/sysadmins/whatsnew.txt
+++ b/omero/sysadmins/whatsnew.txt
@@ -18,14 +18,14 @@ What's new for OMERO 5.3 for sysadmins
 
 - OMERO.web has been decoupled from the server and can now be deployed
   separately. It now requires Python 2.7 meaning systems still running on
-  CentOS 6 will require upgrading.
+  CentOS 6 may require upgrading.
   
 - Support for deploying OMERO.web using Apache has been dropped; if your
   organization’s policies only allow Apache to be used as the external-facing
   web-server you should configure Apache to proxy connections to an Nginx
   instance running on your OMERO server i.e. use Apache as a reverse proxy.
 
-- jquery cache is now disabled by default.
+- JQuery cache is now disabled by default.
 
 - A new script is available to allow users to migrate annotations from Images
   to Wells which you may wish to run server-side when upgrading. These

--- a/omero/sysadmins/whatsnew.txt
+++ b/omero/sysadmins/whatsnew.txt
@@ -13,7 +13,8 @@ What's new for OMERO 5.3 for sysadmins
 - All official OMERO.web apps can now be installed from PyPI. You should
   reinstall your plugins when you upgrade.
 
-- Windows support discontinued, see :doc:`/sysadmins/windows-migration`.
+- Windows support has been discontinued, see
+  :doc:`/sysadmins/windows-migration`.
 
 - OMERO.web has been decoupled from the server and can now be deployed
   separately. Support for deployment using Apache has been dropped; if your
@@ -22,3 +23,8 @@ What's new for OMERO 5.3 for sysadmins
   instance running on your OMERO server i.e. use Apache as a reverse proxy.
 
 - jquery cache is now disabled by default.
+
+- A new script is available to allow users to migrate annotations from Images
+  to Wells which you may wish to run server-side when upgrading. These
+  annotations will be reindexed during upgrade so your users can search Wells
+  by annotations in the new clients UI for Screen Plate Well data.

--- a/omero/sysadmins/whatsnew.txt
+++ b/omero/sysadmins/whatsnew.txt
@@ -25,7 +25,7 @@ What's new for OMERO 5.3 for sysadmins
   web-server you should configure Apache to proxy connections to an Nginx
   instance running on your OMERO server i.e. use Apache as a reverse proxy.
 
-- JQuery cache is now disabled by default.
+- jQuery cache is now disabled by default.
 
 - A new script is available to allow users to migrate annotations from Images
   to Wells which you may wish to run server-side when upgrading. These

--- a/omero/sysadmins/whatsnew.txt
+++ b/omero/sysadmins/whatsnew.txt
@@ -7,7 +7,17 @@ What's new for OMERO 5.3 for sysadmins
   the Ice Python bindings if your package manager does not provide the Ice
   Python packages.
 
-- All OMERO web apps can now be installed using ``pip install``.
+- :doc:`version-requirements` has been updated to reflect other changes in
+  version support for 5.3.0 and tentative plans for 5.4.0.
+  
+- All official OMERO web apps can now be installed using ``pip install``. If
+  you have been running Django 1.6.x prior to upgrading, you should remove and
+  reinstall your plugins when you upgrade.
 
 - Windows support discontinued, see :doc:`/sysadmins/windows-migration`.
 
+- OMERO.web has been decoupled from the server and can now be deployed
+  separately. Support for deployment using Apache has been dropped; if your
+  organization’s policies only allow Apache to be used as the external-facing
+  web-server you should configure Apache to proxy connections to an Nginx
+  instance running on your OMERO server i.e. use Apache as a reverse proxy.

--- a/omero/sysadmins/whatsnew.txt
+++ b/omero/sysadmins/whatsnew.txt
@@ -34,3 +34,8 @@ What's new for OMERO 5.3 for sysadmins
 
 - New options have been added for customizing the tree in the clients, see
   :ref:`client configuration properties <client_configuration>`.
+
+- The default output when importing data via the |CLI| has been updated to
+  give an Image or Plate ID list in the form of ``Image:1,2,3,4`` or
+  ``Plate:101`` to be more usable by scripts etc. The previous behaviour can
+  be restored by using ``--output legacy``.

--- a/omero/sysadmins/whatsnew.txt
+++ b/omero/sysadmins/whatsnew.txt
@@ -10,8 +10,7 @@ What's new for OMERO 5.3 for sysadmins
 - :doc:`version-requirements` has been updated to reflect other changes in
   version support for 5.3.0 and tentative plans for 5.4.0.
   
-- All official OMERO web apps can now be installed using ``pip install``. If
-  you have been running Django 1.6.x prior to upgrading, you should remove and
+- All official OMERO.web apps can now be installed from PyPI. You should
   reinstall your plugins when you upgrade.
 
 - Windows support discontinued, see :doc:`/sysadmins/windows-migration`.
@@ -21,3 +20,5 @@ What's new for OMERO 5.3 for sysadmins
   organization’s policies only allow Apache to be used as the external-facing
   web-server you should configure Apache to proxy connections to an Nginx
   instance running on your OMERO server i.e. use Apache as a reverse proxy.
+
+- jquery cache is now disabled by default.

--- a/omero/sysadmins/whatsnew.txt
+++ b/omero/sysadmins/whatsnew.txt
@@ -27,7 +27,7 @@ What's new for OMERO 5.3 for sysadmins
 - A new script is available to allow users to migrate annotations from Images
   to Wells which you may wish to run server-side when upgrading. These
   annotations will be reindexed during upgrade so your users can search Wells
-  by annotations in the new clients UI for Screen Plate Well data.
+  by annotations in the new GUI for Screen Plate Well data.
 
 - New options have been added for customizing the tree in the clients, see
   :ref:`client configuration properties <client_configuration>`.

--- a/omero/sysadmins/whatsnew.txt
+++ b/omero/sysadmins/whatsnew.txt
@@ -17,7 +17,10 @@ What's new for OMERO 5.3 for sysadmins
   :doc:`/sysadmins/windows-migration`.
 
 - OMERO.web has been decoupled from the server and can now be deployed
-  separately. Support for deployment using Apache has been dropped; if your
+  separately. It now requires Python 2.7 meaning systems still running on
+  CentOS 6 will require upgrading.
+  
+- Support for deploying OMERO.web using Apache has been dropped; if your
   organization’s policies only allow Apache to be used as the external-facing
   web-server you should configure Apache to proxy connections to an Nginx
   instance running on your OMERO server i.e. use Apache as a reverse proxy.
@@ -26,7 +29,7 @@ What's new for OMERO 5.3 for sysadmins
 
 - A new script is available to allow users to migrate annotations from Images
   to Wells which you may wish to run server-side when upgrading. These
-  annotations will be reindexed during upgrade so your users can search Wells
+  annotations will be reindexed automatically so your users can search Wells
   by annotations in the new GUI for Screen Plate Well data.
 
 - New options have been added for customizing the tree in the clients, see


### PR DESCRIPTION
Replaces #1647 

Staged at http://www.openmicroscopy.org/site/support/omero5.3-staging/sysadmins/whatsnew.html

@jburel I've added a line re: https://trello.com/c/AcCpww84/218-django-1-6-11-does-not-support-appconfig-some-omero-web-plugins-may-not-work-correctly too