### PR TITLE
open_with update warning

### DIFF
--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -107,16 +107,13 @@ so that the app is available from the context menu on the webclient tree::
 Updating 'Open with' config
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The default ``Open with`` configuration changed in OMERO 5.3.3 so that
-``Open with > Image Viewer`` *always* uses the ``webgateway`` image viewer instead of
-using the viewer configured by :property:`omero.web.viewer.view`.
-However, the new default ``Open with`` configuration will be ignored if you have previously
-appended any new items to it, since the whole ``open_with`` list
-will then be stored in ``etc/grid/config.xml``.
-
 If you have configured :property:`omero.web.open_with` prior to OMERO 5.3.3 and
-you wish to ensure that ``Open with > Image Viewer`` uses the ``webgateway`` viewer,
-you need to manually update ``open_with`` as
+also set the default viewer with :property:`omero.web.viewer.view`, for example
+as described for `OMERO.iviewer <https://pypi.python.org/pypi/omero-iviewer>`_
+then you will find that ``Open with > Image Viewer`` also opens the OMERO.iviewer
+instead of the ``webgateway`` viewer.
+
+To fix this, you need to manually update ``open_with`` as
 `described on this PR <https://github.com/openmicroscopy/openmicroscopy/pull/5317/>`_.
 
 Memoization files invalidation

--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -108,17 +108,16 @@ Updating 'Open with' config
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The default ``Open with`` configuration changed in OMERO 5.3.3 so that
-``Open with > Image Viewer`` *always* uses the old ``webgateway`` image viewer instead of
+``Open with > Image Viewer`` *always* uses the ``webgateway`` image viewer instead of
 using the viewer configured by :property:`omero.web.viewer.view`.
 However, the new default ``Open with`` configuration will be ignored if you have previously
 appended any new items to it, since the whole ``open_with`` list
-will then be stored in /etc/grid.xml.
+will then be stored in ``etc/grid/config.xml``.
 
 If you have configured :property:`omero.web.open_with` prior to OMERO 5.3.3 and
-you wish to have the old ``webgateway`` viewer available via ``Open with > Image Viewer``
-when the :property:`omero.web.viewer.view` is configured to a different viewer,
+you wish to ensure that ``Open with > Image Viewer`` uses the ``webgateway`` viewer,
 you need to manually update ``open_with`` as
-`described on the PR <https://github.com/openmicroscopy/openmicroscopy/pull/5317/>`_.
+`described on this PR <https://github.com/openmicroscopy/openmicroscopy/pull/5317/>`_.
 
 Memoization files invalidation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -104,7 +104,21 @@ so that the app is available from the context menu on the webclient tree::
     $ bin/omero config append omero.web.open_with '["omero_figure", "new_figure",
       {"supported_objects":["images"], "target": "_blank", "label": "OMERO.figure"}]'
 
+Updating 'Open with' config
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+The default ``Open with`` configuration changed in OMERO 5.3.3 so that
+``Open with > Image Viewer`` *always* uses the old ``webgateway`` image viewer instead of
+using the viewer configured by :property:`omero.web.viewer.view`.
+However, the new default ``Open with`` configuration will be ignored if you have previously
+appended any new items to it, since the whole ``open_with`` list
+will then be stored in /etc/grid.xml.
+
+If you have configured :property:`omero.web.open_with` prior to OMERO 5.3.3 and
+you wish to have the old ``webgateway`` viewer available via ``Open with > Image Viewer``
+when the :property:`omero.web.viewer.view` is configured to a different viewer,
+you need to manually update ``open_with`` as
+`described on the PR <https://github.com/openmicroscopy/openmicroscopy/pull/5317/>`_.
 
 Memoization files invalidation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/omero/sysadmins/server-upgrade.txt
+++ b/omero/sysadmins/server-upgrade.txt
@@ -113,8 +113,19 @@ as described for `OMERO.iviewer <https://pypi.python.org/pypi/omero-iviewer>`_
 then you will find that ``Open with > Image Viewer`` also opens the OMERO.iviewer
 instead of the ``webgateway`` viewer.
 
-To fix this, you need to manually update ``open_with`` as
-`described on this PR <https://github.com/openmicroscopy/openmicroscopy/pull/5317/>`_.
+To fix this, you need to update the ``Image Viewer`` option within
+your :property:`omero.web.open_with` config.
+
+The best way to do this without changing the ordering of the options is to
+``get`` the complete current config, edit the ``Image Viewer`` option, replacing
+``"webindex"`` with ``"webgateway"`` and then ``set`` this as the updated config::
+
+    $ bin/omero config get omero.web.open_with
+    [["Image viewer", "webindex", {"supported_objects": ["image"], "script_url": "we....
+
+    # Replace "webindex" with "webgateway" and paste everything back to set, within single quotes
+
+    $ bin/omero config set omero.web.open_with '[["Image viewer", "webgateway", {"supported_objects": ["image"], "scr....'
 
 Memoization files invalidation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
See discussion at https://github.com/openmicroscopy/openmicroscopy/pull/5317/
This PR describes the problem with previously-configured open_with overriding the new 'Image Viewer' config and links to the PR above for how to manually update.

cc @jburel. 