### PR TITLE
database upgrade for OMERO <5.3.4

### DIFF
--- a/omero/sysadmins/server-upgrade.rst
+++ b/omero/sysadmins/server-upgrade.rst
@@ -121,9 +121,10 @@ precautionary checks also done by the actual upgrade script.
    The :file:`sql/psql/OMERO5.4__0/OMERO5.3__1-precheck.sql` script
    referenced by the above :program:`psql` command assumes a planned
    upgrade from OMERO 5.3.4. If you are instead currently running OMERO
-   5.3.3 or an earlier 5.3.x version then you perform the precheck by using the above
-   command with :file:`sql/psql/OMERO5.4__0/OMERO5.3__0-precheck.sql`.
-   That script verifies that the database contains no trace of
+   5.3.3 or an earlier 5.3.x version then you perform the precheck by
+   using the above command with
+   :file:`sql/psql/OMERO5.4__0/OMERO5.3__0-precheck.sql`. That script
+   verifies that the database contains no trace of
    :secvuln:`2017-SV5-filename-2` having been exploited; this
    vulnerability was fixed in OMERO 5.3.4.
 
@@ -250,9 +251,10 @@ intermediate major release.
 
    The :file:`sql/psql/OMERO5.4__0/OMERO5.3__1.sql` script referenced by
    the above :program:`psql` command assumes upgrade from OMERO 5.3.4.
-   If you are instead currently running OMERO 5.3.3 or an earlier 5.3.x version then you
-   upgrade the database directly to OMERO 5.4.0 by using the above
-   command with :file:`sql/psql/OMERO5.4__0/OMERO5.3__0.sql`.
+   If you are instead currently running OMERO 5.3.3 or an earlier 5.3.x
+   version then you upgrade the database directly to OMERO 5.4.0 by
+   using the above command with
+   :file:`sql/psql/OMERO5.4__0/OMERO5.3__0.sql`.
 
 Delete certain annotations (optional)
 """""""""""""""""""""""""""""""""""""

--- a/omero/sysadmins/server-upgrade.rst
+++ b/omero/sysadmins/server-upgrade.rst
@@ -116,6 +116,14 @@ precautionary checks also done by the actual upgrade script.
     (1 row)
 
 
+.. warning::
+
+   The :file:`sql/psql/OMERO5.4__0/OMERO5.3__1-precheck.sql` script
+   referenced by the above :program:`psql` command assumes a planned
+   upgrade from OMERO 5.3.4. If you are instead currently running OMERO
+   5.3.0 to 5.3.3 then you perform the precheck by using the above
+   command with :file:`sql/psql/OMERO5.4__0/OMERO5.3__0-precheck.sql`.
+
 .. _back-up-the-db:
 
 Perform a database backup
@@ -234,6 +242,14 @@ intermediate major release.
    If you perform the database upgrade using *SQL shell*, make sure you are
    connected to the database using **db_user** before running the script. See
    :forum:`this forum thread <viewtopic.php?f=5&t=7778>` for more information.
+
+.. warning::
+
+   The :file:`sql/psql/OMERO5.4__0/OMERO5.3__1.sql` script referenced by
+   the above :program:`psql` command assumes upgrade from OMERO 5.3.4.
+   If you are instead currently running OMERO 5.3.0 to 5.3.3 then you
+   upgrade the database directly to OMERO 5.4.0 by using the above
+   command with :file:`sql/psql/OMERO5.4__0/OMERO5.3__0.sql`.
 
 Delete certain annotations (optional)
 """""""""""""""""""""""""""""""""""""

--- a/omero/sysadmins/server-upgrade.rst
+++ b/omero/sysadmins/server-upgrade.rst
@@ -123,6 +123,9 @@ precautionary checks also done by the actual upgrade script.
    upgrade from OMERO 5.3.4. If you are instead currently running OMERO
    5.3.0 to 5.3.3 then you perform the precheck by using the above
    command with :file:`sql/psql/OMERO5.4__0/OMERO5.3__0-precheck.sql`.
+   That script verifies that the database contains no trace of
+   :secvuln:`2017-SV5-filename-2` having been exploited; this
+   vulnerability was fixed in OMERO 5.3.4.
 
 .. _back-up-the-db:
 

--- a/omero/sysadmins/server-upgrade.rst
+++ b/omero/sysadmins/server-upgrade.rst
@@ -121,7 +121,7 @@ precautionary checks also done by the actual upgrade script.
    The :file:`sql/psql/OMERO5.4__0/OMERO5.3__1-precheck.sql` script
    referenced by the above :program:`psql` command assumes a planned
    upgrade from OMERO 5.3.4. If you are instead currently running OMERO
-   5.3.0 to 5.3.3 then you perform the precheck by using the above
+   5.3.3 or an earlier 5.3.x version then you perform the precheck by using the above
    command with :file:`sql/psql/OMERO5.4__0/OMERO5.3__0-precheck.sql`.
    That script verifies that the database contains no trace of
    :secvuln:`2017-SV5-filename-2` having been exploited; this
@@ -250,7 +250,7 @@ intermediate major release.
 
    The :file:`sql/psql/OMERO5.4__0/OMERO5.3__1.sql` script referenced by
    the above :program:`psql` command assumes upgrade from OMERO 5.3.4.
-   If you are instead currently running OMERO 5.3.0 to 5.3.3 then you
+   If you are instead currently running OMERO 5.3.3 or an earlier 5.3.x version then you
    upgrade the database directly to OMERO 5.4.0 by using the above
    command with :file:`sql/psql/OMERO5.4__0/OMERO5.3__0.sql`.
 


### PR DESCRIPTION
Look for warning boxes at https://ci.openmicroscopy.org/job/OMERO-DEV-merge-docs/ws/src/omero/_build/html/sysadmins/server-upgrade.html.

I figured that this approach was least invasive to the default workflow which favors those who are already running a secure public release. Note that some version numbers may look odd because `conf_autogen.py` is running behind and the "dbver" helpers it defines appear not to work within `:file:` markup.