### PR TITLE
add note about needing mock module for tables tests

### DIFF
--- a/omero/sysadmins/server-tables.txt
+++ b/omero/sysadmins/server-tables.txt
@@ -80,6 +80,16 @@ After that, the following should succeed:
     Detected cores:    8
     …
 
+.. note::
+
+  If the above test fails with::
+
+    ImportError: No module named mock
+
+  then this is fixed by installing the corresponding Python module::
+
+    pip install mock
+
 Once the required Python libraries are installed, starting OMERO will
 automatically start up the OMERO.tables service; there should be no need
 for further configuration or interaction.

--- a/omero/sysadmins/server-tables.txt
+++ b/omero/sysadmins/server-tables.txt
@@ -86,7 +86,9 @@ After that, the following should succeed:
 
     ImportError: No module named mock
 
-  then this is fixed by installing the corresponding Python module::
+  then this is fixed by installing the corresponding Python module. Use
+  your operating system's package installer if possible or if you must
+  instead use PyPI directly::
 
     pip install mock
 


### PR DESCRIPTION
Says what to do if `tables.test()` fails with the mock error. Cc: @bramalingam.