### PR TITLE
Link web install debian

### DIFF
--- a/omero/sysadmins/unix/install-web.txt
+++ b/omero/sysadmins/unix/install-web.txt
@@ -55,10 +55,15 @@ more specific walk-through listed below.
         Instructions for installing OMERO.web from scratch on
         Ubuntu 16.04 with Ice 3.6.
 
+    :doc:`install-web/walkthrough/omeroweb-install-debian-ice3.6`
+        Instructions for installing OMERO.web from scratch on
+        Debian 9 with Ice 3.6.
+
     :doc:`install-web/walkthrough/omeroweb-install-osx-ice3.6`
         Instructions for installing OMERO.web from scratch on
         on Mac OS X with Homebrew. It is aimed at **developers**
         since typically MacOS X is not suited for serious deployment.
+
 
 .. toctree::
     :maxdepth: 1

--- a/omero/sysadmins/unix/install-web.txt
+++ b/omero/sysadmins/unix/install-web.txt
@@ -68,6 +68,7 @@ more specific walk-through listed below.
     install-web/walkthrough/omeroweb-install-centos7-ice3.6
     install-web/walkthrough/omeroweb-install-ubuntu-ice3.6
     install-web/walkthrough/omeroweb-install-osx-ice3.6
+    install-web/walkthrough/omeroweb-install-debian-ice3.6
 
 .. note:: Support for Apache deployment has been dropped in 5.3.0.
     

--- a/omero/sysadmins/unix/install-web/walkthrough/omeroweb-install-debian-ice3.6.txt
+++ b/omero/sysadmins/unix/install-web/walkthrough/omeroweb-install-debian-ice3.6.txt
@@ -1,0 +1,179 @@
+OMERO.web walkthrough installation Debian 9 and IcePy 3.6
+=========================================================
+
+
+For convenience in this walkthrough the main OMERO.web configuration options have been defined as environment variables. When following this walkthrough you can either use your own values, or alternatively source the following file::
+    
+    OMERO_USER=omero
+    WEBPORT=80
+    WEBSERVER_NAME=localhost
+
+
+
+Create local user omero, homedir :file:`/home/omero` (run as root)::
+    
+    if [ -z "$(getent passwd omero)" ]; then
+    
+        useradd -m omero
+    
+    fi
+    
+    chmod a+X /home/omero
+
+Install ZeroC IcePy 3.6. IcePy is managed by PyPI and will be installed as a part of OMERO.web requirements (run as root)::
+    
+    apt-get -y install libssl-dev libbz2-dev libmcpp-dev libdb++-dev libdb-dev libdb-java
+
+Install other dependencies (run as root)::
+    
+    apt-get update
+    apt-get -y install \
+        python-pip \
+        python-virtualenv
+    
+    
+    apt-get -y install \
+        python-pillow \
+        python-numpy
+    
+
+
+Install VirtualEnv - optional (run as root)::
+    
+    virtualenv /home/omero/omerowebvenv --system-site-packages
+
+Install OMERO.web (run as omero)::
+    
+    cd /home/omero
+    curl -o OMERO.py.zip -L https://downloads.openmicroscopy.org/latest/omero5.3/py.zip
+    unzip -q OMERO.py*
+    
+    zip=$(ls OMERO.py*.zip)
+    rm -f $zip
+    ln -s OMERO.py-* OMERO.py
+
+Install in the virtualenv created previously (run as root)::
+    
+    /home/omero/omerowebvenv/bin/pip install --upgrade -r /home/omero/OMERO.py/share/web/requirements-py27.txt
+
+Configure OMERO.web and generate nginx template (run as omero)::
+    
+    source /home/omero/omerowebvenv/bin/activate
+    # By default no value is set for WEBPREFIX but for example it can be set to /omero
+    if [[ $WEBPREFIX = *[!\ ]* ]]; then
+        /home/omero/OMERO.py/bin/omero config set omero.web.prefix "${WEBPREFIX}"
+        /home/omero/OMERO.py/bin/omero config set omero.web.static_url "${WEBPREFIX}/static/"
+    fi
+    
+    /home/omero/OMERO.py/bin/omero config set omero.web.application_server wsgi-tcp
+    /home/omero/OMERO.py/bin/omero web config nginx --http "${WEBPORT}" --servername "${WEBSERVER_NAME}" > /home/omero/nginx.conf.tmp
+    
+    cat /home/omero/nginx.conf.tmp
+
+Install NGINX (run as root)::
+    
+    #start-install
+    apt-get update
+    apt-get -y install nginx
+    
+    #end-install
+    sed -i.bak -re 's/( default_server.*)/; #\1/' /etc/nginx/nginx.conf
+    mv /etc/nginx/sites-available/default /etc/nginx/sites-available/default.disabled
+    cp /home/omero/nginx.conf.tmp /etc/nginx/conf.d/omeroweb.conf
+    
+    service nginx start
+
+
+Daemon (run as root)::
+    
+    Create a file omero-web-init.d. See example file below.
+    cp omero-web-init.d /etc/init.d/omero-web
+    chmod a+x /etc/init.d/omero-web
+    
+    update-rc.d -f omero-web remove
+    update-rc.d -f omero-web defaults 98 02
+    
+
+**omero-web-init.d** example::
+    
+    #!/bin/bash
+    #
+    # /etc/init.d/omero
+    # Subsystem file for "omero" server
+    #
+    ### BEGIN INIT INFO
+    # Provides:             omero-web
+    # Required-Start:       $local_fs $remote_fs $network $time omero postgresql
+    # Required-Stop:        $local_fs $remote_fs $network $time omero postgresql
+    # Default-Start:        2 3 4 5
+    # Default-Stop:         0 1 6
+    # Short-Description:    OMERO.web
+    ### END INIT INFO
+    #
+    ### Redhat
+    # chkconfig: - 98 02
+    # description: Init script for OMERO.web
+    ###
+    
+    RETVAL=0
+    prog=omero-web
+    
+    # Read configuration variable file if it is present
+    [ -r /etc/default/$prog ] && . /etc/default/$prog
+    
+    
+    OMERO_PY=${OMERO_PY:-/home/omero/OMERO.py}
+    OMERO_USER=${OMERO_USER:-omero}
+    OMERO=${OMERO_PY}/bin/omero
+    VENVDIR=${VENVDIR:-/home/omero/omerowebvenv}
+    
+    start() {
+        echo -n $"Starting $prog:"
+        su - ${OMERO_USER} -c "source $VENVDIR/bin/activate; ${OMERO} web start" &> /dev/null && echo -n ' OMERO.web'
+        sleep 5
+        ls $OMERO_PY/var/log
+        RETVAL=$?
+        [ "$RETVAL" = 0 ]
+            echo
+    }
+    
+    stop() {
+        echo -n $"Stopping $prog:"
+        su - ${OMERO_USER} -c "source $VENVDIR/bin/activate; ${OMERO} web stop" &> /dev/null && echo -n ' OMERO.web'
+        RETVAL=$?
+        [ "$RETVAL" = 0 ]
+            echo
+    }
+    
+    status() {
+        echo -n $"Status $prog:"
+        su - ${OMERO_USER} -c "source $VENVDIR/bin/activate; ${OMERO} web status"
+        RETVAL=$?
+    }
+    
+    case "$1" in
+        start)
+            start
+            ;;
+        stop)
+            stop
+            ;;
+        restart)
+            stop
+            start
+            ;;
+        status)
+            status
+            ;;
+        *)
+            echo $"Usage: $0 {start|stop|restart|status}"
+            RETVAL=1
+    esac
+    exit $RETVAL
+
+Start up services (run as root)::
+    
+    
+    cron
+    service nginx start
+    service omero-web start

