### PR TITLE
add an introduction to folders in the OMERO model

### DIFF
--- a/omero/developers/Model/Containers.txt
+++ b/omero/developers/Model/Containers.txt
@@ -1,0 +1,33 @@
+Folders in the OMERO model
+==========================
+
+OMERO offers both Projects that contain only Datasets and Datasets that
+contain only Images. Images may thus be organized within a two-level
+container hierarchy.
+
+Reflecting the :model_doc:`June 2016 release <schemas/june-2016.html>`
+of the :model_doc:`OME Data Model <developers/model-overview.html>`,
+OMERO 5.3's object model adds a new kind of container, the Folder. In
+many respects they are rather like Datasets: for example, Folders have a
+description, they may be annotated and they may contain Images. However,
+they are different from Datasets in important respects.
+
+Folders may contain:
+
+  - Images
+  - Regions of Interest (ROIs)
+  - other Folders
+
+or a heterogeneous mix of the above.
+
+For organizing data one may use Folder hierarchies of arbitrary depth.
+Just as an Image may be in multiple Datasets at once, the same Folder
+may be in multiple Folders at once. However, there is an acyclicity
+constraint: a Folder may *not* contain itself, even indirectly.
+
+The OMERO graphical clients offer very limited support for Folders. At
+present Folders may be most useful for those working with their data via
+the |OmeroApi| and its gateways or with the :doc:`OMERO.cli obj plugin
+</developers/cli/obj>`. The :help:`measurement tool
+<measurement-tool.html>` in OMERO.insight shows the Folders that ROIs
+are in. OMERO.web is yet to provide support for Folders.

--- a/omero/developers/Model/Containers.txt
+++ b/omero/developers/Model/Containers.txt
@@ -14,9 +14,9 @@ they are different from Datasets in important respects.
 
 Folders may contain:
 
-  - Images
-  - Regions of Interest (ROIs)
-  - other Folders
+- Images
+- Regions of Interest (ROIs)
+- other Folders
 
 or a heterogeneous mix of the above.
 

--- a/omero/developers/index.txt
+++ b/omero/developers/index.txt
@@ -181,6 +181,7 @@ The OME Data Model
     Model/Units
     Model/KeyValuePairs
     Model/XsltTransformations
+    Model/Containers
 
 
 *********

--- a/omero/developers/whatsnew.txt
+++ b/omero/developers/whatsnew.txt
@@ -31,7 +31,7 @@ OMERO Model
 ^^^^^^^^^^^
 
 -  Added ``Folder``, ``FolderImageLink`` and ``FolderRoiLink`` (see this
-   `blog post <http://blog.openmicroscopy.org/data-model/future-plans/2016/05/23/folders-upcoming/>`_ for further information)
+   `blog post <http://blog.openmicroscopy.org/data-model/future-plans/2016/05/23/folders-upcoming/>`_  and :doc:`Model/Containers` for further information)
 -  Added ``ProjectionDef`` to ``RenderingDef``
 -  Added "Arrow" ``markerStart`` and ``markerEnd`` to ``Line`` and
    ``Polyline``

--- a/omero/developers/whatsnew.txt
+++ b/omero/developers/whatsnew.txt
@@ -30,8 +30,10 @@ Java Gateway
 OMERO Model
 ^^^^^^^^^^^
 
--  Added ``Folder``, ``FolderImageLink`` and ``FolderRoiLink`` (see this
-   `blog post <http://blog.openmicroscopy.org/data-model/future-plans/2016/05/23/folders-upcoming/>`_  and :doc:`Model/Containers` for further information)
+-  Added ``Folder``, ``FolderImageLink`` and ``FolderRoiLink``
+   (see this `blog post
+   <http://blog.openmicroscopy.org/data-model/future-plans/2016/05/23/folders-upcoming/>`_
+   and :doc:`Model/Containers` for further information)
 -  Added ``ProjectionDef`` to ``RenderingDef``
 -  Added "Arrow" ``markerStart`` and ``markerEnd`` to ``Line`` and
    ``Polyline``


### PR DESCRIPTION
Added a little documentation on Folders in line with discussion on https://trello.com/c/ghvhqiO2/34-omero-developer-docs-for-model-changes. Staged at http://www.openmicroscopy.org/site/support/omero5.3-staging/developers/Model/Containers.html.