### PR TITLE
JAVA_OPTS for import

### DIFF
--- a/omero/sysadmins/troubleshooting.rst
+++ b/omero/sysadmins/troubleshooting.rst
@@ -299,7 +299,7 @@ For example to set a maximum heap space of 3GB:
 
 ::
 
-            $ export JAVA_OPTS=-Xmx3072M
+            $ export JAVA_OPTS=-Xmx3G
             $ bin/omero import ...
 
 

--- a/omero/sysadmins/troubleshooting.rst
+++ b/omero/sysadmins/troubleshooting.rst
@@ -294,7 +294,7 @@ Not enough heap space
             java.lang.OutOfMemoryError: Java heap space
 
 If you get an out of memory error, you can try increasing the maximum Java heap space,
-by setting the JAVA_OPTS variable before running the import command.
+by setting the :envvar:`JAVA_OPTS` variable before running the import command.
 For example to set a maximum heap space of 3GB:
 
 ::

--- a/omero/sysadmins/troubleshooting.rst
+++ b/omero/sysadmins/troubleshooting.rst
@@ -286,6 +286,23 @@ cleaned after the database has been wiped.
 
     :ome-devel:`[ome-devel] Directory exists but is not registered: CheckedPath(username_id) <2014-October/003020.html>`
 
+Not enough heap space
+^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+            java.lang.OutOfMemoryError: Java heap space
+
+If you get an out of memory error, you can try increasing the maximum Java heap space,
+by setting the JAVA_OPTS variable before running the import command.
+For example to set a maximum heap space of 3GB:
+
+::
+
+            $ export JAVA_OPTS=-Xmx3072M
+            $ bin/omero import ...
+
+
 DropBox fails to start: failed to get session
 ---------------------------------------------
 


### PR DESCRIPTION
Although it's mentioned in the forum a few times, the possibilty to increase the java heap space by setting the `JAVA_OPTS` is not mentioned in the docs. This PR adds a note about it in the 'Import errors' section of the sysadmin troubleshooting site.

See also https://trello.com/c/d4sBcJdT/150-ome-tiff-import-investigation

