### PR TITLE
initial docs for, bin/omero fs mkdir

### DIFF
--- a/omero/sysadmins/cli/fs.txt
+++ b/omero/sysadmins/cli/fs.txt
@@ -353,3 +353,24 @@ For example
      Pixels     | 1499341282   | 34
      Annotation | 3000028      | 53
     (3 rows)
+
+Creating directories
+^^^^^^^^^^^^^^^^^^^^
+
+For directory creation in a Managed repository use :omerocmd:`fs mkdir`:
+this creates both the directory on the underlying filesystem and the
+corresponding entry in the OMERO server's database. The new directory
+will be owned by the :literal:`root` user and in the :literal:`user`
+group. The options available to this subcommand are:
+
+.. program:: omero fs mkdir
+
+.. option:: -h, --help
+
+    Display the help for this subcommand.
+
+.. option:: --parents
+
+    Ensure that the whole given path exists in the Managed repository.
+    Analogous to the common :command:`mkdir`'s :literal:`--parents`
+    option, originally simply :literal:`-p` in IEEE Std 1003.1-2008.

--- a/omero/sysadmins/repository-move.txt
+++ b/omero/sysadmins/repository-move.txt
@@ -153,5 +153,5 @@ configuration. An example of adjusting its usual default value is:
     bin/omero config set omero.fs.repo.path 'volume-B/%user%_%userId%//%year%-%month%/%day%/%time%'
 
 After the OMERO server is started then new imports should upload onto
-:file:`/mnt/omero/large-volume-B/`. At a later date further storage
+the new storage volume. At a later date further storage
 volumes may be added by using this same workflow.

--- a/omero/sysadmins/repository-move.txt
+++ b/omero/sysadmins/repository-move.txt
@@ -124,10 +124,10 @@ Extending the Managed Repository
 It is possible to leave the Managed Repository in place yet have newly
 imported image files stored on a different underlying storage volume.
 For example, if your :property:`omero.managed.dir` is set to
-:file:`/mnt/omero/ManagedRepository` and, as it fills, it would be
-better for future images to be imported onto
-:file:`/mnt/omero/large-volume-B/` then an OMERO administrator may use
-the :omerocmd:`fs mkdir` subcommand to properly set up a subdirectory in
+:file:`/mnt/omero/ManagedRepository` and, as that volume fills, it would
+be better for new imports to be stored elsewhere then an OMERO
+administrator may use the :omerocmd:`fs mkdir` subcommand to properly
+set up a subdirectory for that new volume in
 the existing Managed Repository:
 ::
 
@@ -135,14 +135,17 @@ the existing Managed Repository:
 
 This is the correct way to create
 :file:`/mnt/omero/ManagedRepository/volume-B` ready for new imports.
-When the OMERO server is not running, either mount the new storage
-volume directly at that mount point or create a symbolic link:
+The new storage volume may then be mounted at that mount point.
+Alternatively, if the volume is already mounted elsewhere, such as
+:file:`/mnt/omero/large-volume-B/`, then while the OMERO server is shut
+down you may create a corresponding symbolic link at
+:file:`/mnt/omero/ManagedRepository/volume-B`:
 ::
 
     rmdir /mnt/omero/ManagedRepository/volume-B
     ln -s /mnt/omero/large-volume-B /mnt/omero/ManagedRepository/volume-B
 
-Further, the :property:`omero.fs.repo.path` must be updated in the server
+In either case the :property:`omero.fs.repo.path` must be updated in the server
 configuration. An example of adjusting its usual default value is:
 ::
 

--- a/omero/sysadmins/repository-move.txt
+++ b/omero/sysadmins/repository-move.txt
@@ -153,5 +153,5 @@ configuration. An example of adjusting its usual default value is:
     bin/omero config set omero.fs.repo.path 'volume-B/%user%_%userId%//%year%-%month%/%day%/%time%'
 
 After the OMERO server is started then new imports should upload onto
-the new storage volume. At a later date further storage
-volumes may be added by using this same workflow.
+the new storage volume. At a later date further storage volumes may be
+added by using this same workflow.

