### PR TITLE
centos6 nginx

### DIFF
--- a/omero/sysadmins/unix/server-centos6-ice36.rst
+++ b/omero/sysadmins/unix/server-centos6-ice36.rst
@@ -1,8 +1,11 @@
 OMERO.server installation on CentOS 6 with Python 2.7
 =====================================================
 
-This installation walkthrough should be read in conjunction with
-:doc:`server-installation` and :doc:`install-web`.
+This is an example walkthrough for installing OMERO on CentOS 6 with Python 2.7, using
+a dedicated system user, and should be read in conjunction with
+:doc:`server-installation` and :doc:`install-web`. You can use this as a guide
+for setting up your own test server. For production use you should also read
+the pages listed under :ref:`index-optimizing-server`.
 
 Running OMERO on CentOS 6 has a number of special requirements which
 deviate from the standard installation instructions. The instructions
@@ -103,6 +106,15 @@ variable:
 These settings will enable Python 2.7, and set the necessary
 environment variables for Ice 3.6 to work.
 
+Installing NGINX
+----------------
+
+**The following steps are run as the omero system user.**
+
+.. literalinclude:: walkthrough/walkthrough_centos6_py27_ius.sh
+    :start-after: #start-nginx-install
+    :end-before: #end-nginx-install
+
 Install OMERO.server
 --------------------
 
@@ -133,6 +145,13 @@ Configuring OMERO.web
 ---------------------
 
 **The following steps are run as the omero system user.**
+
+When following this section you can
+either use your own values, or alternatively
+source :download:`settings-web.env <walkthrough/settings-web.env>`:
+
+.. literalinclude:: walkthrough/settings-web.env
+   :start-after: Substitute
 
 Install other OMERO.web dependencies using pip:
 

--- a/omero/sysadmins/unix/server-centos6-ice36.rst
+++ b/omero/sysadmins/unix/server-centos6-ice36.rst
@@ -24,7 +24,7 @@ This should be read in conjunction with :doc:`../version-requirements`.
 
 .. warning::
 
-   CentOS 6 is deprecated, CentOS 7 is preferable for new installations
+   CentOS 6 is deprecated, CentOS 7 is preferable for new installations;
    see :doc:`server-centos7-ice36`.
 
 Setting up

--- a/omero/sysadmins/unix/server-centos6-ice36.rst
+++ b/omero/sysadmins/unix/server-centos6-ice36.rst
@@ -5,8 +5,7 @@ This is an example walkthrough for installing OMERO on CentOS 6 with Python 2.7,
 a dedicated system user, and should be read in conjunction with
 :doc:`server-installation` and :doc:`install-web`. You can use this as a guide
 for setting up your own test server. For production use you should also read
-the pages listed under :ref:`index-optimizing-server`. However CentOS 6 is deprecated,
-CentOS 7 is preferable for new installations see :doc:`server-centos7-ice36`.
+the pages listed under :ref:`index-optimizing-server`. 
 
 
 Running OMERO on CentOS 6 has a number of special requirements which
@@ -23,6 +22,10 @@ This guide describes how to install the **recommended** versions, not all
 the supported versions.
 This should be read in conjunction with :doc:`../version-requirements`.
 
+.. warning::
+
+   CentOS 6 is deprecated, CentOS 7 is preferable for new installations
+   see :doc:`server-centos7-ice36`.
 
 Setting up
 ----------

--- a/omero/sysadmins/unix/server-centos6-ice36.rst
+++ b/omero/sysadmins/unix/server-centos6-ice36.rst
@@ -5,7 +5,9 @@ This is an example walkthrough for installing OMERO on CentOS 6 with Python 2.7,
 a dedicated system user, and should be read in conjunction with
 :doc:`server-installation` and :doc:`install-web`. You can use this as a guide
 for setting up your own test server. For production use you should also read
-the pages listed under :ref:`index-optimizing-server`.
+the pages listed under :ref:`index-optimizing-server`. However CentOS 6 is deprecated,
+CentOS 7 is preferable for new installations see :doc:`server-centos7-ice36`.
+
 
 Running OMERO on CentOS 6 has a number of special requirements which
 deviate from the standard installation instructions. The instructions


### PR DESCRIPTION
Add nginx section following re-organisation

The walkthroughs in omero-install have been re-organized to allow a split of the doc between server and web
Some dependencies/variables were no longer installed/set for centos 6 as a consequence.

Since we won't have a installation of omeroweb separately from omeroserver for centos6, i have kept the actual structure