### PR TITLE
rename of graphical client for IceGrid

### DIFF
--- a/omero/sysadmins/grid.rst
+++ b/omero/sysadmins/grid.rst
@@ -64,8 +64,8 @@ JAR is provided in the OMERO source code under :file:`lib/repository`.
 
     :zerocdoc:`icegridadmin Command Line Tool <display/Ice/icegridadmin+Command+Line+Tool>`
         Chapter of the ZeroC_ manual about the :command:`icegridadmin` CLI
-    :zerocdoc:`IceGrid Admin Graphical Tool <display/Ice/IceGrid+Admin+Graphical+Tool>`
-        Chapter of the ZeroC_ manual about the GridGUI tool
+    :zerocdoc:`IceGrid GUI Tool <display/Ice/IceGrid+GUI+Tool>`
+        Chapter of the ZeroC_ manual about the IceGrid GUI tool
 
 
 How it works


### PR DESCRIPTION
Probably don't need to specifically point to the 3.6 docs as despite the name change the 3.7 instructions look to be just fine for getting it going and basic use of it.