--- a/omero/sysadmins/unix/server-debian9-ice36.txt
+++ b/omero/sysadmins/unix/server-debian9-ice36.txt
@@ -111,7 +111,7 @@ Installing and running OMERO.web
 
 OMERO.web is deployed using Nginx, for more details on how to install
 and run the OMERO.web client
-see :doc:`install-web/walkthrough/omeroweb-install-ubuntu-ice3.6`.
+see :doc:`install-web/walkthrough/omeroweb-install-debian-ice3.6`.
 
 Running OMERO.server
 --------------------

--- a/omero/users/history.txt
+++ b/omero/users/history.txt
@@ -1,11 +1,30 @@
 OMERO version history
 =====================
 
+5.4.0-m2 (July 2017)
+--------------------
+
+Developer preview release. Intended *only as a developer preview* for updating
+code before the full public release of 5.4.0. **Use at your own risk.**
+
+Changes include:
+
+- fixed OMERO.server permissions bug with restricted administrators
+- adjusted OMERO.blitz API to allow some query results to be cached
+- improve OMERO.web experience and fixed bugs for restricted administrators
+- improve OMERO.cli:
+  - fixed admin plugin so "cleanse" can handle larger directories
+  - have chgrp plugin check administrator Chgrp restriction
+  - added to chown plugin ability to target all of given users' data
+  - adjusted handling of standard input
+- various improvements in integration tests
+
+
 5.4.0-m1 (July 2017)
 --------------------
 
-Developer preview release - **only intended as a developer preview for
-updating code before the full public release of 5.4.0. Use at your own risk**.
+Developer preview release. Intended *only as a developer preview* for updating
+code before the full public release of 5.4.0. **Use at your own risk.**
 
 Changes include:
 


### PR DESCRIPTION
Point to installation instruction for web on debian 9

see https://trello.com/c/00CYQi2t/29-debian-installation-page

To test:

From debian installation page, check that the link for web installation points to the instructions for web on debian 9