### PR TITLE
Improve backup recommendations

### DIFF
--- a/omero/sysadmins/server-backup-and-restore.txt
+++ b/omero/sysadmins/server-backup-and-restore.txt
@@ -64,6 +64,12 @@ OMERO.server has three main backup sources:
 
 .. warning:: You must back up *(1)* and *(2)* regularly.
 
+    Regular backups taken while the server is still running are usually
+    sufficient but you should be aware that they may not be consistent
+    snapshots. The **safest** course of action is to perform
+    backups during server downtime when possible, especially if you think you
+    may need the backup.
+
 You need to back up *(3)* only before you make changes. You can copy it into 
 ``/OMERO/backup`` to ensure it is kept safe::
 

--- a/omero/sysadmins/server-backup-and-restore.txt
+++ b/omero/sysadmins/server-backup-and-restore.txt
@@ -71,15 +71,15 @@ You need to back up *(3)* only before you make changes. You can copy it into
 Other backup sources
 """"""""""""""""""""
 
-If you have edited ``etc/grid/(win)default.xml`` directly for any
+If you have edited :file:`etc/grid/(win)default.xml` directly for any
 reason then you will also need to copy that file to somewhere safe, such
-as ``/OMERO/backup``.
+as :file:`/OMERO/backup`.
 
-The lib/scripts directory should also be backed up, but restoring it
+The :file:`lib/scripts` directory should also be backed up, but restoring it
 may pose issues if any of your users have added their own "official
 scripts". A github repository is available at
 `<https://github.com/ome/scripts>`_ which provides help for merging
-your lib/scripts directories.
+your scripts directories.
 
 .. _backup-and-restore_postgresql:
 
@@ -88,7 +88,7 @@ Backing up your PostgreSQL database
 
 Database backups can be achieved using the PostgreSQL ``pg_dump``
 command. Here is an example backup script that can be placed in
-``/etc/cron.daily`` to perform daily database backups::
+:file:`/etc/cron.daily` to perform daily database backups::
 
     #!/bin/bash
 
@@ -185,7 +185,7 @@ your configuration, you should follow the first two (*Create a
 non-superuser database user* and *Create a database for OMERO data to
 reside in*) steps of :doc:`unix/server-installation`. Once you have ensured
 that the database user and empty database exist, you can restore the
-``pg_dump`` file as follows::
+:file:`pg_dump` file as follows::
 
     $ sudo -u postgres pg_restore -Fc -d omero_database omero.2010-06-05_16:27:29-GMT.pg_dump
 

--- a/omero/sysadmins/server-backup-and-restore.txt
+++ b/omero/sysadmins/server-backup-and-restore.txt
@@ -55,30 +55,31 @@ OMERO.server has three main backup sources:
     (assumed to be :file:`/OMERO`)
 3.  OMERO.server configuration
 
-    .. note::
-        The lib/scripts directory should also be backed up, but restoring it 
-        may pose issues if any of your users have added their own "official 
-        scripts". A github repository is now available under 
-        `<https://github.com/ome/scripts>`_ which provides help for merging 
-        your lib/scripts directories.
-
 .. warning:: You must back up *(1)* and *(2)* regularly.
 
-    Regular backups taken while the server is still running are usually
-    sufficient but you should be aware that they may not be consistent
-    snapshots. The **safest** course of action is to perform
-    backups during server downtime when possible, especially if you think you
-    may need the backup.
+Regular backups taken while the server is still running are usually
+sufficient but you should be aware that they may not be consistent
+snapshots. The **safest** course of action is to perform
+backups during server downtime when possible, especially if you think you
+may need the backup.
 
 You need to back up *(3)* only before you make changes. You can copy it into 
 ``/OMERO/backup`` to ensure it is kept safe::
 
     $ bin/omero config get > /OMERO/backup/omero.config
 
-.. note::
-    If you have edited ``etc/grid/(win)default.xml`` directly for any
-    reason then you will also need to copy that file to somewhere safe, such
-    as ``/OMERO/backup``.
+Other backup sources
+""""""""""""""""""""
+
+If you have edited ``etc/grid/(win)default.xml`` directly for any
+reason then you will also need to copy that file to somewhere safe, such
+as ``/OMERO/backup``.
+
+The lib/scripts directory should also be backed up, but restoring it
+may pose issues if any of your users have added their own "official
+scripts". A github repository is available at
+`<https://github.com/ome/scripts>`_ which provides help for merging
+your lib/scripts directories.
 
 .. _backup-and-restore_postgresql:
 


### PR DESCRIPTION
See https://trello.com/c/hYTcCr5b/41-shut-down-server-for-backup

As well as adding in info about possibly shutting down your server to do the backups, I've tweaked the structure of this section too - the combination of warning and note boxes was a bit of a mess, it's hopefully clearer now!

Staged at https://www.openmicroscopy.org/site/support/omero5.3-staging/sysadmins/server-backup-and-restore.html#backing-up-omero