### PR TITLE
doc extlink URL fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -436,8 +436,8 @@ ZeroC                       https://zeroc.com
 Ice                         https://zeroc.com
 Jenkins                     http://jenkins-ci.org
 roadmap                     https://trac.openmicroscopy.org/ome/roadmap
-Open Microscopy Environment http://www.openmicroscopy.org
-Glencoe Software, Inc.      http://www.glencoesoftware.com/
+Open Microscopy Environment https://www.openmicroscopy.org
+Glencoe Software, Inc.      https://www.glencoesoftware.com/
 =========================== ==============================================
 
 Abbreviations

--- a/README.rst
+++ b/README.rst
@@ -436,7 +436,7 @@ ZeroC                       https://zeroc.com
 Ice                         https://zeroc.com
 Jenkins                     http://jenkins-ci.org
 roadmap                     https://trac.openmicroscopy.org/ome/roadmap
-Open Microscopy Environment http://www.openmicroscopy.org/site
+Open Microscopy Environment http://www.openmicroscopy.org
 Glencoe Software, Inc.      http://www.glencoesoftware.com/
 =========================== ==============================================
 

--- a/common/conf.py
+++ b/common/conf.py
@@ -155,10 +155,10 @@ extlinks = {
     'community' : (oo_root + '/support/%s', ''),
     'omero' : (oo_root + '/omero/%s', ''),
     'bf' : (oo_root + '/bio-formats/%s', ''),
-    # One branch only doc links. Branched docs links in conf.py files for
-    # individual doc sets
-    'model_doc' : (docs_root + '/ome-model/5.5.7/%s', ''),
+    # Doc links
+    'model_doc' : (docs_root + '/latest/ome-model/%s', ''),
     'devs_doc' : (docs_root + '/contributing/%s', ''),
+    'bf_doc' : (docs_root + '/latest/bio-formats/%s', ''),
     'schema' : (oo_root + '/Schemas/%s', ''),
     # Help links
     'help' : (help_root + '/%s', ''),

--- a/common/conf.py
+++ b/common/conf.py
@@ -158,7 +158,6 @@ extlinks = {
     # Doc links
     'model_doc' : (docs_root + '/latest/ome-model/%s', ''),
     'devs_doc' : (docs_root + '/contributing/%s', ''),
-    'bf_doc' : (docs_root + '/latest/bio-formats/%s', ''),
     'schema' : (oo_root + '/Schemas/%s', ''),
     # Help links
     'help' : (help_root + '/%s', ''),

--- a/contributing/conf.py
+++ b/contributing/conf.py
@@ -51,8 +51,6 @@ contributing_extlinks = {
     
     # Doc links
     'omero_doc' : (docs_root + '/latest/omero/%s', ''),
-    'bf_doc' : (docs_root + '/latest/bio-formats/%s', ''),
-    'model_doc' : (docs_root + '/ome-model/5.5.7/%s', ''),
     
     #Remaining plone links
     'community_plone' : (oo_site_root + '/community/%s', ''),

--- a/contributing/conf.py
+++ b/contributing/conf.py
@@ -51,7 +51,7 @@ contributing_extlinks = {
     
     # Doc links
     'omero_doc' : (docs_root + '/latest/omero/%s', ''),
-    
+    'bf_doc' : (docs_root + '/latest/bio-formats/%s', ''),
     #Remaining plone links
     'community_plone' : (oo_site_root + '/community/%s', ''),
     'team_plone' : (oo_site_root + '/team/%s', '')

--- a/omero/autogen_db_version.py
+++ b/omero/autogen_db_version.py
@@ -14,7 +14,8 @@ def get_mmp(sqlfile):
 
 
 serverdir = sys.argv[1]
-required = {'omero.db.version': None, 'omero.db.patch': None}
+required = {'omero.db.version': None, 'omero.db.patch': None,
+            'versions.bioformats': None}
 with open(os.path.join(serverdir, 'etc', 'omero.properties')) as f:
     for line in f.readlines():
         m = re.match('([\w\.]+)=(.*)', line.strip())

--- a/omero/conf.py
+++ b/omero/conf.py
@@ -99,6 +99,8 @@ omero_extlinks = {
     'pythondoc' : (downloads_root + '/latest/omero5.4/api/python/%s', ''),
     # Downloads
     'downloads' : (downloads_root + '/latest/omero5.4/%s', ''),
+    # Versioned Bio-Formats doc link
+    'bf_v_doc' : (docs_root + '/bio-formats/' + conf_autogen.versions_bioformats + '/' + '%s', ''),
     # Miscellaneous links
     'springdoc' : ('http://docs.spring.io/spring/docs/%s', ''),
     'ivydoc' : ('http://ant.apache.org/ivy/history/2.3.0/%s', ''),

--- a/omero/conf.py
+++ b/omero/conf.py
@@ -97,8 +97,6 @@ omero_extlinks = {
     # API links
     'javadoc' : (downloads_root + '/latest/omero5.4/api/%s', ''),
     'pythondoc' : (downloads_root + '/latest/omero5.4/api/python/%s', ''),
-    # Doc links
-    'bf_doc' : (oo_site_root + '/support/bio-formats/%s', ''),
     # Downloads
     'downloads' : (downloads_root + '/latest/omero5.4/%s', ''),
     # Miscellaneous links

--- a/omero/conf_autogen.py
+++ b/omero/conf_autogen.py
@@ -1,4 +1,5 @@
 omero_db_version = "OMERO5.4DEV"
 omero_db_patch = "3"
+versions_bioformats = "5.6.0"
 current_dbver = "OMERO5.4DEV__3"
 previous_dbver = "OMERO5.3__0"

--- a/omero/developers/ImportFS.rst
+++ b/omero/developers/ImportFS.rst
@@ -52,7 +52,7 @@ Filesets
 --------
 
 A ``fileset`` is a concept new to OMERO.fs which captures how
-:bf_doc:`Bio-Formats <>` relates files to the images that they encode. If
+:bf_v_doc:`Bio-Formats <>` relates files to the images that they encode. If
 importing a single file leads to a single corresponding image being viewable
 then a one-to-one mapping exists from file to image. However, an image's
 information may be split among multiple files, or a single file may encode

--- a/omero/sysadmins/UpgradeCheck.rst
+++ b/omero/sysadmins/UpgradeCheck.rst
@@ -12,7 +12,7 @@ in your browser will redirect you to this page).
 .. note:: If you have been redirected here by clicking on a link to 
     ``http://upgrade.openmicroscopy.org.uk`` in an error message or log while 
     trying to run one of the **Bio-Formats command line tools**, please see 
-    the :bf_doc:`Bio-Formats command line tools documentation 
+    the :bf_v_doc:`Bio-Formats command line tools documentation 
     <users/comlinetools/index.html#version-checker>` for assistance.
 
 

--- a/omero/users/cli/import.rst
+++ b/omero/users/cli/import.rst
@@ -6,7 +6,7 @@ the command line, and is ideally suited for anyone wanting to use a
 shell-scripted or web-based front-end interface for importing. Based upon the
 same set of libraries as the standard importer, the command line version
 supports the same file formats and functions in much the same way. Visit
-:bf_doc:`Supported Formats <supported-formats.html>` for a detailed list of
+:bf_v_doc:`Supported Formats <supported-formats.html>` for a detailed list of
 supported formats.
 
 Overview

--- a/omero/users/clients-overview.rst
+++ b/omero/users/clients-overview.rst
@@ -145,7 +145,7 @@ image files for import into an OMERO server.
 
 The tool uses Bio-Formats for translation of proprietary file formats in
 preparation for upload to an OMERO.server. Visit
-:bf_doc:`Supported Formats <supported-formats.html>`
+:bf_v_doc:`Supported Formats <supported-formats.html>`
 for a detailed list of supported formats.
 
 .. figure:: /images/importer.png


### PR DESCRIPTION
Updates the Model docs extlink to use the latest redirect now that works and also I spotted that I'd updated the BF doc link in the contributing docs conf.py but not the OMERO one so I've moved it to common conf.py (since both doc sets use it) and updated it.