### PR TITLE
Add more restricted admin info to permissions page

### DIFF
--- a/omero/developers/Server/Permissions.rst
+++ b/omero/developers/Server/Permissions.rst
@@ -1,54 +1,5 @@
-OMERO permissions history, querying and usage
+OMERO permissions querying, usage and history
 =============================================
-
-Introduction
-------------
-
-The OMERO permissions model has had a significant overhaul from version 4.1.x 
-to 4.4.x. Users and groups have existed in OMERO since well before the initial 
-4.1.x releases and numerous permissions levels were possible in the 4.1.x 
-series but it was largely assumed that an Experimenter belonged to a single 
-Group and that the permissions of that Group were private.
- 
-The OMERO permissions system received its first significant update in 4.2.0 
-with the introduction of multiple group support throughout the platform and 
-group permissions levels. 
-
-In a 4.1.x object graph ``Group`` containment was not enforced i.e. two linked 
-objects (such as a ``Project`` and ``Dataset``) could in theory be members of 
-two distinct ``Groups``. All objects continued to carry their permissions and 
-those permissions were persisted in the database.
-
-Things to note about 4.2.x permissions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-* Objects could not be moved between groups easily.
-* It was not possible to reduce the permissions level of a group.
-* The delete service (introduced in OMERO 4.2.1) was made aware of the 
-  permissions system.
-* 'Default Group' switching was required to make queries in different 
-  permissions contexts.
-
-.. note:: Queries span only one group at a time. Inserts and updates as other 
-          users must be done by creating a session as that user.
-
-Changes for OMERO 4.4.x
-^^^^^^^^^^^^^^^^^^^^^^^
-
-The second major OMERO permissions system innovations were performed in 4.4.0:
-
-* Cross group querying was reintroduced.
-* Change group was enabled, allowing the movement of graphs of objects between 
-  groups.
-* Permissions level reduction was made possible for read-annotate to read-only 
-  transitions.
-* A thorough user interface review resulted in the following features being made available in the UI:
-   - single group browsing and user-switching (available since 4.4.0)
-   - browsing data across multiple groups (available since 4.4.6 and refined in 4.4.7)
-* The concept of a 'Default or Primary Group' was deprecated.
-
-.. note:: Queries, inserts and updates span ``any`` or ``all`` groups and ``any`` user via options flags.
-
 
 Working with the OMERO |release| permissions system
 ---------------------------------------------------
@@ -498,3 +449,58 @@ queries are only (unless otherwise filtered) restricted at the group level and
 not at the level of the user. Furthermore, the delete service always 
 internally performs all its queries in the ``omero.group=-1`` context unless 
 another more explicit one is specified.
+
+History
+-------
+
+The OMERO permissions model has had a significant overhaul from version 4.1.x 
+to 4.4.x. Users and groups have existed in OMERO since well before the initial 
+4.1.x releases and numerous permissions levels were possible in the 4.1.x 
+series but it was largely assumed that an Experimenter belonged to a single 
+Group and that the permissions of that Group were private.
+ 
+The OMERO permissions system received its first significant update in 4.2.0 
+with the introduction of multiple group support throughout the platform and 
+group permissions levels. 
+
+In a 4.1.x object graph ``Group`` containment was not enforced i.e. two linked 
+objects (such as a ``Project`` and ``Dataset``) could in theory be members of 
+two distinct ``Groups``. All objects continued to carry their permissions and 
+those permissions were persisted in the database.
+
+Things to note about 4.2.x permissions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* Objects could not be moved between groups easily.
+* It was not possible to reduce the permissions level of a group.
+* The delete service (introduced in OMERO 4.2.1) was made aware of the 
+  permissions system.
+* 'Default Group' switching was required to make queries in different 
+  permissions contexts.
+
+.. note:: Queries span only one group at a time. Inserts and updates as other 
+          users must be done by creating a session as that user.
+
+Changes for OMERO 4.4.x
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The second major OMERO permissions system innovations were performed in 4.4.0:
+
+* Cross group querying was reintroduced.
+* Change group was enabled, allowing the movement of graphs of objects between 
+  groups.
+* Permissions level reduction was made possible for read-annotate to read-only 
+  transitions.
+* A thorough user interface review resulted in the following features being made available in the UI:
+   - single group browsing and user-switching (available since 4.4.0)
+   - browsing data across multiple groups (available since 4.4.6 and refined in 4.4.7)
+* The concept of a 'Default or Primary Group' was deprecated.
+
+.. note:: Queries, inserts and updates span ``any`` or ``all`` groups and ``any`` user via options flags.
+
+Changes for OMERO 5.4.x
+^^^^^^^^^^^^^^^^^^^^^^^
+
+OMERO 5.4.0 included Restricted Administrators as a new user role. See
+:doc:`/sysadmins/admins-with-restricted-privileges` and :doc:`LightAdmins` for
+more information.

--- a/omero/sysadmins/server-permissions.rst
+++ b/omero/sysadmins/server-permissions.rst
@@ -14,7 +14,7 @@ members of the group depends on the permissions settings for that
 group. Whenever a user logs on to an OMERO server, they are connected
 under one of their groups. All data they import and any work that is
 done is assigned to the current group, however the user can now
-easily copy their data into another group.
+easily move their data into another group.
 
 Users
 -----

--- a/omero/sysadmins/server-permissions.rst
+++ b/omero/sysadmins/server-permissions.rst
@@ -36,17 +36,21 @@ Users
     **Group member**
         This is the standard user.
 
