### PR TITLE
Add doc for mapping of OMERO.web light admin UI to back end permissions

### DIFF
--- a/omero/sysadmins/index.txt
+++ b/omero/sysadmins/index.txt
@@ -18,6 +18,7 @@ Server Background
     limitations
     server-permissions
     admins-with-restricted-privileges
+    mapping-restricted-admins
 
 *******************
 Server Installation

--- a/omero/sysadmins/mapping-restricted-admins.txt
+++ b/omero/sysadmins/mapping-restricted-admins.txt
@@ -1,0 +1,48 @@
+Restricted administrators OMERO.web interface to server permissions mapping
+===========================================================================
+
+
+Summary
+-------
+
+OMERO allows you to create administrators with a subset of the full
+administrator privileges,
+see :doc:`/sysadmins/admins-with-restricted-privileges`.
+The OMERO.web user interface form for creation and editing of
+restricted administrators
+(see the :help:`create new users <sharing-data#admin>` section)
+collates the server-side privileges
+into fewer options and gives the options user friendly
+names. Here, the mapping of the OMERO.web options to the 
+server-side privileges is given. The server-side privileges
+are more granular and direct work with them is possible on the CLI,
+as described in :doc:`/sysadmins/cli/LightAdmins`.
+
+Map of the OMERO.web UI options to the server-side privileges
+-------------------------------------------------------------
+
+================================ =============================================== 
+Option in OMERO.web              Server-side privilege(s)  
+-------------------------------- -----------------------------------------------
+Sudo                              Sudo                    
+Write data                        WriteOwned, WriteFile, WriteManagedRepo                           
+Delete data                       DeleteOwned, DeleteFile, DeleteManagedRepo                
+Chgrp                             Chgrp                
+Chown                             Chown                
+Create and Edit groups            ModifyGroup                
+Create and Edit Users             ModifyUser               
+Add Users to Groups               ModifyGroupMembership                
+Upload Scripts                    WriteScriptRepo, DeleteScriptRepo                
+
+================================ =============================================== 
+
+.. note::
+    **CLI lists restrictions, OMERO.web lists privileges**
+    The lists shown using CLI commands recommended in 
+    :doc:`/sysadmins/cli/LightAdmins` will be complementary
+    lists to the ones which can be deduced from the table above.
+
+.. note::
+    **ReadSession privilege is never given to restricted admin**
+    In OMERO.web, you can never create an administrator with restricted
+    privileges who has the "ReadSession" privilege.


### PR DESCRIPTION
This doc maps the checkboxes in the OMERO.web admin UI for the creation of the light admins to the back-end permissions, as defined by @mtbc .

To test:

  - check logic, spelling, etc.
  - check crosslinking with other docs