### PR TITLE
Remove anchors from Ice documentation links

### DIFF
--- a/omero/sysadmins/grid.rst
+++ b/omero/sysadmins/grid.rst
@@ -308,7 +308,7 @@ permissions verifier, so that anyone with a proper OMERO account can
 access the server.
 
 See :zerocdoc:`Controlling Access to IceGrid Sessions
-<display/Ice/Resource+Allocation+using+IceGrid+Sessions#ResourceAllocationusingIceGridSessions-ControllingAccesstoIceGridSessions>`
+<display/Ice/Resource+Allocation+using+IceGrid+Sessions>`
 of the Ice manual for more information.
 
 Unique node names

--- a/omero/sysadmins/troubleshooting.rst
+++ b/omero/sysadmins/troubleshooting.rst
@@ -116,7 +116,7 @@ Server fails to start
    need to specify which network interface to use.
    :omerocmd:`config set Ice.Default.Host 127.0.0.1`, for example, would
    force OMERO to only listen on localhost. See
-   :zerocdoc:`Proxy and Endpoint Syntax  <display/Ice/Proxy+and+Endpoint+Syntax#ProxyandEndpointSyntax-address>`
+   :zerocdoc:`Proxy and Endpoint Syntax  <display/Ice/Proxy+and+Endpoint+Syntax>`
    for more information.
 
 .. _remote_clients_cannot_connect:


### PR DESCRIPTION
These anchors are being marked as broken by the Sphinx linkchecker. Since these
are subsections of the page, this commit proposes to drop the anchor suffix
and link to the page instead which includes a top-level menu.

With this PR https://ci.openmicroscopy.org/job/OMERO-DEV-merge-docs/ should turn back to green