### PR TITLE
Contributing documentation: add WWW-merge

### DIFF
--- a/contributing/ci-docs.txt
+++ b/contributing/ci-docs.txt
@@ -284,7 +284,7 @@ The following set of jobs are used to review or publish the content of the
 		This job is used to review the PRs opened against the master branch of
 		https://github.com/openmicroscopy/www.openmicroscopy.org
 
-		#. |merge| and push the branch to https://github.com/snoopycrimecop/www.openmicroscopy.org/tree/gh-pages
+		#. |merge| and pushes the branch to https://github.com/snoopycrimecop/www.openmicroscopy.org/tree/gh-pages
 		#. The GitHub pages deploys the staging website content under http://snoopycrimecop.github.io/www.openmicroscopy.org/
 
 	:jenkinsjob:`OME-help-staging`

--- a/contributing/ci-docs.txt
+++ b/contributing/ci-docs.txt
@@ -274,7 +274,7 @@ located in the ome-model repository and is built from the master branch.
 Jekyll websites
 ^^^^^^^^^^^^^^^
 
-The following set of jobs are used to review or publish the content of the
+The following set of jobs is used to review or publish the content of the
 :doc:`OME Jekyll websites <jekyll>`.
 
 .. glossary::
@@ -285,7 +285,7 @@ The following set of jobs are used to review or publish the content of the
 		https://github.com/openmicroscopy/www.openmicroscopy.org
 
 		#. |merge| and pushes the branch to https://github.com/snoopycrimecop/www.openmicroscopy.org/tree/gh-pages
-		#. The GitHub pages deploys the staging website content under http://snoopycrimecop.github.io/www.openmicroscopy.org/
+		#. The GitHub Pages service deploys the staging website content under http://snoopycrimecop.github.io/www.openmicroscopy.org/
 
 	:jenkinsjob:`OME-help-staging`
 

--- a/contributing/ci-docs.txt
+++ b/contributing/ci-docs.txt
@@ -8,30 +8,25 @@ tab of Jenkins.
 	:header-rows: 1
 
 	-	* Job task
-		* OMERO 5.2.x series
-		* OMERO 5.4.x series
+		* OMERO 5.x series
 
 	-	* Builds the latest OMERO documentation for publishing
-		* :term:`OMERO-5.2-latest-docs`
 		* :term:`OMERO-DEV-latest-docs`
 
 	-	* Builds the OMERO documentation for review
-		* :term:`OMERO-5.2-merge-docs`
 		* :term:`OMERO-DEV-merge-docs`
 
 	-	* Builds the auto-generated OMERO documentation
-		*
 		* :term:`OMERO-DEV-latest-docs-autogen`
 
 	-	* Builds the auto-generated OMERO documentation for review
-		*
 		* :term:`OMERO-DEV-merge-docs-autogen`
 
 .. list-table::
 	:header-rows: 1
 
 	-	* Job task
-		* Bio-Formats 5.3.x series
+		* Bio-Formats 5.x series
 
 	-	* Builds the latest Bio-Formats documentation for publishing
 		* :term:`BIOFORMATS-DEV-latest-docs`
@@ -123,41 +118,10 @@ are then used:
 - for the Bio-Formats and OMERO sets of documentation, the name of the
   Jenkins job is set by :envvar:`JENKINS_JOB`.
 
-OMERO 5.2.x series
-^^^^^^^^^^^^^^^^^^
+OMERO 5.x series
+^^^^^^^^^^^^^^^^
 
-The branch for the 5.2.x series of the OMERO documentation is dev_5_2.
-
-.. glossary::
-
-	:jenkinsjob:`OMERO-5.2-latest-docs`
-
-		This job is used to build the dev_5_2 branch of the OMERO
-		documentation and publish the official documentation for the 5.2.x
-		release of OMERO
-
-		#. |sphinxbuild|
-		#. |linkcheck|
-		#. If the build is promoted,
-			#. |ssh-doc| :file:`omero-5.2-release.tmp`
-			#. |deploy-doc| http://www.openmicroscopy.org/site/support/omero5.2/
-
-
-	:jenkinsjob:`OMERO-5.2-merge-docs`
-
-		This job is used to review the PRs opened against the dev_5_2 branch
-		of the OMERO documentation
-
-		#. |merge|
-		#. |sphinxbuild|
-		#. |linkcheck|
-		#. |ssh-doc| :file:`omero-5.2-staging.tmp`
-		#. |deploy-doc| http://www.openmicroscopy.org/site/support/omero5.2-staging/
-
-OMERO 5.4.x series
-^^^^^^^^^^^^^^^^^^
-
-The branch for the 5.4.x series of the OMERO documentation is develop.
+The branch for the 5.x series of the OMERO documentation is develop.
 
 .. glossary::
 
@@ -205,7 +169,7 @@ The branch for the 5.4.x series of the OMERO documentation is develop.
 		   :omedoc_scc_branch:`develop/merge/autogen`
 
 Bio-Formats 5.x series
-^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^
 
 The branch for the 5.x series of the Bio-Formats documentation is develop.
 

