### PR TITLE
Improve accuracy of logback.xml reload explanation

### DIFF
--- a/omero/developers/logging.txt
+++ b/omero/developers/logging.txt
@@ -32,7 +32,9 @@ Java servers
 Java server components are configured by passing
 ``-Dlogback.configurationFile=etc/logback.xml`` to each Java process.
 :source:`logback.xml <etc/logback.xml>` includes the ``scan`` attribute so
-that changes to the logging configuration do not require a restart.
+that changes to the logging configuration are `automatically reloaded at
+regular intervals
+<https://logback.qos.ch/manual/configuration.html#autoScan>`_.
 
 By default, the output from logback is sent to:
 ``var/log/<servername>.log``. Once files reach a size of 500MB, they are

--- a/omero/developers/logging.txt
+++ b/omero/developers/logging.txt
@@ -31,10 +31,8 @@ Java servers
 
 Java server components are configured by passing
 ``-Dlogback.configurationFile=etc/logback.xml`` to each Java process.
-:source:`Entry.java <components/blitz/src/ome/services/blitz/Entry.java>`
-guarantees that the :source:`logback.xml <etc/logback.xml>`
-file is read periodically so that changes to your logging configuration
-do not require a restart.
+:source:`logback.xml <etc/logback.xml>` includes the ``scan`` attribute so
+that changes to the logging configuration do not require a restart.
 
 By default, the output from logback is sent to:
 ``var/log/<servername>.log``. Once files reach a size of 500MB, they are


### PR DESCRIPTION
The current docs say `Entry.java` automatically reloads the `logback.xml` config. As far as I can tell it's the `logback.xml` file itself that ensures it's automatically reloaded at regular intervals.