### PR TITLE
GitHub moved description of code review

### DIFF
--- a/contributing/using-git.txt
+++ b/contributing/using-git.txt
@@ -813,8 +813,8 @@ Code reviews and comments
 On the flip-side, a major advantage to having the above branching
 workflow is that is far easier to review the entire impact and style of
 a deliverable before it is integrated into the mainline. Any commit or
-even line which is being proposed for release can be commented on
-`<https://github.com/features/projects/codereview>`_
+even line which is being proposed for release can be commented as shown
+on `<https://github.com/features/#code-review>`_
 
 If you would like to include other users beyond just the branch owner in
 the discussion, you can use a twitter-style name to invite them


### PR DESCRIPTION
Fixes https://ci.openmicroscopy.org/job/CONTRIBUTING-merge-docs/ by adjusting GitHub code review link as found by @manics. Staged at http://www.openmicroscopy.org/site/support/contributing-staging/using-git.html#code-reviews-and-comments.