### PR TITLE
web install doc

### DIFF
--- a/omero/autogen_docs
+++ b/omero/autogen_docs
@@ -39,6 +39,7 @@ echo "Generating omeroweb install walkthrough"
 (cd $WORKSPACE/omeroweb-install && ansible-playbook ./.travis/../ansible/omeroweb-install-doc.yml -i ./.travis/../ansible/hosts/centos7-ice3.6 --extra-vars '{"os": "centos7", "ice_version": "3.6", "clean": True}')
 (cd $WORKSPACE/omeroweb-install && ansible-playbook ./.travis/../ansible/omeroweb-install-doc.yml -i ./.travis/../ansible/hosts/ubuntu-ice3.6 --extra-vars '{"os": "ubuntu", "ice_version": "3.6", "clean": True}')
 (cd $WORKSPACE/omeroweb-install && ansible-playbook ./.travis/../ansible/omeroweb-install-doc.yml -i ./.travis/../ansible/hosts/osx-ice3.6 --extra-vars '{"os": "osx", "ice_version": "3.6", "clean": True}')
+(cd $WORKSPACE/omeroweb-install && ansible-playbook ./.travis/../ansible/omeroweb-install-doc.yml -i ./.travis/../ansible/hosts/osx-ice3.6 --extra-vars '{"os": "debian", "ice_version": "3.6", "clean": True}')
 
 mv $WORKSPACE/omeroweb-install/ansible/doc/* $WORKSPACE/src/omero/sysadmins/unix/install-web/walkthrough
 


### PR DESCRIPTION
Generate install web doc for debian


See
https://trello.com/c/00CYQi2t/29-debian-installation-page

and https://github.com/ome/omeroweb-install/pull/17


To test:
 * Check that the correct value is used for the doc i.e. ``debian``
 * The doc generation will have already been tested by travis see https://github.com/ome/omeroweb-install/pull/17


