### PR TITLE
remove pytest markers

### DIFF
--- a/omero/developers/testing.txt
+++ b/omero/developers/testing.txt
@@ -245,15 +245,15 @@ the integration tests marked as ``broken``:
 
     ./build.py -f components/tools/OmeroPy/build.xml integration -DMARK=broken
 
-By default tests marked as ``long_running`` and ``broken`` are excluded and so
+By default tests marked as ``broken`` are excluded so
 the following two builds are equivalent:
 
 ::
 
     ./build.py -f components/tools/OmeroPy/build.xml integration
-    ./build.py -f components/tools/OmeroPy/build.xml integration -DMARK="not (long_running or broken)"
+    ./build.py -f components/tools/OmeroPy/build.xml integration -DMARK="not broken"
 
-In order to run **all** tests, including ``long_running`` and ``broken``,
+In order to run **all** tests, including ``broken``,
 an empty marker must be used:
 
 ::
@@ -307,9 +307,9 @@ to rebuild or restart the server. A few basic options are shown below.
     decorated with. Available markers can be listed using the
     :option:`--markers` option.
     For example, to run all integration tests excluding those decorated with
-    the marker `long_running`::
+    the marker `broken`::
 
-        ./setup.py test -t test/integration -m "not long_running"
+        ./setup.py test -t test/integration -m "not broken"
 
 .. option:: --markers
 
@@ -480,13 +480,9 @@ To view all available markers the :option:`--markers` option can be used with
 :program:`setup.py test` or :program:`py.test` as detailed in
 :ref:`running-python-tests-directly`.
 
-There are a small number of custom markers defined:
+There is one custom marker defined:
 
 .. glossary::
-
-    `long_running`
-        Used to mark tests as long running. These are tests that typically take
-        10 minutes or more and are excluded from the daily integration builds.
 
     `broken`
         Used to mark broken tests. These are tests that fail consistently with no
@@ -494,12 +490,6 @@ There are a small number of custom markers defined:
         and instead are run in a separate daily build. `broken` markers should have a
         reason, an associated Trac ticket number or both. If there are multiple
         associated tickets then a comma-separated list should be used.
-
-    `intermittent`
-        Used to mark tests that fail intermittently. `intermittent` markers should
-        have a reason, an associated Trac ticket number or both. If there are
-        multiple associated tickets then a comma-separated list should be used. Tests
-        marked as intermittent are included in the daily integration builds.
 
 ::
 
@@ -510,14 +500,6 @@ There are a small number of custom markers defined:
       @pytest.mark.broken(reason="Asserting false", ticket="12345,67890")
       def testBroken():
           assert False, "Bound to fail"
-
-      @pytest.mark.long_running
-      def testLongRunning():
-          self.somePotentiallyLongCall()
-
-      @pytest.mark.intermittent(reason="Occasionally times out", ticket="98765")
-      def testIntermittent():
-          self.somePotentiallyIntermittentCall()
 
 Using the Python test library
 """""""""""""""""""""""""""""


### PR DESCRIPTION
https://github.com/openmicroscopy/openmicroscopy/pull/5299 removes the `intermittent` and `long_running` custom pytest markers: they are now hardly used. Staged at http://www.openmicroscopy.org/site/support/omero5.3-staging/developers/testing.html.