### PR TITLE
omero.web.public.get_only

### DIFF
--- a/omero/sysadmins/public.rst
+++ b/omero/sysadmins/public.rst
@@ -63,8 +63,8 @@ To set this up on your OMERO.web installation:
 - By default the public user is only allowed to perform GET requests. This means
   that the public user will not be able to Create, Edit or Delete data which
   requires POST requests.
-  You can change that by setting the :property:`omero.web.public.get_only`
-  property:
+  If you want to allow these actions from the public user, you can change the
+  :property:`omero.web.public.get_only` property:
   ::
 
       $ bin/omero config set omero.web.public.get_only false

--- a/omero/sysadmins/public.rst
+++ b/omero/sysadmins/public.rst
@@ -111,6 +111,12 @@ To set this up on your OMERO.web installation:
 
      $ bin/omero config set omero.web.public.server_id 1
 
+- By default the public user is only allowed to perform GET requests. You can 
+  change that by setting the :property:`omero.web.public.get_only` property:
+  ::
+
+     $ bin/omero config set omero.web.public.get_only false
+
 If you enable public access to the main webclient but still wish registered
 users to be able to login, the login page can always be accessed using a link
 of the form `\https://your_host/webclient/login/`.

--- a/omero/sysadmins/public.rst
+++ b/omero/sysadmins/public.rst
@@ -60,6 +60,15 @@ To set this up on your OMERO.web installation:
 
      $ bin/omero config set omero.web.public.password '<password>'
 
+- By default the public user is only allowed to perform GET requests. This means
+  that the public user will not be able to Create, Edit or Delete data which
+  requires POST requests.
+  You can change that by setting the :property:`omero.web.public.get_only`
+  property:
+  ::
+
+      $ bin/omero config set omero.web.public.get_only false
+
 - Set the :property:`omero.web.public.url_filter`. This filter is a
   regular expression that will allow only matching URLs to be accessed
   by the public user.
@@ -95,13 +104,14 @@ To set this up on your OMERO.web installation:
 
 
   - You can use the full webclient UI for public browsing of images.
-    However, the webclient UI was not designed for public use and allows
-    various actions that create data or are resource intensive.
-    These can be selectively disabled using the following command:
+    Attempts by public user to create, edit or delete data will fail silently
+    with the default :property:`omero.web.public.get_only` setting above. You 
+    may also choose to disable various dialogs for these actions such as
+    launching scripts or OME-TIFF export, for example:
 
     ::
 
-       $ bin/omero config set omero.web.public.url_filter '^/(webadmin/myphoto/|webclient/(?!(action|logout|annotate_(file|tags|comment|rating|map)|script_ui|ome_tiff|figure_script))|webgateway/(?!(archived_files|download_as)))'
+       $ bin/omero config set omero.web.public.url_filter '^/(webadmin/myphoto/|webclient/(?!(script_ui|ome_tiff|figure_script))|webgateway/(?!(archived_files|download_as)))'
 
 - Set the :property:`omero.web.public.server_id` which the public user will be
   automatically connected to. Default: 1 (the first server in the
@@ -111,11 +121,6 @@ To set this up on your OMERO.web installation:
 
      $ bin/omero config set omero.web.public.server_id 1
 
-- By default the public user is only allowed to perform GET requests. You can 
-  change that by setting the :property:`omero.web.public.get_only` property:
-  ::
-
-     $ bin/omero config set omero.web.public.get_only false
 
 If you enable public access to the main webclient but still wish registered
 users to be able to login, the login page can always be accessed using a link

--- a/omero/sysadmins/whatsnew.rst
+++ b/omero/sysadmins/whatsnew.rst
@@ -39,3 +39,6 @@ What's new for OMERO 5.3 for sysadmins
   give an Image or Plate ID list in the form of ``Image:1,2,3,4`` or
   ``Plate:101`` to be more usable by scripts etc. The previous behavior can
   be restored by using ``--output legacy``.
+
+- The Public user is restricted to GET requests by default. This can be changed
+  by setting the new configuration property :property:`omero.web.public.get_only`.


### PR DESCRIPTION
Adds the new 'omero.web.public.get_only' property to the docs.
Are there other places where this should be mentioned?

See https://github.com/openmicroscopy/openmicroscopy/pull/5406 and https://trello.com/c/BdVULJRw/138-publicgetonly-docs .