### PR TITLE
remove confusing note from model docs

### DIFF
--- a/omero/developers/Model.txt
+++ b/omero/developers/Model.txt
@@ -443,9 +443,6 @@ users do not simultaneously edit the same object. That works so:
 Identity and versioning make working with the object model difficult
 sometimes, but guarantee that our data is never corrupted.
 
-.. note:: 
-    There is one exception to this discussed below under :ref:`Model#Links`. 
-
 
 Working with the object model
 -----------------------------


### PR DESCRIPTION
See https://trello.com/c/UUeRZdAs/674-confusing-note-in-model-docs. Staged at https://www.openmicroscopy.org/site/support/omero5.3-staging/developers/Model.html.