### PR TITLE
Debian9

### DIFF
--- a/omero/sysadmins/index.txt
+++ b/omero/sysadmins/index.txt
@@ -37,6 +37,7 @@ series of commands.
     unix/server-centos6-ice36
     unix/server-centos7-ice36
     unix/server-ubuntu-ice36
+    unix/server-debian9-ice36
     unix/server-install-homebrew
     unix/server-binary-repository
     unix/server-postgresql

--- a/omero/sysadmins/unix/server-debian9-ice36.txt
+++ b/omero/sysadmins/unix/server-debian9-ice36.txt
@@ -1,0 +1,147 @@
+OMERO.server installation on Debian 9
+=====================================
+
+This is an example walkthrough for installing OMERO on Debian 9, using
+a dedicated system user, and should be read in conjunction with
+:doc:`install-web`. You can use this as a guide
+for setting up your own test server. For production use you should also read
+the pages listed under :ref:`index-optimizing-server`.
+
+This guide describes how to install the **recommended** versions, not all
+the supported versions.
+This should be read in conjunction with :doc:`../version-requirements`.
+
+These instructions assume your Linux distribution is configured with a UTF-8
+locale (this is normally the default).
+
+For convenience in this walkthrough the main OMERO configuration options have
+been defined as environment variables. When following this walkthrough you can
+either use your own values, or alternatively source the following file:
+
+.. literalinclude:: walkthrough/settings.env
+   :start-after: Substitute
+
+:download:`settings.env <walkthrough/settings.env>`
+
+
+Installing prerequisites
+------------------------
+
+**The following steps are run as root.**
+
+Install Java 1.8, Ice 3.6 and PostgreSQL 9.6:
+
+To install Java 1.8 and other dependencies:
+
+.. literalinclude:: walkthrough/walkthrough_debian9.sh
+    :start-after: #start-step01
+    :end-before: # install Ice
+
+To install Ice 3.6:
+
+.. literalinclude:: walkthrough/walkthrough_debian9.sh
+    :start-after: #start-recommended-ice
+    :end-before: #end-recommended-ice
+
+To install PostgreSQL 9.6:
+
+.. literalinclude:: walkthrough/walkthrough_debian9.sh
+    :start-after: # install Postgres
+    :end-before: #end-step01
+
+Create an omero system user, and a directory for the OMERO repository:
+
+.. literalinclude:: walkthrough/walkthrough_debian9.sh
+    :start-after: #start-step02
+    :end-before: #end-step02
+
+Create a database user and initialize a new database for OMERO:
+
+.. literalinclude:: walkthrough/walkthrough_debian9.sh
+    :start-after: #start-step03
+    :end-before: #end-step03
+
+
+Installing OMERO.server
+-----------------------
+
+**The following steps are run as the omero system user.**
+
+Download, unzip and configure OMERO. The rest of this walkthrough assumes the
+OMERO.server is installed into the home directory of the omero system user.
+
+Note that this script requires the same environment variables that were set
+earlier in `settings.env`, so you may need to copy and/or source this file as
+the omero user.
+
+You will need to install the server corresponding to your Ice version.
+
+Install ``server-ice36.zip``:
+
+.. literalinclude:: walkthrough/walkthrough_debian9.sh
+    :start-after: #start-release-ice36
+    :end-before: #end-release-ice36
+
+Configure:
+
+.. literalinclude:: walkthrough/walkthrough_debian9.sh
+    :start-after: #end-release-ice36
+    :end-before: #end-step04
+
+Installing and running OMERO.web
+--------------------------------
+
+OMERO.web is deployed using Nginx, for more details on how to install
+and run the OMERO.web client
+see :doc:`install-web/walkthrough/omeroweb-install-ubuntu-ice3.6`.
+
+Running OMERO.server
+--------------------
+
+**The following steps are run as the omero system user.**
+
+OMERO should now be set up. To start the server run::
+
+    OMERO.server/bin/omero admin start
+
+In addition an `init.d` script is available should you wish to
+start OMERO automatically.
+
+| :download:`omero-init.d <walkthrough/omero-init.d>`
+
+
+Securing OMERO
+--------------
+
+**The following steps are run as root.**
+
+If multiple users have access to the machine running OMERO you should restrict
+access to OMERO.server's configuration and runtime directories, and optionally
+the OMERO data directory:
+
+.. literalinclude:: walkthrough/walkthrough_debian9.sh
+    :start-after: #start-step07
+    :end-before: #end-step07
+
+.. _linux_walkthrough_regular_tasks:
+
+Regular tasks
+-------------
+
+**The following steps are run as root.**
+
+The default OMERO.web session handler uses temporary files to store sessions
+which should be deleted at regular intervals, for instance by creating a cron
+job:
+
+.. literalinclude:: walkthrough/walkthrough_debian9.sh
+    :start-after: #start-omeroweb-cron
+    :end-before: #end-omeroweb-cron
+
+Copy the following commands into the appropriate location:
+
+.. literalinclude:: walkthrough/walkthrough_debian9.sh
+    :start-after: #start-copy-omeroweb-cron
+    :end-before: #end-copy-omeroweb-cron
+
+| :download:`omero-web-cron <walkthrough/omero-web-cron>`

