### PR TITLE
Document how to disable unencrypted Ice connections

### DIFF
--- a/omero/sysadmins/server-security.txt
+++ b/omero/sysadmins/server-security.txt
@@ -190,6 +190,10 @@ all ports with 1, use :property:`omero.ports.prefix`::
 
     $ bin/omero config set omero.ports.prefix 1
 
+You can disable unencrypted connections by redirecting clients to the |SSL|
+port using the server property :property:`omero.router.insecure`::
+
+    $ bin/omero config set omero.router.insecure "OMERO.Glacier2/router:ssl -p 4064 -h @omero.host@"
 
 --------------
 


### PR DESCRIPTION
Based on internal discussions this is officially supported but not currently documented.

See also https://www.openmicroscopy.org/community/viewtopic.php?f=5&t=8252&p=18063#p18066

# Testing

1. Setup a normal OMERO.server but block port 4063 (e.g. with a firewall). Attempt a remote import, it should fail.
2. Set the configuration property described in this PR and restart the server.
3. A remote import should now work.