### PR TITLE
Removed usage of deleteObject method

### DIFF
--- a/omero/developers/Java.txt
+++ b/omero/developers/Java.txt
@@ -805,7 +805,7 @@ In the following example, we create an image and delete it.
     image.setDescription("descriptionImage1");
     IObject object = dm.saveAndReturnObject(ctx, image.asIObject());
 
-    Response rsp = dm.deleteObject(ctx, object);
+    Response rsp = dm.delete(ctx, object).loop(10, 500);
 
 Render Images
 -------------


### PR DESCRIPTION
`deleteObject` method was deprecated, and has been removed now. This PR also removes the usage of that method in the documentation.