--- a/contributing/ci-docs.txt
+++ b/contributing/ci-docs.txt
@@ -77,11 +77,20 @@ the help builds.
 	-	* Job task
 		*
 
-	-	* Review Figure website PRs
+	-	* Review PRs opened against the OME Website
+		* :term:`WWW-merge`
+
+	-	* Review PRs opened against the OMERO.figure website
 		* :term:`FIGURE-help-staging`
 
-	-	* Publish Figure website
-		* :term:`FIGURE-help-release`
+	-	* Publish the OMERO.figure website
+		* :term:`FIGURE-help-staging`
+
+	-	* Review PRs opened against the OME help website
+		* :term:`OME-help-staging`
+
+	-	* Publish the OME help website
+		* :term:`OME-help-release`
 
 OME Files comprises OME Files C++ and OME CMake Super-Build Sphinx manuals,
 which are taken from separate repositories but built and hosted as a bundle.
@@ -262,25 +271,32 @@ located in the ome-model repository and is built from the master branch.
 		#. |sphinxbuild|
 		#. |linkcheck|
 
-OME Help
-^^^^^^^^
+Jekyll websites
+^^^^^^^^^^^^^^^
 
-The repository for the OME help is https://github.com/openmicroscopy/ome-help.
+The following set of jobs are used to review or publish the content of the
+:doc:`OME Jekyll websites <jekyll>`.
 
 .. glossary::
+
+	:jenkinsjob:`WWW-merge`
+
+		This job is used to review the PRs opened against the master branch of
+		https://github.com/openmicroscopy/www.openmicroscopy.org
+
+		#. |merge| and push the branch to https://github.com/snoopycrimecop/www.openmicroscopy.org/tree/gh-pages
+		#. The GitHub pages deploys the staging website content under http://snoopycrimecop.github.io/www.openmicroscopy.org/
 
 	:jenkinsjob:`OME-help-staging`
 
 		This job is used to review the PRs opened against the master branch
-		of the OME help documentation
+		of https://github.com/openmicroscopy/ome-help
 
 		#. |merge| (and also incorporates :omehelp_scc_branch:`cname_staging`
 		   to allow	 deployment to a non-GitHub URL) then pushes the resulting
 		   branch to :omehelp_scc_branch:`gh-pages`
 		#. The GitHub Pages service updates the content of
 		   http://help.staging.openmicroscopy.org
-
-		.. seealso:: :doc:`jekyll`
 
 	:jenkinsjob:`OME-help-release`
 
@@ -295,25 +311,16 @@ The repository for the OME help is https://github.com/openmicroscopy/ome-help.
 			#. rysnc the content of :file:`/ome/data_repo/public/help-staging`
 			   to :file:`/ome/data_repo/public/help`
 
-OMERO.figure website
-^^^^^^^^^^^^^^^^^^^^
-
-The repository for OMERO.figure is https://github.com/ome/omero-figure.
-
-.. glossary::
-
 	:jenkinsjob:`FIGURE-help-staging`
 
 		This job is used to review the PRs opened against the gh-pages-staging
-		branch of figure repository
+		branch of https://github.com/ome/omero-figure.
 
 		#. |merge| (and also incorporates :figure_scc_branch:`cname_staging` to
 		   allow  deployment to a non-GitHub URL) then pushes the resulting
 		   branch to :figure_scc_branch:`gh-pages`
 		#. The GitHub Pages service updates the content of
 		   http://figure.staging.openmicroscopy.org
-
-		.. seealso:: :doc:`jekyll`
 
 	:jenkinsjob:`FIGURE-help-release`
 
@@ -324,7 +331,6 @@ The repository for OMERO.figure is https://github.com/ome/omero-figure.
 		   to https://github.com/ome/omero-figure/tree/gh-pages. If
 		   this PR is merged, the GitHub Pages service updates the content of
 		   http://figure.openmicroscopy.org
-
 
 OME Files
 ^^^^^^^^^

--- a/contributing/jekyll.txt
+++ b/contributing/jekyll.txt
@@ -1,11 +1,13 @@
 Jekyll hosted websites
 ======================
 
-A number of OME websites are produced using Jekyll, including
+A number of OME websites are produced using `Jekyll <http://jekyllrb.com/>`_,
+including:
 
-- `Blog <http://blog.openmicroscopy.org/>`_
-- `Help <http://help.openmicroscopy.org/>`_
-- `Figure <http://figure.openmicroscopy.org/>`_
+- the `OME website <https://www.openmicroscopy.org/>`_
+- the `OME blog <http://blog.openmicroscopy.org/>`_
+- the `OME Help <http://help.openmicroscopy.org/>`_
+- the `OMERO.figure website <http://figure.openmicroscopy.org/>`_
 
 These sites can be built and tested by installing a local copy of Jekyll.
 The help and Figure sites are also built by CI jobs, see :doc:`ci-docs`.


### PR DESCRIPTION
The main purpose of this PR is to add the CI job allowing to integrate and review the PRs opened against the OME website. The page about the Jekyll websites is also modified to include the new website.

To test this PR, review the new WWW-merge entry.