### PR TITLE
Autogen nginx-omero.conf

### DIFF
--- a/omero/autogen_docs
+++ b/omero/autogen_docs
@@ -33,7 +33,7 @@ echo "Generating DB script example"
 echo "Generating Web configuration templates"
 # Nginx / WSGI
 $WORKSPACE/OMERO.server/bin/omero web config nginx | sed "s|$WORKSPACE/OMERO.server|/home/omero/OMERO.py|g" > omero/sysadmins/unix/install-web/nginx-omero.conf
-$WORKSPACE/OMERO.server/bin/omero web config nginx-location | sed "s|$WORKSPACE/OMERO.server|/home/omero|g" | grep -v '^#' > omero/sysadmins/unix/install-web/nginx-location.conf
+$WORKSPACE/OMERO.server/bin/omero web config nginx-location | sed "s|$WORKSPACE/OMERO.server|/home/omero/OMERO.py|g" | grep -v '^#' > omero/sysadmins/unix/install-web/nginx-location.conf
 $WORKSPACE/OMERO.server/bin/omero web config nginx-location | sed "s|/opt/omero/web|/home/omero|g" | grep '^##' | cut -c3-
 > omero/sysadmins/unix/install-web/nginx-location-manual-wrapper.conf
 

--- a/omero/autogen_docs
+++ b/omero/autogen_docs
@@ -33,7 +33,7 @@ echo "Generating DB script example"
 echo "Generating Web configuration templates"
 # Nginx / WSGI
 $WORKSPACE/OMERO.server/bin/omero web config nginx | sed "s|$WORKSPACE/OMERO.server|/home/omero/OMERO.py|g" > omero/sysadmins/unix/install-web/nginx-omero.conf
-$WORKSPACE/OMERO.server/bin/omero web config nginx-location | sed "s|$WORKSPACE|/home/omero|g" | grep -v '^#' > omero/sysadmins/unix/install-web/nginx-location.conf
+$WORKSPACE/OMERO.server/bin/omero web config nginx-location | sed "s|$WORKSPACE/OMERO.server|/home/omero|g" | grep -v '^#' > omero/sysadmins/unix/install-web/nginx-location.conf
 $WORKSPACE/OMERO.server/bin/omero web config nginx-location | sed "s|/opt/omero/web|/home/omero|g" | grep '^##' | cut -c3-
 > omero/sysadmins/unix/install-web/nginx-location-manual-wrapper.conf
 

--- a/omero/autogen_docs
+++ b/omero/autogen_docs
@@ -32,7 +32,7 @@ echo "Generating DB script example"
 
 echo "Generating Web configuration templates"
 # Nginx / WSGI
-$WORKSPACE/OMERO.server/bin/omero web config nginx | sed "s|$WORKSPACE|/home/omero|g" > omero/sysadmins/unix/install-web/nginx-omero.conf
+$WORKSPACE/OMERO.server/bin/omero web config nginx | sed "s|$WORKSPACE/OMERO.server|/home/omero/OMERO.py|g" > omero/sysadmins/unix/install-web/nginx-omero.conf
 $WORKSPACE/OMERO.server/bin/omero web config nginx-location | sed "s|$WORKSPACE|/home/omero|g" | grep -v '^#' > omero/sysadmins/unix/install-web/nginx-location.conf
 $WORKSPACE/OMERO.server/bin/omero web config nginx-location | sed "s|/opt/omero/web|/home/omero|g" | grep '^##' | cut -c3-
 > omero/sysadmins/unix/install-web/nginx-location-manual-wrapper.conf


### PR DESCRIPTION
Replace OMERO.server by OMERO.py
The generated file is used when OMERO.web is installed separately from OMERO.server

cc  @manics 