### PR TITLE
Cross-ref object glossary on CLI docs

### DIFF
--- a/omero/developers/cli/obj.txt
+++ b/omero/developers/cli/obj.txt
@@ -6,6 +6,8 @@ Working with objects
 The :omerocmd:`obj` command allows to create and update OMERO objects. More
 information can be displayed using ``bin/omero obj -h``.
 
+A complete :doc:`/developers/Model/EveryObject` is available for reference.
+
 Object creation
 ^^^^^^^^^^^^^^^
 

--- a/omero/users/cli/containers-annotations.txt
+++ b/omero/users/cli/containers-annotations.txt
@@ -1,12 +1,14 @@
 Creating containers and annotations
 -----------------------------------
 
-The :omerocmd:`obj` command allows users to create and update OMERO objects.
-This command can be used to create containers, i.e. projects, datasets, screens
-and folders. It can also be used to create annotations, and, combined with the
-:omerocmd:`upload` command, file annotations. These annotations can then be
-attached to containers or imported images and plates. This page gives a few
-examples of some simple but fairly common workflows.
+The :omerocmd:`obj` command allows users to create and update OMERO objects. A
+complete :doc:`/developers/Model/EveryObject` is available for reference.
+
+This command can be used to create containers, i.e. projects, datasets,
+screens and folders. It can also be used to create annotations, and, combined
+with the :omerocmd:`upload` command, file annotations. These annotations can
+then be attached to containers or imported images and plates. This page gives
+a few examples of some simple but fairly common workflows.
 
 Creating containers
 ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Following a conversation on slack this am regarding CLI docs for folders, this implements the suggestion that it would be handy to link to the object glossary on the CLI pages for handling objects.

Staged at https://www.openmicroscopy.org/site/support/omero5.3-staging/developers/cli/obj.html and  https://www.openmicroscopy.org/site/support/omero5.3-staging/users/cli/containers-annotations.html