### PR TITLE
tell sysadmins awkward CLI means to manage light admins

### DIFF
--- a/omero/sysadmins/cli/LightAdmins.txt
+++ b/omero/sysadmins/cli/LightAdmins.txt
@@ -26,27 +26,37 @@ administrator restrictions in the awkward manner described hereunder.
 View an administrator's restrictions
 ------------------------------------
 
-For an administrator with user ID 123, :omerocmd:`hql "SELECT ap.name
-FROM Experimenter user JOIN user.config AS ap WHERE user.id = 123 AND
-ap.name LIKE 'AdminPrivilege:%' AND LOWER(ap.value) <> 'true' ORDER BY
-ap.name"` lists their applicable restrictions such that the
-administrator may *not* exercise privileges for that operation.
+For an administrator with user ID 123,
+
+.. code-block:: shell
+
+  $ bin/omero hql "SELECT ap.name FROM Experimenter user JOIN user.config AS ap WHERE user.id = 123 AND ap.name LIKE 'AdminPrivilege:%' AND LOWER(ap.value) <> 'true' ORDER BY ap.name"
+
+lists their applicable restrictions such that the administrator may
+*not* exercise privileges for that operation.
 
 
 Set a restriction on an administrator
 -------------------------------------
 
-For an administrator with user ID 123, :omerocmd:`obj map-set
-Experimenter:123 config AdminPrivilege:SomePrivilege false` restricts
-them so that they may no longer exercise `SomePrivilege`.
+For an administrator with user ID 123,
 
+.. code-block:: shell
+
+  $ bin/omero obj map-set Experimenter:123 config AdminPrivilege:SomePrivilege false
+
+restricts them so that they may no longer exercise `SomePrivilege`.
 
 Clear a restriction from an administrator
 -----------------------------------------
 
-For an administrator with user ID 123, :omerocmd:`obj map-set
-Experimenter:123 config AdminPrivilege:SomePrivilege true` removes a
-restriction so that they may exercise `SomePrivilege`.
+For an administrator with user ID 123,
+
+.. code-block:: shell
+
+  $ bin/omero obj map-set Experimenter:123 config AdminPrivilege:SomePrivilege true
+
+removes a restriction so that they may exercise `SomePrivilege`.
 
 .. note::
 

--- a/omero/sysadmins/cli/LightAdmins.txt
+++ b/omero/sysadmins/cli/LightAdmins.txt
@@ -1,11 +1,13 @@
 Adjusting administrator restrictions
 ====================================
 
-OMERO 5.4 introduced the concept of a restricted administrator. These
-and each of the specific permissions restrictions are described in
-:doc:`/developers/Server/LightAdmins`. OMERO.web offers easy management
-of restrictions and is recommended for setting up restricted
-administrators via its :help:`Admin tab <facility-manager#lightadmin>`.
+OMERO 5.4 introduced the concept of a :doc:`restricted administrator
+<../admins-with-restricted-privileges>`. The meaning and representation
+of the server's underlying permissions restrictions is described in
+:doc:`developer documentation</developers/Server/LightAdmins>`.
+OMERO.web offers easy management of restrictions and is recommended for
+setting up restricted administrators via its :help:`Admin tab
+<facility-manager#lightadmin>`.
 
 OMERO.cli does not offer easy management of restrictions because support
 is yet to be added. In the meantime it can already manipulate

--- a/omero/sysadmins/cli/LightAdmins.txt
+++ b/omero/sysadmins/cli/LightAdmins.txt
@@ -1,5 +1,3 @@
-:orphan:
-
 Adjusting administrator restrictions
 ====================================
 

--- a/omero/sysadmins/cli/LightAdmins.txt
+++ b/omero/sysadmins/cli/LightAdmins.txt
@@ -16,11 +16,11 @@ administrator restrictions in the awkward manner described hereunder.
 .. warning::
 
   OMERO.web provides a simplified view of the available restrictions:
-  checking *one* box in the web interface may lift *multiple*
-  underlying restrictions from the administrator. The recommended OMERO.web management
-  interface may thus prove confusing if OMERO.cli has been used to set a
-  combination of restrictions that does not correspond to those bundles
-  of related restrictions available in OMERO.web.
+  checking *one* box in the web interface may lift *multiple* underlying
+  restrictions from the administrator. The recommended OMERO.web
+  management interface may thus prove confusing if OMERO.cli has been
+  used to set a combination of restrictions that does not correspond to
+  those bundles of related restrictions available in OMERO.web.
 
 
 View an administrator's restrictions

