### PR TITLE
'omero/plugins' PYTHON path

### DIFF
--- a/omero/developers/cli/extending.rst
+++ b/omero/developers/cli/extending.rst
@@ -12,8 +12,8 @@ will automatically include them.
 For testing purposes the ``--path`` argument can be used to point to other plugin
 files or directories, too.
 
-|CLI| plugins are also pip-installable. Search for ``omero-cli-*`` on `PyPI
-<https://pypi.python.org/pypi>`_.
+|CLI| plugins are also pip-installable. Search for ``omero-cli-*`` on
+:pypi:`PyPI <>`.
 
 Thread-safety
 ^^^^^^^^^^^^^

--- a/omero/developers/cli/extending.rst
+++ b/omero/developers/cli/extending.rst
@@ -6,7 +6,7 @@ directory. On execution, all plugins in that directory are registered
 with the |CLI|. 
 
 Alternatively, plugins can be added to any directory ending with
-``omero/plugins``. If this directory is part of the ``PYTHON`` path the |CLI|
+``omero/plugins``. If this directory is part of the ``PYTHONPATH`` the |CLI|
 will automatically include them.
 
 For testing purposes the ``--path`` argument can be used to point to other plugin

--- a/omero/developers/cli/extending.rst
+++ b/omero/developers/cli/extending.rst
@@ -3,8 +3,17 @@ Extensions
 
 Plugins can be written and put in the ``lib/python/omero/plugins``
 directory. On execution, all plugins in that directory are registered
-with the |CLI|. Alternatively, the :option:`--path` argument can be used to
-point to other plugin files or directories.
+with the |CLI|. 
+
+Alternatively, plugins can be added to any directory ending with
+``omero/plugins``. If this directory is part of the ``PYTHON`` path the |CLI|
+will automatically include them.
+
+For testing purposes the ``--path`` argument can be used to point to other plugin
+files or directories, too.
+
+|CLI| plugins are also pip installable. Search for ``omero-cli-*`` on `PyPI
+<https://pypi.python.org/pypi>`_.
 
 Thread-safety
 ^^^^^^^^^^^^^

--- a/omero/developers/cli/extending.rst
+++ b/omero/developers/cli/extending.rst
@@ -12,7 +12,7 @@ will automatically include them.
 For testing purposes the ``--path`` argument can be used to point to other plugin
 files or directories, too.
 
-|CLI| plugins are also pip installable. Search for ``omero-cli-*`` on `PyPI
+|CLI| plugins are also pip-installable. Search for ``omero-cli-*`` on `PyPI
 <https://pypi.python.org/pypi>`_.
 
 Thread-safety


### PR DESCRIPTION
With https://github.com/openmicroscopy/openmicroscopy/pull/4619 any 'omero/plugins' directory on the PYTHON path will
be searched for plugins. This PR just modifies the doc accordingly.

See:
https://trello.com/c/qMrZfcoU/78-external-cli-plugins
https://trello.com/c/DeEfMN0E/140-doc-cli-plugin-deployment