--- a/omero/sysadmins/repository-move.txt
+++ b/omero/sysadmins/repository-move.txt
@@ -117,3 +117,37 @@ to ``/Volumes/imports/ManagedRepository``:
     If :property:`omero.managed.dir` is set then the Managed Repository and
     the OMERO data directory should be treated independently and thus be moved
     separately if necessary.
+
+Extending the Managed Repository
+--------------------------------
+
+It is possible to leave the Managed Repository in place yet have newly
+imported image files stored on a different underlying storage volume.
+For example, if your :property:`omero.managed.dir` is set to
+:file:`/mnt/omero/ManagedRepository` and, as it fills, it would be
+better for future images to be imported onto
+:file:`/mnt/omero/large-volume-B/` then an OMERO administrator may use
+the :omerocmd:`fs mkdir` subcommand to properly set up a subdirectory in
+the existing Managed Repository:
+::
+
+    bin/omero fs mkdir volume-B
+
+This is the correct way to create
+:file:`/mnt/omero/ManagedRepository/volume-B` ready for new imports.
+When the OMERO server is not running, either mount the new storage
+volume directly at that mount point or create a symbolic link:
+::
+
+    rmdir /mnt/omero/ManagedRepository/volume-B
+    ln -s /mnt/omero/large-volume-B /mnt/omero/ManagedRepository/volume-B
+
+Further, the :property:`omero.fs.repo.path` must be updated in the server
+configuration. An example of adjusting its usual default value is:
+::
+
+    bin/omero config set omero.fs.repo.path 'volume-B/%user%_%userId%//%year%-%month%/%day%/%time%'
+
+After the OMERO server is started then new imports should upload onto
+:file:`/mnt/omero/large-volume-B/`. At a later date further storage
+volumes may be added by using this same workflow.

--- a/omero/sysadmins/repository-move.txt
+++ b/omero/sysadmins/repository-move.txt
@@ -124,8 +124,8 @@ Extending the Managed Repository
 It is possible to leave the Managed Repository in place yet have newly
 imported image files stored on a different underlying storage volume.
 For example, if your :property:`omero.managed.dir` is set to
-:file:`/mnt/omero/ManagedRepository` and, as that volume fills, it would
-be better for new imports to be stored elsewhere then an OMERO
+:file:`/mnt/omero/ManagedRepository` then, as that volume fills, it
+would become better for new imports to be stored elsewhere. An OMERO
 administrator may use the :omerocmd:`fs mkdir` subcommand to properly
 set up a subdirectory for that new volume in the existing Managed
 Repository:

--- a/omero/sysadmins/repository-move.txt
+++ b/omero/sysadmins/repository-move.txt
@@ -127,8 +127,8 @@ For example, if your :property:`omero.managed.dir` is set to
 :file:`/mnt/omero/ManagedRepository` and, as that volume fills, it would
 be better for new imports to be stored elsewhere then an OMERO
 administrator may use the :omerocmd:`fs mkdir` subcommand to properly
-set up a subdirectory for that new volume in
-the existing Managed Repository:
+set up a subdirectory for that new volume in the existing Managed
+Repository:
 ::
 
     bin/omero fs mkdir volume-B
@@ -140,6 +140,7 @@ Alternatively, if the volume is already mounted elsewhere, such as
 :file:`/mnt/omero/large-volume-B/`, then while the OMERO server is shut
 down you may create a corresponding symbolic link at
 :file:`/mnt/omero/ManagedRepository/volume-B`:
+
 ::
 
     rmdir /mnt/omero/ManagedRepository/volume-B


### PR DESCRIPTION
Introduces some initial minimal documentation for the `bin/omero fs mkdir` command introduced in https://github.com/openmicroscopy/openmicroscopy/pull/5205 as part of https://trello.com/c/aKMV6KJI/24-bug-fs-symlink-strategy-fails.

Staged at http://www.openmicroscopy.org/site/support/omero5.3-staging/sysadmins/repository-move.html#extending-the-managed-repository and http://www.openmicroscopy.org/site/support/omero5.3-staging/sysadmins/cli/fs.html#creating-directories.