### PR TITLE
Unicode BlitzGateway

### DIFF
--- a/omero/developers/PythonBlitzGateway.rst
+++ b/omero/developers/PythonBlitzGateway.rst
@@ -80,6 +80,40 @@ loading).
        survivin
     >>> conn.close()
 
+
+Unicode
+"""""""
+
+When unwrapping omero.model rstring attributes as shown above,
+the BlitzObjectWrapper subclasses will decode the utf8-encoded
+string and return the resulting unicode string.
+
+However, some methods added to BlitzObjectWrappers
+will return strings as follows::
+
+    BlitzObjectWrapper.getName()            except ExperimenterWrapper.getName() and LogicalChannelWrapper.getName()
+    BlitzObjectWrapper.getDescription()
+    AnnotationWrapper.getNs()
+    FileAnnotationWrapper.getFileName()
+    TagAnnotationWrapper.getValue()
+    CommentAnnotationWrapper.getValue()
+    MapAnnotationWrapper.getValue()  - list of strings
+    PlateWrapper.getColumnLabels() / getRowLabels()   - list of strings or integers
+    WellWrapper.getWellPos()
+    ColorHolder.getHtml() / getCss()
+    ChannelWrapper.getLut()
+    ImageWrapper.getChannelLabels()  - list of strings
+
+When using unicode strings, care must be taken when printing to
+the console if they include non-ASCII characters as
+`described here <https://pythonhosted.org/kitchen/unicode-frustrations.html>`_.
+
+When using the BlitzGateway in the OMERO.web framework,
+Django will convert strings into unicode strings so it's safe to
+use either. See Django
+`Unicode data <https://docs.djangoproject.com/en/1.8/ref/unicode/#general-string-handling>`_.
+
+
 Wrapper coverage
 """"""""""""""""
 

--- a/omero/developers/PythonBlitzGateway.rst
+++ b/omero/developers/PythonBlitzGateway.rst
@@ -84,12 +84,13 @@ loading).
 Unicode
 """""""
 
-When unwrapping omero.model rstring attributes as shown above,
-the BlitzObjectWrapper subclasses will decode the utf8-encoded
+When unwrapping ``omero.rtypes.rstring`` attributes from
+``omero.model.object`` instances as shown above,
+the ``BlitzObjectWrapper`` subclasses will decode the utf8-encoded
 string and return the resulting unicode string.
 
-However, some methods added to BlitzObjectWrappers
-will return strings as follows::
+However, some methods added to ``BlitzObjectWrappers``
+will return regular strings as follows::
 
     BlitzObjectWrapper.getName()            except ExperimenterWrapper.getName() and LogicalChannelWrapper.getName()
     BlitzObjectWrapper.getDescription()
@@ -109,7 +110,7 @@ the console if they include non-ASCII characters as
 `described here <https://pythonhosted.org/kitchen/unicode-frustrations.html>`_.
 
 When using the BlitzGateway in the OMERO.web framework,
-Django will convert strings into unicode strings so it's safe to
+Django will convert strings into unicode strings so it is safe to
 use either. See Django
 `Unicode data <https://docs.djangoproject.com/en/1.8/ref/unicode/#general-string-handling>`_.
 


### PR DESCRIPTION
Add Unicode info to the BlitzGateway docs page.
See discussion at https://github.com/openmicroscopy/openmicroscopy/pull/5400

To test, check output from various BlitzGateway wrappers, e.g.

```
$ bin/omero shell --login

In [1]: from omero.gateway import BlitzGateway

In [2]: conn = BlitzGateway(client_obj=client)

In [3]: u = conn.getUser()

In [4]: u.getFullName()
Out[4]: u'Will Mo\xf6re'

In [5]: u._obj.getFirstName().val
Out[5]: 'Will'

In [7]: u.getLastName()
Out[7]: u'Mo\xf6re'

In [8]: u.getName()
Out[8]: u'will'

In [9]: i = conn.getObject("Image", 9551)

In [10]: i.getName()
Out[10]: '438_01_R3D_D3D\xc3\xb6.dv'

In [11]: i.getOwnerFullName()
Out[11]: u'Will Mo\xf6re'

In [27]: for c in i.getChannels():
    print type(c.getLut())
   ....:     
<type 'str'>
<type 'NoneType'>
```