+    **Restricted Administrators**
+        New in OMERO 5.4.0, these administrators can be created with a subset
+        of privileges allowing trusted users to act on behalf of all other
+        OMERO users for a defined set of tasks. See
+        :doc:`/sysadmins/admins-with-restricted-privileges` for further
+        information.
 
-Groups and users must be created by the server administrator. Users can
+Groups and users must be created by the server administrator or a restricted
+administrator with the correct privileges. Users can
 then be added by the administrator or by one of the group owners
 assigned by the administrator. This would typically be the PI of the
-lab. The group's owners or server administrator can also choose the
+lab. The group's owners or administrators can also choose the
 permission level for that group. See the :help:`Help guide for managing groups
 <sharing-data.html#owner>` for more information about how to administrate them
 in OMERO.
-Version 5.4.0 introduces the ability to create 'Restricted Administrators'
-with a selected subset of permissions,
-see :doc:`/sysadmins/admins-with-restricted-privileges` for further information.
 
 Group permission levels
 -----------------------
@@ -124,6 +128,11 @@ The various permission levels are:
          to all the data.
 
 
+.. note:: Restricted administrators are designed to work independently of
+    group permissions. They act as full administrators when using their subset
+    of privileges, allowing them to perform actions on data belonging to other
+    users even in private groups (see the permissions tables below).
+
 .. seealso::
 
     :help:`Help guide for sharing data <sharing-data.html>`
@@ -188,8 +197,15 @@ Permissions tables
 
 The following are the permissions valid for users working on data belonging to
 other group members. These permissions depend on the group permissions and on
-the type of the user performing the action. 
+the type of the user performing the action.
 
+**Restricted administrators act as full administrators when using their
+subset of privileges and standard group members for all other actions**. For
+example, a data analyst with write data privileges can edit data even in a
+private group (without having to be a member of that group) but without the
+delete privilege they cannot delete data belonging to another user unless that
+data is in a read-write group they are a member of. See
+:doc:`/sysadmins/admins-with-restricted-privileges` for further information.
 
 |
 

--- a/omero/sysadmins/server-permissions.rst
+++ b/omero/sysadmins/server-permissions.rst
@@ -217,7 +217,9 @@ their subset of privileges. See
 ^^^^^^^^^^^^^^^^^^^^^
 
 This table covers both full server administrators and restricted
-administrators with the privileges required for these actions.
+administrators with the privileges required for these actions. Restricted
+administrators act as group members for any actions that are not covered by
+their subset of privileges.
 
 |
 
@@ -271,8 +273,6 @@ administrators with the privileges required for these actions.
 :term:`Mix data`                              N                      N                       N              Y
 =============================== ======================= ===================== ====================== ===================
 
-Note that restricted administrators act as group members for any actions that
-are not covered by their subset of privileges.
 
 Key
 ^^^

--- a/omero/sysadmins/server-permissions.rst
+++ b/omero/sysadmins/server-permissions.rst
@@ -29,9 +29,9 @@ Users
 
     **Group owner**
         Your group may have one or more owners. The group
-        owner has some additional rights within each group than a standard
-        group member, including the ability to add other members to the
-        group.
+        owner has some additional rights within each group compared to a
+        standard group member, including the ability to add other members to
+        the group.
 
     **Group member**
         This is the standard user.

--- a/omero/sysadmins/server-permissions.rst
+++ b/omero/sysadmins/server-permissions.rst
@@ -44,8 +44,9 @@ Users
         information.
 
 Groups and users must be created by the server administrator or a restricted
-administrator with the correct privileges. Users can
-then be added by the administrator or by one of the group owners
+administrator with the correct privileges. Users can then be added by the
+administrator (either a full admin or a restricted admin with the correct
+privileges) or by one of the group owners
 assigned by the administrator. This would typically be the PI of the
 lab. The group's owners or administrators can also choose the
 permission level for that group. See the :help:`Help guide for managing groups
@@ -200,17 +201,23 @@ other group members. These permissions depend on the group permissions and on
 the type of the user performing the action.
 
 **Restricted administrators act as full administrators when using their
-subset of privileges and standard group members for all other actions**. For
+subset of privileges. For all actions which are not covered by their
+privileges subset, they act as standard group members.** For
 example, a data analyst with write data privileges can edit data even in a
 private group (without having to be a member of that group) but without the
 delete privilege they cannot delete data belonging to another user unless that
-data is in a read-write group they are a member of. See
+data is in a read-write group they are a member of. All restricted
+administrators can view and download any data regardless of group type and
+their subset of privileges. See
 :doc:`/sysadmins/admins-with-restricted-privileges` for further information.
 
 |
 
 :term:`Administrator`
 ^^^^^^^^^^^^^^^^^^^^^
+
+This table covers both full server administrators and restricted
+administrators with the privileges required for these actions.
 
 |
 
@@ -263,6 +270,9 @@ data is in a read-write group they are a member of. See
 :term:`Remove annotations`                N                      N                       N              Y
 :term:`Mix data`                              N                      N                       N              Y
 =============================== ======================= ===================== ====================== ===================
+
+Note that restricted administrators act as group members for any actions that
+are not covered by their subset of privileges.
 
 Key
 ^^^


### PR DESCRIPTION
See https://trello.com/c/CyNSQK9a/157-add-restricted-admin-mention-cross-reference-to-sysadmins-groups-permissions-system-page

Both @pwalczysko and i managed to miss that we had actually added restricted admins to the main permissions page so I've moved the reference to signpost it better and I've also added some extra info further down the page with a further cross-reference incase someone skips straight to the permissions table.