### PR TITLE
Improve description of pixeldata properties

### DIFF
--- a/omero/sysadmins/config.txt
+++ b/omero/sysadmins/config.txt
@@ -1180,12 +1180,22 @@ Default: `pixelDataEventLogQueue`
 omero.pixeldata.max_plane_height
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+With :property:`omero.pixeldata.max_plane_width` specifies
+the plane size cutoff above which a pixel pyramid should
+either be read directly from the file format or generated
+by the pixeldata service.
+
 Default: `3192`
 
 .. property:: omero.pixeldata.max_plane_width
 
 omero.pixeldata.max_plane_width
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+With :property:`omero.pixeldata.max_plane_height` specifies
+the plane size cutoff above which a pixel pyramid should
+either be read directly from the file format or generated
+by the pixeldata service.
 
 Default: `3192`
 


### PR DESCRIPTION
See http://lists.openmicroscopy.org.uk/pipermail/ome-users/2017-July/006561.html

This PR aims at explaining the intent of the `omero.pixeldata.max_plane_{width,height}` configuration properties.

Opened initially against ome-documentation to review the wording. Next this should be properly opened against `etc/omero.properties`.