### PR TITLE
Pypi url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -438,6 +438,7 @@ Jenkins                     http://jenkins-ci.org
 roadmap                     https://trac.openmicroscopy.org/ome/roadmap
 Open Microscopy Environment https://www.openmicroscopy.org
 Glencoe Software, Inc.      https://www.glencoesoftware.com/
+PyPI                        https://pypi.python.org
 =========================== ==============================================
 
 Abbreviations

--- a/common/conf.py
+++ b/common/conf.py
@@ -189,6 +189,7 @@ rst_epilog = """
 .. _Python: http://www.python.org
 .. _Libjpeg: http://libjpeg.sourceforge.net/
 .. _Django: https://www.djangoproject.com/
+.. _PyPI: https://pypi.python.org
 
 .. |SSH| replace:: :abbr:`SSH (Secure Shell)`
 .. |VM| replace:: :abbr:`VM (Virtual Machine)`

--- a/contributing/ci-consortium.rst
+++ b/contributing/ci-consortium.rst
@@ -42,5 +42,4 @@ OMERO.webtagging
 ^^^^^^^^^^^^^^^^
 
 The source code for OMERO.webtagging is hosted under
-https://github.com/MicronOxford/webtagging/. Since 3.0.0, the Web app is released under https://pypi.python.org/pypi/omero-webtagging-tagsearch and
-https://pypi.python.org/pypi/omero-webtagging-autotag.
+https://github.com/MicronOxford/webtagging/. Since 3.0.0, the Web app is released under :pypi:`omero-webtagging-tagsearch` and :pypi:`omero-webtagging-autotag`.

--- a/contributing/deployment-tools.rst
+++ b/contributing/deployment-tools.rst
@@ -112,7 +112,7 @@ adjustment to production CD.
 
     Any Python module that is distributed from Linux distro packages
     must be installed from RPM file. Python modules only available
-    on PyPI should be added as PIP requirement.
+    on PyPI_ should be added as PIP requirement.
 
 
 Pre release testing

--- a/contributing/tools-maintenance.rst
+++ b/contributing/tools-maintenance.rst
@@ -2,7 +2,7 @@ Development tools: maintenance
 ==============================
 
 Most of the development tools used internally by the OME project are
-Python-based and hosted on `PyPI`_. Their source
+Python-based and hosted on PyPI_. Their source
 code is on GitHub.
 
 Maintainer prerequisites

--- a/contributing/tools-maintenance.rst
+++ b/contributing/tools-maintenance.rst
@@ -2,7 +2,7 @@ Development tools: maintenance
 ==============================
 
 Most of the development tools used internally by the OME project are
-Python-based and hosted on the :pypi:`Python Package Index <>`. Their source
+Python-based and hosted on `PyPI`_. Their source
 code is on GitHub.
 
 Maintainer prerequisites

--- a/omero/developers/Web/CreateApp.rst
+++ b/omero/developers/Web/CreateApp.rst
@@ -9,7 +9,7 @@ database mapping, since all data comes from the OMERO server and is
 saved back there. You will notice that the models.py files in each app
 are empty.
 
-All official OMERO applications can be installed from :pypi:`Python Package Index <>`.
+All official OMERO applications can be installed from `PyPI`_.
 
 Getting set up
 --------------

--- a/omero/developers/Web/CreateApp.rst
+++ b/omero/developers/Web/CreateApp.rst
@@ -9,7 +9,7 @@ database mapping, since all data comes from the OMERO server and is
 saved back there. You will notice that the models.py files in each app
 are empty.
 
-All official OMERO applications can be installed from `PyPI`_.
+All official OMERO applications can be installed from PyPI_.
 
 Getting set up
 --------------

--- a/omero/developers/cli/extending.rst
+++ b/omero/developers/cli/extending.rst
@@ -13,7 +13,7 @@ For testing purposes the ``--path`` argument can be used to point to other
 plugin files or directories, too.
 
 |CLI| plugins are also pip-installable. Search for ``omero-cli-*`` on
-`PyPI`_.
+PyPI_.
 
 Thread-safety
 ^^^^^^^^^^^^^

--- a/omero/developers/cli/extending.rst
+++ b/omero/developers/cli/extending.rst
@@ -13,7 +13,7 @@ For testing purposes the ``--path`` argument can be used to point to other
 plugin files or directories, too.
 
 |CLI| plugins are also pip-installable. Search for ``omero-cli-*`` on
-:pypi:`PyPI <>`.
+`PyPI`_.
 
 Thread-safety
 ^^^^^^^^^^^^^

--- a/omero/sysadmins/omeroweb-upgrade.rst
+++ b/omero/sysadmins/omeroweb-upgrade.rst
@@ -89,8 +89,8 @@ Updating 'Open with' config
 
 If you have configured :property:`omero.web.open_with` prior to OMERO 5.3.3 and
 also set the default viewer with :property:`omero.web.viewer.view`, for example
-as described for `OMERO.iviewer <https://pypi.python.org/pypi/omero-iviewer>`_
-then you will find that ``Open with > Image Viewer`` also opens the OMERO.iviewer
+as described for :pypi:`OMERO.iviewer <omero-iviewer>` then you will find that
+``Open with > Image Viewer`` also opens the OMERO.iviewer
 instead of the ``webgateway`` viewer.
 
 To fix this, you need to update the ``Image Viewer`` option within

--- a/omero/sysadmins/omeroweb-upgrade.rst
+++ b/omero/sysadmins/omeroweb-upgrade.rst
@@ -70,7 +70,7 @@ reason, it is possible that an update of OMERO will cause issues with an older
 version of a plugin. It is best when updating the server to also install any
 available plugin updates according to their own documentation.
 
-Since 5.3, all official OMERO.web plugins can be installed from :pypi:`Python Package Index <>`.
+Since 5.3, all official OMERO.web plugins can be installed from `PyPI`_.
 You should remove all previously installed plugins and install the latest
 versions using `pip <https://pip.pypa.io/en/stable/>`_.
 

--- a/omero/sysadmins/omeroweb-upgrade.rst
+++ b/omero/sysadmins/omeroweb-upgrade.rst
@@ -70,7 +70,7 @@ reason, it is possible that an update of OMERO will cause issues with an older
 version of a plugin. It is best when updating the server to also install any
 available plugin updates according to their own documentation.
 
-Since 5.3, all official OMERO.web plugins can be installed from `PyPI`_.
+Since 5.3, all official OMERO.web plugins can be installed from PyPI_.
 You should remove all previously installed plugins and install the latest
 versions using `pip <https://pip.pypa.io/en/stable/>`_.
 

--- a/omero/sysadmins/server-tables.rst
+++ b/omero/sysadmins/server-tables.rst
@@ -88,7 +88,7 @@ After that, the following should succeed:
 
   then this is fixed by installing the corresponding Python module. Use
   your operating system's package installer if possible or if you must
-  instead use PyPI directly::
+  instead use PyPI_ directly::
 
     pip install mock
 

--- a/omero/sysadmins/unix/install-web/walkthrough/omeroweb-install-centos7-ice3.6.rst
+++ b/omero/sysadmins/unix/install-web/walkthrough/omeroweb-install-centos7-ice3.6.rst
@@ -4,28 +4,24 @@ OMERO.web installation separately from OMERO.server on CentOS 7 and IcePy 3.6
 Please first read :doc:`../../server-centos7-ice36`.
 
 
-This is an example walkthrough for installing OMERO.web decoupled from the OMERO.server in a **virtual environment** using OMERO.py and a dedicated system user. Installing OMERO.web in a virtual environment is the preferred way. For convenience in this walkthrough the main OMERO.web configuration options have been defined as environment variables. When following this walkthrough you can either use your own values, or alternatively use the following ones::
-    
-    OMERO_USER=omero
-    WEBPORT=80
-    WEBSERVER_NAME=localhost
-
-
+This is an example walkthrough for installing OMERO.web decoupled from the OMERO.server in a **virtual environment** using OMERO.py and a dedicated system user. Installing OMERO.web in a virtual environment is the preferred way. For convenience in this walkthrough, we will use the **omero system user** and define the main OMERO.web configuration options as environment variables.
 
 **The following steps are run as root.**
 
-Create a local system user omero if required, create the homedir too :file:`/home/omero`::
+If required, first create a local system user omero and create the homedir too :file:`/home/omero`::
     
     useradd -m omero
     
     chmod a+X /home/omero
+
+
 
 Installing prerequisites
 ------------------------
 
 **The following steps are run as root.**
 
-Install ZeroC IcePy 3.6. IcePy is managed by `PyPI <https://pypi.python.org/pypi>`_, a package management system used to install and manage software packages written in Python. IcePy will be installed as part of the OMERO.web requirements::
+Install ZeroC IcePy 3.6. IcePy is managed by `PyPI`_, a package management system used to install and manage software packages written in Python. IcePy will be installed as part of the OMERO.web requirements::
     
     yum -y install \
         gcc \
@@ -65,8 +61,8 @@ Install other dependencies. The number of dependencies to install depends on the
     
 
 
-Creating virtual environment
-----------------------------
+Creating a virtual environment
+------------------------------
 
 **The following steps are run as root.**
 
@@ -111,6 +107,11 @@ Configuring OMERO.web
 
 **The following steps are run as the omero system user.**
 
+For convenience the main OMERO.web configuration options have been defined as environment variables. You can either use your own values, or alternatively use the following ones::
+    
+    export WEBPORT=80
+    export WEBSERVER_NAME=localhost
+
 Configure OMERO.web and create the NGINX OMERO configuration file::
     
     . /home/omero/omerowebvenv/bin/activate
@@ -142,25 +143,16 @@ Running OMERO.web
 
 **The following steps are run as the omero system user.**
 
-To start the OMERO.web client run::
+
+To start the OMERO.web client manually run::
     
-    source /home/omero/omerowebvenv/bin/activate
+    . /home/omero/omerowebvenv/bin/activate
     
-    OMERO.py/bin/omero web start
+    /home/omero/OMERO.py/bin/omero web start
 
 **The following steps are run as root.**
 
-Should you wish to run OMERO.web automatically, a `systemd.service` file could be created. See example file below::
-    
-    cp omero-web-systemd.service /etc/systemd/system/omero-web.service
-    
-    systemctl daemon-reload
-    
-    systemctl enable omero-web.service
-    
-    systemctl start omero-web.service
-
-`omero-web-systemd.service` example::
+Should you wish to run OMERO.web automatically, a `systemd.service` file could be created. See below an example file `omero-web-systemd.service`::
     
     [Unit]
     Description=OMERO.web
@@ -180,6 +172,18 @@ Should you wish to run OMERO.web automatically, a `systemd.service` file could b
     
     [Install]
     WantedBy=multi-user.target
+
+Copy the `systemd.service` file, then enable and start the service::
+    
+    cp omero-web-systemd.service /etc/systemd/system/omero-web.service
+    
+    systemctl daemon-reload
+    
+    systemctl enable omero-web.service
+    
+    systemctl stop omero-web.service
+    
+    systemctl start omero-web.service
 
 
 Maintenance

--- a/omero/sysadmins/unix/install-web/walkthrough/omeroweb-install-debian-ice3.6.rst
+++ b/omero/sysadmins/unix/install-web/walkthrough/omeroweb-install-debian-ice3.6.rst
@@ -4,28 +4,24 @@ OMERO.web installation separately from OMERO.server on Debian 9 and IcePy 3.6
 Please first read :doc:`../../server-debian9-ice36`.
 
 
-This is an example walkthrough for installing OMERO.web decoupled from the OMERO.server in a **virtual environment** using OMERO.py and a dedicated system user. Installing OMERO.web in a virtual environment is the preferred way. For convenience in this walkthrough the main OMERO.web configuration options have been defined as environment variables. When following this walkthrough you can either use your own values, or alternatively use the following ones::
-    
-    OMERO_USER=omero
-    WEBPORT=80
-    WEBSERVER_NAME=localhost
-
-
+This is an example walkthrough for installing OMERO.web decoupled from the OMERO.server in a **virtual environment** using OMERO.py and a dedicated system user. Installing OMERO.web in a virtual environment is the preferred way. For convenience in this walkthrough, we will use the **omero system user** and define the main OMERO.web configuration options as environment variables.
 
 **The following steps are run as root.**
 
-Create a local system user omero if required, create the homedir too :file:`/home/omero`::
+If required, first create a local system user omero and create the homedir too :file:`/home/omero`::
     
     useradd -m omero
     
     chmod a+X /home/omero
+
+
 
 Installing prerequisites
 ------------------------
 
 **The following steps are run as root.**
 
-Install ZeroC IcePy 3.6. IcePy is managed by `PyPI <https://pypi.python.org/pypi>`_, a package management system used to install and manage software packages written in Python. IcePy and will be installed as part of the OMERO.web requirements::
+Install ZeroC IcePy 3.6. IcePy is managed by `PyPI`_, a package management system used to install and manage software packages written in Python. IcePy and will be installed as part of the OMERO.web requirements::
     
     apt-get -y install libssl-dev libbz2-dev libmcpp-dev libdb++-dev libdb-dev libdb-java
 
@@ -60,8 +56,8 @@ Install other dependencies. The number of dependencies to install depends on the
         tk8.6-dev
 
 
-Creating virtual environment
-----------------------------
+Creating a virtual environment
+------------------------------
 
 **The following steps are run as root.**
 
@@ -106,6 +102,11 @@ Configuring OMERO.web
 
 **The following steps are run as the omero system user.**
 
+For convenience the main OMERO.web configuration options have been defined as environment variables. You can either use your own values, or alternatively use the following ones::
+    
+    export WEBPORT=80
+    export WEBSERVER_NAME=localhost
+
 Configure OMERO.web and create the NGINX OMERO configuration file::
     
     . /home/omero/omerowebvenv/bin/activate
@@ -136,25 +137,16 @@ Running OMERO.web
 
 **The following steps are run as the omero system user.**
 
-To start the OMERO.web client run::
+
+To start the OMERO.web client manually run::
     
-    source /home/omero/omerowebvenv/bin/activate
+    . /home/omero/omerowebvenv/bin/activate
     
-    OMERO.py/bin/omero web start
+    /home/omero/OMERO.py/bin/omero web start
 
 **The following steps are run as root.**
 
-Should you wish to run OMERO.web automatically, a `init.d` file could be created::
-    
-    Create omero-web-init.d. See example file below.
-    cp omero-web-init.d /etc/init.d/omero-web
-    chmod a+x /etc/init.d/omero-web
-    
-    update-rc.d -f omero-web remove
-    update-rc.d -f omero-web defaults 98 02
-    
-
-`omero-web-init.d` example::
+Should you wish to run OMERO.web automatically, a `init.d` file could be created. See below an example file `omero-web-init.d`::
     
     #!/bin/bash
     #
@@ -229,6 +221,15 @@ Should you wish to run OMERO.web automatically, a `init.d` file could be created
             RETVAL=1
     esac
     exit $RETVAL
+
+Copy the `init.d` file, then configure the service::
+    
+    cp omero-web-init.d /etc/init.d/omero-web
+    chmod a+x /etc/init.d/omero-web
+    
+    update-rc.d -f omero-web remove
+    update-rc.d -f omero-web defaults 98 02
+    
 
 Start up services::
     

--- a/omero/sysadmins/unix/install-web/walkthrough/omeroweb-install-osx-ice3.6.rst
+++ b/omero/sysadmins/unix/install-web/walkthrough/omeroweb-install-osx-ice3.6.rst
@@ -4,11 +4,10 @@ OMERO.web installation on Mac OS X and IcePy 3.6
 Please first read :doc:`../../server-install-homebrew`.
 
 
-This is an example walkthrough for installing OMERO.web decoupled from the OMERO.server in a **virtual environment** using OMERO.py and a dedicated system user. Installing OMERO.web in a virtual environment is the preferred way. For convenience in this walkthrough the main OMERO.web configuration options have been defined as environment variables. When following this walkthrough you can either use your own values, or alternatively use the following ones::
-    
-    OMERO_USER=
-    WEBPORT=80
-    WEBSERVER_NAME=localhost
+This is an example walkthrough for installing OMERO.web decoupled from the OMERO.server in a **virtual environment** using OMERO.py and a dedicated system user. Installing OMERO.web in a virtual environment is the preferred way. For convenience in this walkthrough, we will use the ** system user** and define the main OMERO.web configuration options as environment variables.
+
+**The following steps are run as root.**
+
 
 Install Homebrew in /usr/local::
     
@@ -19,9 +18,6 @@ Install Homebrew in /usr/local::
     
     brew update
     brew doctor
-
-**The following steps are run as root.**
-
 
 Installing prerequisites
 ------------------------
@@ -78,6 +74,11 @@ Configuring OMERO.web
 ---------------------
 
 
+For convenience the main OMERO.web configuration options have been defined as environment variables. You can either use your own values, or alternatively use the following ones::
+    
+    export WEBPORT=80
+    export WEBSERVER_NAME=localhost
+
 Configure OMERO.web and create the NGINX OMERO configuration file::
     
     . ~/omerowebvenv/bin/activate
@@ -101,12 +102,11 @@ Copy the generated configuration file into the NGINX configuration directory::
 Running OMERO.web
 -----------------
 
-To start the OMERO.web client run::
+To start the OMERO.web client manually run::
     
-    source ~/omerowebvenv/bin/activate
+    . ~/omerowebvenv/bin/activate
     
-    OMERO.py/bin/omero web start
-
+    ~/OMERO.py/bin/omero web start
 
 
 Start up services::

--- a/omero/sysadmins/unix/install-web/walkthrough/omeroweb-install-ubuntu-ice3.6.rst
+++ b/omero/sysadmins/unix/install-web/walkthrough/omeroweb-install-ubuntu-ice3.6.rst
@@ -4,28 +4,24 @@ OMERO.web installation separately from OMERO.server on Ubuntu 16.04 and IcePy 3.
 Please first read :doc:`../../server-ubuntu-ice36`.
 
 
-This is an example walkthrough for installing OMERO.web decoupled from the OMERO.server in a **virtual environment** using OMERO.py and a dedicated system user. Installing OMERO.web in a virtual environment is the preferred way. For convenience in this walkthrough the main OMERO.web configuration options have been defined as environment variables. When following this walkthrough you can either use your own values, or alternatively use the following ones::
-    
-    OMERO_USER=omero
-    WEBPORT=80
-    WEBSERVER_NAME=localhost
-
-
+This is an example walkthrough for installing OMERO.web decoupled from the OMERO.server in a **virtual environment** using OMERO.py and a dedicated system user. Installing OMERO.web in a virtual environment is the preferred way. For convenience in this walkthrough, we will use the **omero system user** and define the main OMERO.web configuration options as environment variables.
 
 **The following steps are run as root.**
 
-Create a local system user omero if required, create the homedir too :file:`/home/omero`::
+If required, first create a local system user omero and create the homedir too :file:`/home/omero`::
     
     useradd -m omero
     
     chmod a+X /home/omero
+
+
 
 Installing prerequisites
 ------------------------
 
 **The following steps are run as root.**
 
-Install ZeroC IcePy 3.6. IcePy is managed by `PyPI <https://pypi.python.org/pypi>`_, a package management system used to install and manage software packages written in Python. IcePy and will be installed as part of the OMERO.web requirements::
+Install ZeroC IcePy 3.6. IcePy is managed by `PyPI`_, a package management system used to install and manage software packages written in Python. IcePy and will be installed as part of the OMERO.web requirements::
     
     apt-get -y install db5.3-util
     apt-get -y install libssl-dev libbz2-dev libmcpp-dev libdb++-dev libdb-dev
@@ -67,8 +63,8 @@ Install other dependencies. The number of dependencies to install depends on the
     
 
 
-Creating virtual environment
-----------------------------
+Creating a virtual environment
+------------------------------
 
 **The following steps are run as root.**
 
@@ -113,6 +109,11 @@ Configuring OMERO.web
 
 **The following steps are run as the omero system user.**
 
+For convenience the main OMERO.web configuration options have been defined as environment variables. You can either use your own values, or alternatively use the following ones::
+    
+    export WEBPORT=80
+    export WEBSERVER_NAME=localhost
+
 Configure OMERO.web and create the NGINX OMERO configuration file::
     
     . /home/omero/omerowebvenv/bin/activate
@@ -140,25 +141,16 @@ Running OMERO.web
 
 **The following steps are run as the omero system user.**
 
-To start the OMERO.web client run::
+
+To start the OMERO.web client manually run::
     
-    source /home/omero/omerowebvenv/bin/activate
+    . /home/omero/omerowebvenv/bin/activate
     
-    OMERO.py/bin/omero web start
+    /home/omero/OMERO.py/bin/omero web start
 
 **The following steps are run as root.**
 
-Should you wish to run OMERO.web automatically, a `init.d` file could be created::
-    
-    Create omero-web-init.d. See example file below.
-    cp omero-web-init.d /etc/init.d/omero-web
-    chmod a+x /etc/init.d/omero-web
-    
-    update-rc.d -f omero-web remove
-    update-rc.d -f omero-web defaults 98 02
-    
-
-`omero-web-init.d` example::
+Should you wish to run OMERO.web automatically, a `init.d` file could be created. See below an example file `omero-web-init.d`::
     
     #!/bin/bash
     #
@@ -233,6 +225,15 @@ Should you wish to run OMERO.web automatically, a `init.d` file could be created
             RETVAL=1
     esac
     exit $RETVAL
+
+Copy the `init.d` file, then configure the service::
+    
+    cp omero-web-init.d /etc/init.d/omero-web
+    chmod a+x /etc/init.d/omero-web
+    
+    update-rc.d -f omero-web remove
+    update-rc.d -f omero-web defaults 98 02
+    
 
 Start up services::
     

--- a/omero/sysadmins/unix/install-web/web-deployment.rst
+++ b/omero/sysadmins/unix/install-web/web-deployment.rst
@@ -96,7 +96,7 @@ Prerequisites
 
    -  :pypi:`virtualenv` (optional) tool to create isolated Python environments
 
-   -  `PyPI`_ a package management system used to install and manage
+   -  PyPI_ a package management system used to install and manage
       software packages written in Python. PyPI is already installed if
       you are using Python 2 >=2.7.9
 

--- a/omero/sysadmins/unix/install-web/web-deployment.rst
+++ b/omero/sysadmins/unix/install-web/web-deployment.rst
@@ -96,7 +96,7 @@ Prerequisites
 
    -  :pypi:`virtualenv` (optional) tool to create isolated Python environments
 
-   -  :pypi:`PyPI <>` a package management system used to install and manage
+   -  `PyPI`_ a package management system used to install and manage
       software packages written in Python. PyPI is already installed if
       you are using Python 2 >=2.7.9
 

--- a/omero/sysadmins/unix/install-web/web-deployment.rst
+++ b/omero/sysadmins/unix/install-web/web-deployment.rst
@@ -402,7 +402,7 @@ See
 EXPERIMENTAL: Sync workers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- Install `futures <https://pypi.python.org/pypi/futures>`_ ::
+- Install :pypi:`futures` ::
 
       $ pip install futures
 

--- a/omero/sysadmins/whatsnew.rst
+++ b/omero/sysadmins/whatsnew.rst
@@ -10,7 +10,7 @@ What's new for OMERO 5.3 for sysadmins
 - :doc:`version-requirements` has been updated to reflect other changes in
   version support for 5.3.0 and tentative plans for 5.4.0.
   
-- All official OMERO.web apps can now be installed from PyPI. You should
+- All official OMERO.web apps can now be installed from PyPI_. You should
   reinstall your plugins when you upgrade.
 
 - Windows support has been discontinued, see


### PR DESCRIPTION
This PR fixes a problem noticed by @pwalczysko see https://github.com/ome/omeroweb-install/pull/33#pullrequestreview-62385374

I have also updated few links to use ``:pypi:``