### PR TITLE
updating regex according to doc wording

### DIFF
--- a/omero/sysadmins/public.txt
+++ b/omero/sysadmins/public.txt
@@ -91,7 +91,7 @@ To set this up on your OMERO.web installation:
 
     ::
 
-       $ bin/omero config set omero.web.public.url_filter '/my_web_public'
+       $ bin/omero config set omero.web.public.url_filter '^/my_web_public'
 
 
   - You can use the full webclient UI for public browsing of images.


### PR DESCRIPTION
Document wording is: " to allow only URLs that start with ‘/my_web_public’ you would use:"

The regex appears to match anywhere in the path - so `/my_web_public` would match and allow if used anywhere after the `url`, and before the `GET parameters`, cf https://docs.python.org/2/library/urlparse.html

cf https://github.com/openmicroscopy/openmicroscopy/blob/557a52c93d9d355a6483470b97311a224fce7329/components/tools/OmeroWeb/omeroweb/decorators.py#L242

Thankfully the regex is only matching `request.path` i.e. before any GET parameters, so you can't add `/my_web_public` to another valid URL as a GET parameter, and have it matched/allowed - this would only allow a match to a valid URL, albeit in the middle of the path string, rather than from the start as the docs suggest.

I suggest this as the easiest fix, i.e. updating the regex to match from the start of the string, which brings it into line with the other examples, and the wording of the documentation.