--- a/omero/sysadmins/unix/server-debian9-ice36.txt
+++ b/omero/sysadmins/unix/server-debian9-ice36.txt
@@ -88,6 +88,50 @@ Configure:
     :start-after: #end-release-ice36
     :end-before: #end-step04
 
+Patching OMERO.server
+---------------------
+
+Weaker ciphers like ADH are disabled by default in OpenSSL 1.1.0,
+version installed on Debian 9.
+This means that it is not possible to connect to an OMERO.server
+using any OMERO clients e.g. the Java Desktop client,
+the OMERO.web client or the CLI.
+The parameter ``@SECLEVEL=0``, enabling the weaker ciphers, needs to be
+added in two files in order to allow connection.
+
+In ``OMERO.server/etc/templates/grid/templates.xml``,
+
+replace line ``108`` ::
+  
+  <property name="IceSSL.Ciphers" value="ADH"/>
+
+by ::
+    
+    <property name="IceSSL.Ciphers" value="ADH:@SECLEVEL=0"/>
+
+
+and line ``478`` ::
+  
+  <property name="IceSSL.Ciphers" value="ADH:!LOW:!MD5:!EXP:!3DES:@STRENGTH"/>
+
+by ::
+    
+    <property name="IceSSL.Ciphers" value="ADH:!LOW:!MD5:!EXP:!3DES:@STRENGTH:@SECLEVEL=0"/>
+
+
+In ``OMERO.server/lib/python/omero/clients.py``,
+
+depending on the Ice version used, replace line ``207`` (Ice 3.6) or ``209`` (Ice 3.5) ::
+
+    self._optSetProp(id, "IceSSL.Ciphers", "ADH")
+
+by ::
+
+    self._optSetProp(id, "IceSSL.Ciphers", "ADH:@SECLEVEL=0")
+
+and run ``python -m py_compile clients.py`` to recompile the file.
+
+
 Installing and running OMERO.web
 --------------------------------
 
@@ -123,7 +167,7 @@ the OMERO data directory:
     :start-after: #start-step07
     :end-before: #end-step07
 
-.. _linux_walkthrough_regular_tasks:
+.. _debian_walkthrough_regular_tasks:
 
 Regular tasks
 -------------

--- a/omero/sysadmins/unix/server-debian9-ice36.txt
+++ b/omero/sysadmins/unix/server-debian9-ice36.txt
@@ -92,7 +92,7 @@ Patching OMERO.server
 ---------------------
 
 Weaker ciphers like ADH are disabled by default in OpenSSL 1.1.0,
-version installed on Debian 9.
+the version installed on Debian 9.
 This means that it is not possible to connect to an OMERO.server
 using any OMERO clients e.g. the Java Desktop client,
 the OMERO.web client or the CLI.

--- a/omero/sysadmins/unix/server-debian9-ice36.txt
+++ b/omero/sysadmins/unix/server-debian9-ice36.txt
@@ -99,37 +99,11 @@ the OMERO.web client or the CLI.
 The parameter ``@SECLEVEL=0``, enabling the weaker ciphers, needs to be
 added in two files in order to allow connection.
 
-In ``OMERO.server/etc/templates/grid/templates.xml``,
+.. literalinclude:: walkthrough/walkthrough_debian9.sh
+    :start-after: #start-seclevel
+    :end-before: #end-seclevel
 
-replace line ``108`` ::
-  
-  <property name="IceSSL.Ciphers" value="ADH"/>
-
-by ::
-    
-    <property name="IceSSL.Ciphers" value="ADH:@SECLEVEL=0"/>
-
-
-and line ``478`` ::
-  
-  <property name="IceSSL.Ciphers" value="ADH:!LOW:!MD5:!EXP:!3DES:@STRENGTH"/>
-
-by ::
-    
-    <property name="IceSSL.Ciphers" value="ADH:!LOW:!MD5:!EXP:!3DES:@STRENGTH:@SECLEVEL=0"/>
-
-
-In ``OMERO.server/lib/python/omero/clients.py``,
-
-depending on the Ice version used, replace line ``207`` (Ice 3.6) or ``209`` (Ice 3.5) ::
-
-    self._optSetProp(id, "IceSSL.Ciphers", "ADH")
-
-by ::
-
-    self._optSetProp(id, "IceSSL.Ciphers", "ADH:@SECLEVEL=0")
-
-and run ``python -m py_compile clients.py`` to recompile the file.
+Run ``python -m py_compile OMERO.server/lib/python/omero/clients.py`` to recompile the file.
 
 
 Installing and running OMERO.web

--- a/omero/sysadmins/unix/server-installation.txt
+++ b/omero/sysadmins/unix/server-installation.txt
@@ -20,6 +20,10 @@ more specific walk-through listed below.
         Instructions for installing OMERO.server from scratch on
         Ubuntu 14.04 and Ubuntu 16.04 with Ice 3.6.
 
+    :doc:`server-debian9-ice36`
+        Instructions for installing OMERO.server from scratch on
+        Debian 9 with Ice 3.6.
+
     :doc:`server-install-homebrew`
         Instructions for installing and building OMERO.server on Mac
         OS X with Homebrew using our special formulas (i.e. from the


### PR DESCRIPTION
Add a new page for Debian 9 installation
Recent posts on the forum indicates that Debian 9 is used in various locations

The web section will need to be adjusted
This will require some changes to omeroweb-install

cc @mtbc 

https://trello.com/c/00CYQi2t/29-debian-installation-page