--- a/omero/sysadmins/cli/LightAdmins.txt
+++ b/omero/sysadmins/cli/LightAdmins.txt
@@ -1,0 +1,61 @@
+:orphan:
+
+Adjusting administrator restrictions
+====================================
+
+OMERO 5.4 introduced the concept of a restricted administrator. These
+and each of the specific permissions restrictions are described in
+:doc:`/developers/Server/LightAdmins`. OMERO.web offers easy management
+of restrictions and is recommended for setting up restricted
+administrators via its :help:`Admin tab <facility-manager#lightadmin>`.
+
+OMERO.cli does not offer easy management of restrictions because support
+is yet to be added. In the meantime it can already manipulate
+administrator restrictions in the awkward manner described hereunder.
+
+.. warning::
+
+  OMERO.web provides a simplified view of the available restrictions:
+  *one* checkbox offered in the web interface may represent *multiple*
+  underlying restrictions. The recommended OMERO.web management
+  interface may thus prove confusing if OMERO.cli has been used to set a
+  combination of restrictions that does not correspond to those bundles
+  of related restrictions available in OMERO.web.
+
+
+View an administrator's restrictions
+------------------------------------
+
+For an administrator with user ID 123, :omerocmd:`hql "SELECT ap.name
+FROM Experimenter user JOIN user.config AS ap WHERE user.id = 123 AND
+ap.name LIKE 'AdminPrivilege:%' AND LOWER(ap.value) <> 'true' ORDER BY
+ap.name"` lists their applicable restrictions such that the
+administrator may *not* exercise privileges for that operation.
+
+
+Set a restriction on an administrator
+-------------------------------------
+
+For an administrator with user ID 123, :omerocmd:`obj map-set
+Experimenter:123 config AdminPrivilege:SomePrivilege false` restricts
+them so that they may no longer exercise `SomePrivilege`.
+
+
+Clear a restriction from an administrator
+-----------------------------------------
+
+For an administrator with user ID 123, :omerocmd:`obj map-set
+Experimenter:123 config AdminPrivilege:SomePrivilege true` removes a
+restriction so that they may exercise `SomePrivilege`.
+
+.. note::
+
+  You may not clear a restriction from an administrator if you have that
+  same restriction applying to yourself.
+
+.. warning::
+
+  Never clear `AdminPrivilege:ReadSession` from a restricted
+  administrator unless clearing *all* their restrictions to make them
+  into a full administrator. No restricted administrator should be able
+  to read all OMERO sessions.

--- a/omero/sysadmins/cli/LightAdmins.txt
+++ b/omero/sysadmins/cli/LightAdmins.txt
@@ -17,7 +17,7 @@ administrator restrictions in the awkward manner described hereunder.
 
   OMERO.web provides a simplified view of the available restrictions:
   checking *one* box in the web interface may lift *multiple* underlying
-  restrictions from the administrator. The recommended OMERO.web
+  restrictions from an administrator. The recommended OMERO.web
   management interface may thus prove confusing if OMERO.cli has been
   used to set a combination of restrictions that does not correspond to
   those bundles of related restrictions available in OMERO.web.

--- a/omero/sysadmins/cli/LightAdmins.txt
+++ b/omero/sysadmins/cli/LightAdmins.txt
@@ -16,8 +16,8 @@ administrator restrictions in the awkward manner described hereunder.
 .. warning::
 
   OMERO.web provides a simplified view of the available restrictions:
-  *one* checkbox offered in the web interface may represent *multiple*
-  underlying restrictions. The recommended OMERO.web management
+  checking *one* box in the web interface may lift *multiple*
+  underlying restrictions from the administrator. The recommended OMERO.web management
   interface may thus prove confusing if OMERO.cli has been used to set a
   combination of restrictions that does not correspond to those bundles
   of related restrictions available in OMERO.web.

--- a/omero/sysadmins/cli/index.txt
+++ b/omero/sysadmins/cli/index.txt
@@ -13,6 +13,7 @@ need.
     config
     admin
     usergroup
+    LightAdmins
     fs
 
 .. seealso::

--- a/omero/sysadmins/cli/usergroup.txt
+++ b/omero/sysadmins/cli/usergroup.txt
@@ -22,6 +22,12 @@ enter::
 Additional parameters such as the email address, institution, middle name etc
 can be passed as optional arguments to the :omerocmd:`user add` command.
 
+For managing the permissions of restricted administrators
+:doc:`OMERO.cli does provide means <LightAdmins>` but that functionality
+is not yet offered in a friendly manner by the :omerocmd:`user` command.
+The :help:`OMERO.web Admin interface <facility-manager#lightadmin>` is
+recommended for this task instead.
+
 If you are using ldap as an authentication backend, you can create
 an OMERO user account for jsmith using the :omerocmd:`ldap create` command,
 which allows the administrator to add jsmith to an OMERO group, before they


### PR DESCRIPTION
This new page omero/sysadmins/cli/LightAdmins.html explains how light administrator privileges can be manipulated from the CLI. It is brief and uninviting because we don't recommend this approach and soon we should be able to provide a better CLI means via `bin/omero user ...` or somesuch but if need be we can point people to this summary how-to in the meantime if its warnings don't scare them off. See https://trello.com/c/iZeXX5FD/6-manage-admin-privileges-from-cli for more background.