### PR TITLE
further link light admin pages

### DIFF
--- a/omero/sysadmins/admins-with-restricted-privileges.rst
+++ b/omero/sysadmins/admins-with-restricted-privileges.rst
@@ -17,11 +17,11 @@ facility managers, image analysts, or anybody who needs to organize
 users and data of others in OMERO.
 
 Full administrators in OMERO can create new administrators with
-restricted privileges using the OMERO.web
-interface, see the :help:`create new users <sharing-data#admin>` section
-of our Help documentation. With considerably more difficulty one may
-also :doc:`use OMERO.cli to adjust the restrictions <cli/light-admins>`
-on an administrator.
+restricted privileges using the OMERO.web interface, see the
+:help:`create new users <sharing-data#admin>` section of our Help
+documentation. With considerably more difficulty one may also :doc:`use
+OMERO.cli to adjust the restrictions <cli/light-admins>` on an
+administrator.
 
 We suggest here four setups that should cover the four mainstream
 workflows. Nevertheless, you can combine the privileges

--- a/omero/sysadmins/admins-with-restricted-privileges.rst
+++ b/omero/sysadmins/admins-with-restricted-privileges.rst
@@ -21,7 +21,7 @@ restricted privileges using the OMERO.web interface, see the
 :help:`create new users <sharing-data#admin>` section of our Help
 documentation. OMERO.cli does not yet support easy management of
 restrictions nor does it offer the helpful :doc:`permissions mapping
-<mapping-restricted-admins>` so we do not recommend :doc:`using
+<mapping-restricted-admins>` but advanced users may :doc:`use
 OMERO.cli to adjust the restrictions <cli/light-admins>` on an
 administrator.
 

--- a/omero/sysadmins/admins-with-restricted-privileges.rst
+++ b/omero/sysadmins/admins-with-restricted-privileges.rst
@@ -19,7 +19,9 @@ users and data of others in OMERO.
 Full administrators in OMERO can create new administrators with
 restricted privileges using the OMERO.web interface, see the
 :help:`create new users <sharing-data#admin>` section of our Help
-documentation. With considerably more difficulty one may also :doc:`use
+documentation. OMERO.cli does not yet support easy management of
+restrictions nor does it offer the helpful :doc:`permissions mapping
+<mapping-restricted-admins>` so we do not recommend :doc:`using
 OMERO.cli to adjust the restrictions <cli/light-admins>` on an
 administrator.
 

--- a/omero/sysadmins/admins-with-restricted-privileges.rst
+++ b/omero/sysadmins/admins-with-restricted-privileges.rst
@@ -21,9 +21,8 @@ restricted privileges using the OMERO.web interface, see the
 :help:`create new users <sharing-data#admin>` section of our Help
 documentation. OMERO.cli does not yet support easy management of
 restrictions nor does it offer the helpful :doc:`permissions mapping
-<mapping-restricted-admins>` but advanced users may :doc:`use
-OMERO.cli to adjust the restrictions <cli/light-admins>` on an
-administrator.
+<mapping-restricted-admins>` but advanced users may :doc:`use OMERO.cli
+to adjust the restrictions <cli/light-admins>` on an administrator.
 
 We suggest here four setups that should cover the four mainstream
 workflows. Nevertheless, you can combine the privileges

--- a/omero/sysadmins/admins-with-restricted-privileges.rst
+++ b/omero/sysadmins/admins-with-restricted-privileges.rst
@@ -19,7 +19,9 @@ users and data of others in OMERO.
 Full administrators in OMERO can create new administrators with
 restricted privileges using the OMERO.web
 interface, see the :help:`create new users <sharing-data#admin>` section
-of our Help documentation.
+of our Help documentation. With considerably more difficulty one may
+also :doc:`use OMERO.cli to adjust the restrictions <cli/light-admins>`
+on an administrator.
 
 We suggest here four setups that should cover the four mainstream
 workflows. Nevertheless, you can combine the privileges

--- a/omero/sysadmins/cli/light-admins.rst
+++ b/omero/sysadmins/cli/light-admins.rst
@@ -16,11 +16,13 @@ administrator restrictions in the awkward manner described hereunder.
 .. warning::
 
   OMERO.web provides a simplified view of the available restrictions:
-  the :doc:`permissions mapping <../mapping-restricted-admins>` is such that checking *one* box in the web interface may lift *multiple* underlying
-  restrictions from an administrator. The recommended OMERO.web
-  management interface may thus prove confusing if OMERO.cli has been
-  used to set a combination of restrictions that does not correspond to
-  those bundles of related restrictions available in OMERO.web.
+  the :doc:`permissions mapping <../mapping-restricted-admins>` is such
+  that checking *one* box in the web interface may lift *multiple*
+  underlying restrictions from an administrator. The recommended
+  OMERO.web management interface may thus prove confusing if OMERO.cli
+  has been used to set a combination of restrictions that does not
+  correspond to those bundles of related restrictions available in
+  OMERO.web.
 
 
 View an administrator's restrictions

--- a/omero/sysadmins/cli/light-admins.rst
+++ b/omero/sysadmins/cli/light-admins.rst
@@ -16,7 +16,7 @@ administrator restrictions in the awkward manner described hereunder.
 .. warning::
 
   OMERO.web provides a simplified view of the available restrictions:
-  checking *one* box in the web interface may lift *multiple* underlying
+  the :doc:`permissions mapping <../mapping-restricted-admins>` is such that checking *one* box in the web interface may lift *multiple* underlying
   restrictions from an administrator. The recommended OMERO.web
   management interface may thus prove confusing if OMERO.cli has been
   used to set a combination of restrictions that does not correspond to

--- a/omero/sysadmins/mapping-restricted-admins.rst
+++ b/omero/sysadmins/mapping-restricted-admins.rst
@@ -12,7 +12,7 @@ The OMERO.web user interface form for creation and editing of
 restricted administrators
 (see the :help:`create new users <sharing-data#admin>` section)
 collates the server-side privileges
-into fewer options and gives the options user friendly
+into fewer options and gives the options user-friendly
 names. Here, the mapping of the OMERO.web options to the 
 server-side privileges is given. The server-side privileges
 are more granular and direct work with them is possible on the CLI,

--- a/omero/sysadmins/mapping-restricted-admins.rst
+++ b/omero/sysadmins/mapping-restricted-admins.rst
@@ -1,5 +1,5 @@
-Restricted administrators OMERO.web interface to server permissions mapping
-===========================================================================
+Administrator restrictions: relating OMERO.webadmin to OMERO.server
+===================================================================
 
 
 Summary


### PR DESCRIPTION
Beyond those from #1714 adds a couple more links among light admin pages. See https://trello.com/c/kDxd1MeO/57-cross-reference-light-admin-docs for background.