### PR TITLE
Update osx install instructions

### DIFF
--- a/omero/sysadmins/unix/server-install-homebrew.rst
+++ b/omero/sysadmins/unix/server-install-homebrew.rst
@@ -10,10 +10,6 @@ OMERO.server installation on OS X with Homebrew
     via Homebrew, in addition to all its prerequisites. It is aimed at **developers**
     since typically MacOS X is not suited for serious server deployment.
 
-These instructions are implemented in a series of `automated scripts
-<https://github.com/ome/omero-install/tree/develop/osx>`_ which
-install OMERO via Homebrew from a fresh configuration.
-
 Prerequisites
 -------------
 

--- a/omero/sysadmins/unix/server-install-homebrew.rst
+++ b/omero/sysadmins/unix/server-install-homebrew.rst
@@ -127,7 +127,11 @@ OMERO installation
 OMERO |release| server
 ^^^^^^^^^^^^^^^^^^^^^^
 
-To install and deploy the |release| release of OMERO.server, run::
+Run the following command to download a build of OMERO Server to a folder called '/OMERO'
+
+    mkdir -p Omero && curl https://downloads.openmicroscopy.org/omero/5.3.4/artifacts/OMERO.server-5.3.4-ice36-b69.zip > Omero/OMERO.server.zip
+
+Extract the OMERO.server.zip
 
     $ brew install omero53 --with-nginx --with-cpp
     $ export PYTHONPATH=$(brew --prefix omero53)/lib/python

--- a/omero/sysadmins/unix/server-install-homebrew.rst
+++ b/omero/sysadmins/unix/server-install-homebrew.rst
@@ -24,6 +24,17 @@ Homebrew requires the latest version of Xcode. Install :program:`Xcode` and
 the Command Line Tools for Xcode from the App Store. If you have already
 installed it, make sure all the latest updates are installed.
 
+Homebrew
+^^^^^^^^
+
+.. _`Homebrew wiki`: https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Installation.md
+
+Homebrew will install all packages under :file:`/usr/local`. See also: Installation instructions on the `Homebrew wiki`_.
+
+Install Homebrew using the following command in terminal::
+
+    $ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+
 Java
 ^^^^
 
@@ -41,6 +52,7 @@ running::
     $ javac -version
     javac 1.8.0_51
 
+
 OSX Basics
 ------------
 
@@ -48,9 +60,12 @@ In order to develop on OMERO, we recommend you ensure you have your MAC setup fo
 developement. This first step to achieving this, is to create a bash_profile file in the
 root directory of your user folder.
 
-To create a ~/.bash_profile from terminal, if one does not already exist::
+To create a .bash_profile from terminal, if one does not already exist::
 
     $ touch ~/.bash_profile
+
+OMERO enviorment variables
+------------------
 
 Open your .bash_profile in your favourite text editor, such as the built in TextEdit app::
 
@@ -58,19 +73,6 @@ Open your .bash_profile in your favourite text editor, such as the built in Text
 
 Requirements
 ------------
-
-.. _`Homebrew wiki`: https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Installation.md
-
-All the requirements for OMERO will be installed under :file:`/usr/local`. See also: Installation instructions on the `Homebrew wiki`_.
-
-Install Homebrew using the following command in terminal::
-
-    $ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-
-Update Homebrew and run 'brew doctor' to fix potential issues beforehand::
-
-    $ brew update
-    $ brew doctor
 
 Install git if not already present::
 
@@ -80,7 +82,17 @@ Install PostgreSQL database server::
 
     $ brew install postgresql
 
+OMERO depends on ICE 3.6 and unfortuently does not run with
+the latest version of ICE at this time (ICE 3.7.3). To obtain
+ICE 3.6, we need to add a *tap* to Homebrew::
 
+    $ brew tap zeroc-ice/tap
+    $ brew install zeroc-ice/tap/ice36
+
+.. Note:
+If you already have a version of ICE thats not 3.6 installed, you can instruct Homebrew to *unlink*
+it using ```$ brew unlink ice```. You can then instruct Homebrew to link to ICE 3.6 using
+```$ brew link ice@36```.
 
 .. _`Homebrew and Python`: https://github.com/Homebrew/brew/blob/master/docs/Homebrew-and-Python.md
 
@@ -95,13 +107,27 @@ To install the Python provided by Homebrew::
 
     $ brew install python
 
-(OPTIONAL) If you haven't already, follow the instructions from the brew python install and 
+Homebrew installs Python in the follwing location::
+
+    '/usr/local/opt/python/libexec/bin'
+
+Follow the instructions from the brew python install and 
 set the homebrew version of Python to be used rather than the Python version shipped
 with OSX::
 
     export PATH="/usr/local/opt/python/libexec/bin:$PATH"
 
-Check that Python is working and is version 2.7::
+**(OPTIONAL)** OR alternativly, to keep things a little cleaner, add the following 
+enviorment variable to your .bash_profile:
+
+    # Environment variable pointing to Homebrew Python location
+    export PYTHON_BREW=/usr/local/opt/python/libexec/bin
+ 
+and set the *PATH* to be::
+
+    export PATH="$PYTHON_BREW:$PATH"
+
+Check that Python is working and is version 2.7.x::
 
     $ which python
     /usr/local/opt/python/libexec/bin/python
@@ -109,41 +135,21 @@ Check that Python is working and is version 2.7::
     $ python --version
     Python 2.7.13
 
+For developing with OMERO, or Python in general, we would recommend you 
+use VirtaulEnv.
+VirtualEnv allows us to develop python applications without having to 
+worry about clashing thirdparty packages for different Python
+projects. 
+For example, OMERO requires Django 1.8 but you might have a project
+that uses Django 1.9. With Django 1.9 present on your system, you won't be
+able to run OMERO.
+
 If everything looks okay, go ahead and use pip to get VirtaulEnv
 
     $ pip install virtualenv
 
-VirtualEnv, eseentially, allows us to develop python applications
-without having to worry about clashing thirdparty package versions.
-
-
-
-
 See the :download:`step01_deps.sh <walkthrough/osx/step01_deps.sh>` script for
 the steps described above.
-
-OMERO enviorment variables
-------------------
-
-Make sure you have the following lines in your .bash_profile::
-
-    # UTF-8 and US language settings for Postgres
-    export LANG=en_US.UTF-8
-    export LANGUAGE=en_US:en
-
-    # OMERO Server distribution directory
-    export OMERO_SERVER=Omero/Server
-
-    # OMERO python libraries
-    export OMERO_PYTHON_LIBS=${OMERO_SERVER}/lib/python
-
-    # OMERO ice configuration
-    export OMERO_ICE_CONFIG=${OMERO_SERVER}/etc/ice.config
-
-    # Full path
-    export PATH=$OMERO_SERVER/bin:$OMERO_ICE_CONFIG:$PATH
-
-
 
 
 OMERO pre-built installation
@@ -152,17 +158,20 @@ OMERO pre-built installation
 OMERO |release| server
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Run the following command to download a build of OMERO Server to a folder called '/OMERO'
+Using the Terminal, prepare a place for your OMERO server to be downloaded to.
+We suggest a folder on your user directory called 'Omero':
 
-    $ mkdir -p Omero
-    $ curl https://downloads.openmicroscopy.org/omero/5.3.4/artifacts/OMERO.server-5.3.4-ice36-b69.zip > Omero/OMERO.server.zip
+    $ mkdir -p ~/Omero
 
-Extract the OMERO.server.zip
+Run the following command to download a build of OMERO Server:
 
-    $ brew install omero53 --with-nginx --with-cpp
-    $ export OMERO_SERVER=Omero/Server
-    $ export OMERO_PYTHON_LIBS=Omero/Server/lib/python
-    $ export OMERO_ICE_CONFIG=Omero/Server/etc/ice.config
+    $ curl https://downloads.openmicroscopy.org/omero/5.3.4/artifacts/OMERO.server-5.3.4-ice36-b69.zip > ~/Omero/OMERO.server.zip
+
+Extract the OMERO.zip
+
+Once extracted, open your .bash_profile in your favourite text editor, such as the built in TextEdit app::
+
+    $ open -a TextEdit.app ~/.bash_profile
 
 This will install the OMERO server to /usr/local/Cellar/omero, which means you
 will find the log files in :file:`/usr/local/Cellar/omero/|release|/var/log`.
@@ -173,7 +182,7 @@ The binaries will be linked to :file:`/usr/local/bin`::
 
 Install Ice 3.6 extension for Python and OMERO python dependencies::
 
-    $ pip install -r $(brew --prefix omero53)/share/web/requirements-py27-all.txt
+    $ pip install -r ~Omero/share/web/requirements-py27-all.txt
     $ cd /usr/local
     $ bash bin/omero_python_deps
 
@@ -185,15 +194,14 @@ Start database server::
 OMERO configuration
 ------------------
 
-
-
-Create database and user::
+1. To use Omero, we need to first needt to setup Postgres.
+Open a command-line terminal and run the following commands to create a 
+user called *db_user* and database called *omero_database*::
 
     $ createuser -w -D -R -S db_user
     $ createdb -E UTF8 -O db_user omero_database
-    $ psql -h localhost -U db_user -l
 
-Set database parameters in OMERO::
+2. Now we need to hSet database parameters in OMERO::
 
     $ omero config set omero.db.name omero_database
     $ omero config set omero.db.user db_user
@@ -215,19 +223,13 @@ See the OMERO installation script :download:`step02_omero.sh <walkthrough/osx/st
 Development server
 ^^^^^^^^^^^^^^^^^^
 
-If you wish to build OMERO.server from source for development
-purposes, using the git repository, first use Homebrew to install the
-OMERO dependencies::
-
-    $ brew install --only-dependencies omero
-
 The default version of Ice installed by the OMERO formula is currently
 Ice 3.6.
 
 Prepare a place for your OMERO code to live, e.g.::
 
-    $ mkdir -p ~/code/projects
-    $ cd ~/code/projects
+    $ mkdir -p ~/Omero/code/projects
+    $ cd ~/Omero/code/projects
 
 If you want the development version of OMERO.server, you can clone the source
 code from the project's GitHub account to build locally::
@@ -261,6 +263,31 @@ pick the right executbale::
     $ export PATH=~/code/projects/openmicroscopy/dist/bin:$PATH
 
 and follow the steps for setting up the database and OMERO data directory as mentioned in the previous section.
+
+OMERO example bash_profile
+------------------
+
+Open your .bash_profile in your favourite text editor, such as the built in TextEdit app::
+
+    $ open -a TextEdit.app ~/.bash_profile
+
+Your bash profile should look similar to the follwoing::
+
+    # UTF-8 and US language settings for Postgres
+    export LANG=en_US.UTF-8
+    export LANGUAGE=en_US:en
+
+    # OMERO Server distribution directory
+    export OMERO_SERVER=Omero/Server
+
+    # OMERO python libraries
+    export OMERO_PYTHON_LIBS=${OMERO_SERVER}/lib/python
+
+    # OMERO ice configuration
+    export OMERO_ICE_CONFIG=${OMERO_SERVER}/etc/ice.config
+
+    # Full path
+    export PATH=$OMERO_SERVER/bin:$OMERO_ICE_CONFIG:$PATH
 
 OMERO.web
 ^^^^^^^^^

--- a/omero/sysadmins/unix/server-install-homebrew.rst
+++ b/omero/sysadmins/unix/server-install-homebrew.rst
@@ -308,31 +308,6 @@ OMERO configuration
     $ omero db script --password omero -f - | psql -h localhost -U db_user omero_database
 
 
-OMERO example .bash_profile
---------------------------
-
-Open your .bash_profile in your favourite text editor, such as the built in TextEdit app::
-
-    $ open -a TextEdit.app ~/.bash_profile
-
-If you've followed this guide your bash profile should look similar to the follwoing::
-
-    # UTF-8 and US language settings for Postgres
-    export LANG=en_US.UTF-8
-    export LANGUAGE=en_US:en
-
-    # OMERO Server distribution directory
-    export OMERO_SERVER=Omero/Server
-
-    # OMERO python libraries
-    export OMERO_PYTHON_LIBS=${OMERO_SERVER}/lib/python
-
-    # OMERO ice configuration
-    export OMERO_ICE_CONFIG=${OMERO_SERVER}/etc/ice.config
-
-    # Full path
-    export PATH=$OMERO_SERVER/bin:$OMERO_ICE_CONFIG:$PATH
-
 OMERO.web
 ^^^^^^^^^
 
@@ -389,6 +364,31 @@ See example script for a basic functionality test: :download:`step04_test.sh <wa
 
 Common issues
 -------------
+
+Example .bash_profile
+^^^^^^^^^^^^^^^^^^^^^^
+
+Open your .bash_profile in your favourite text editor, such as the built in TextEdit app::
+
+    $ open -a TextEdit.app ~/.bash_profile
+
+If you've followed this guide your bash profile should look similar to the follwoing::
+
+    # UTF-8 and US language settings for Postgres
+    export LANG=en_US.UTF-8
+    export LANGUAGE=en_US:en
+
+    # OMERO Server distribution directory
+    export OMERO_SERVER=Omero/server
+
+    # OMERO python libraries
+    export OMERO_PYTHON_LIBS=${OMERO_SERVER}/lib/python
+
+    # OMERO ice configuration
+    export OMERO_ICE_CONFIG=${OMERO_SERVER}/etc/ice.config
+
+    # Full path
+    export PATH=$OMERO_SERVER/bin:$OMERO_ICE_CONFIG:$PATH
 
 General considerations
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/omero/sysadmins/unix/server-install-homebrew.rst
+++ b/omero/sysadmins/unix/server-install-homebrew.rst
@@ -399,8 +399,14 @@ If you have followed this guide your :file:`.bash_profile` should look similar t
     # OMERO ice configuration
     export OMERO_ICE_CONFIG=${OMERO_SERVER}/etc/ice.config
 
+    # Homebrew Python path
+    export BREW_PYTHON=/usr/local/opt/python/libexec/bin
+
     # Full path
-    export PATH=$OMERO_SERVER/bin:$OMERO_ICE_CONFIG:$PATH
+    export PATH=$OMERO_SERVER/bin:$OMERO_ICE_CONFIG:BREW_PYTHON:$PATH
+
+    # Start a virtual environment for developing Python
+    alias startVmOmero='source ~/Virtual/omero/bin/activate'
 
 General considerations
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/omero/sysadmins/unix/server-install-homebrew.rst
+++ b/omero/sysadmins/unix/server-install-homebrew.rst
@@ -52,24 +52,24 @@ running::
     javac 1.8.0_51
 
 
-OSX Basics
-------------
+OS X Basics
+-----------
 
-In order to develop on OMERO, we recommend you ensure you have your MAC setup for
-developement. The first step to achieving this is to create a .bash_profile file in the
+In order to develop on OMERO, we recommend you ensure you have your Mac setup for
+development. The first step to achieving this is to create a :file:`.bash_profile` file in the
 root directory of your user folder.
 
-To create a .bash_profile from terminal, if one does not already exist::
+To create a :file:`.bash_profile` from terminal, if one does not already exist::
 
     $ touch ~/.bash_profile
 
-To open your .bash_profile in a text editor, such as the built in TextEdit app, use::
+To open your :file:`.bash_profile` in a text editor, such as the built-in TextEdit app, use::
 
     $ open -a TextEdit.app ~/.bash_profile
 
 .. note::
-   If you want to see changes to your .bash_profile take affect without restarting
-   OSX, run::
+   If you want to see changes to your :file:`.bash_profile` take effect without restarting
+   OS X, run::
 
    $ source ~/.bash_profile
 
@@ -85,37 +85,37 @@ Requirements
     $ brew install postgresql
 
    To ensure PostgreSQL uses UTF-8 encoding, open your bash profile and 
-   add the following enviorment variables::
+   add the following enviornment variables::
 
     export LANG=en_US.UTF-8
     export LANGUAGE=en_US:en
 
-3. OMERO depends on ICE 3.6 and unfortuently does not run with 
-   the latest version of ICE at this time (ICE 3.7.3). To obtain 
-   ICE 3.6, we need to add a *tap* to Homebrew::
+3. OMERO depends on Ice 3.6 and unfortunately does not run with 
+   the latest version of Ice at this time (Ice 3.7.3). To obtain 
+   Ice 3.6, we need to add a *tap* to Homebrew::
 
     $ brew tap zeroc-ice/tap
     $ brew install zeroc-ice/tap/ice36
 
 .. Note::
-   If you already have a version of ICE thats not 3.6 installed, you can instruct Homebrew to *unlink* it using 
-   ```$ brew unlink ice```. You can then instruct Homebrew to link to ICE 3.6 using ```$ brew link ice@36```
+   If you already have a version of Ice that is not 3.6 installed, you can instruct Homebrew to *unlink* it using 
+   ```$ brew unlink ice```. You can then instruct Homebrew to link to Ice 3.6 using ```$ brew link ice@36```
 
 4. Install Python provided by Homebrew::
 
     $ brew install python
 
-   Homebrew installs Python in the follwing location::
+   Homebrew installs Python in the following location::
 
     '/usr/local/opt/python/libexec/bin'
 
-   Follow the instructions from the brew python install and set the Homebrew version of Python 
-   to be used rather than the Python shipped with OSX. Add the following line to your .bash_profile::
+   Follow the instructions from the brew Python install and set the Homebrew version of Python 
+   to be used rather than the Python shipped with OS X. Add the following line to your :file:`.bash_profile`::
 
     export PATH="/usr/local/opt/python/libexec/bin:$PATH"
 
 .. note:: 
-   To keep things a little cleaner, add the following enviorment variable to your .bash_profile::
+   To keep things a little cleaner, add the following enviornment variable to your :file:`.bash_profile`::
 
     # Environment variable pointing to Homebrew Python location
     export PYTHON_BREW=/usr/local/opt/python/libexec/bin
@@ -132,37 +132,37 @@ Requirements
     $ python --version
     Python 2.7.13
 
-6. For developing with OMERO, or Python in general, we would recommend you use VirtaulEnv.
-   VirtualEnv allows us to develop python applications without having to 
-   worry about clashing thirdparty packages for different Python projects.
+6. For developing with OMERO, or Python in general, we would recommend you use Virtualenv.
+   Virtualenv allows us to develop Python applications without having to 
+   worry about clashing third-party packages for different Python projects.
 
-   Use pip to get `VirtualEnv <https://virtualenv.pypa.io/en/stable/>`__::
+   Use pip to get `Virtualenv <https://virtualenv.pypa.io/en/stable/>`__::
 
     $ pip install virtualenv
 
-   With VirtualEnv installed, create a virtual enviorment::
+   With Virtualenv installed, create a virtual enviornment::
 
     $ virtualenv ~/Virtual/omero
 
    This will create a folder to hold Python libraries in the the directory :file:`~Virtual/omero/lib`
 
-.. note:: You can activate the VirtualEnv enviorment that we created using::
+.. note:: You can activate the Virtualenv enviornment that we created using::
 
     $ source ~/Virtual/omero/bin/activate
 
-   This will swtich to using pip and python in the VirtualEnv directory 
-   :file:`~/Virtual/omero/bin` and any pip libraries you install, whilst the VirtaulEnv
+   This will swtich to using Pip and Python in the Virtualenv directory 
+   :file:`~/Virtual/omero/bin` and any Pip libraries you install, whilst the Virtualenv
    is activated, will be installed to :file:`source ~/Virtual/omero/lib`.
 
-   .. note:: (OPTIONAL) You can add an `alias` to your .bash_profile file to make this step easier::
+   .. note:: (OPTIONAL) You can add an `alias` to your :file:`.bash_profile` to make this step easier::
 
         alias startVmOmero="source ~/Virtual/omero/bin/activate"
 
-      Reload bash_profile in OSX::
+      Reload :file:`.bash_profile` in OS X::
 
         $ source ~/.bash_profile
 
-      Now you can activate the VirtualEnv enviorment using::
+      Now you can activate the Virtualenv enviornment using::
 
         $ startVmOmero
 
@@ -175,44 +175,44 @@ OMERO installation
 Pre-built server
 ^^^^^^^^^^^^^^^^
 
-1. Using the command-line Terminal, prepare a place for your OMERO server to 
+1. Using the command-line terminal, prepare a place for your OMERO server to 
    be downloaded to. We suggest a folder on your user directory called 'Omero'::
 
-    $ mkdir -p ~/Omero
+    $ mkdir -p ~/Projects/Omero
 
    Run the following command to download a build of OMERO.Server::
 
-    $ curl https://downloads.openmicroscopy.org/omero/5.3.4/artifacts/OMERO.server-5.3.4-ice36-b69.zip > ~/Omero/server.zip
+    $ curl https://downloads.openmicroscopy.org/omero/5.3.4/artifacts/OMERO.server-5.3.4-ice36-b69.zip > ~/Projects/Omero/server.zip
 
    Extract the :file:`server.zip`
 
-2. Once extracted, open your .bash_profile in a text editor, 
-   such as the built in TextEdit app::
+2. Once extracted, open your :file:`.bash_profile` in a text editor, 
+   such as the built-in TextEdit app::
 
     $ open -a TextEdit.app ~/.bash_profile
 
-   Add an enviorment variable OMERO_SERVER to the .bash_profile which points
-   to the location of the OMERO executbale::
+   Add an enviornment variable :envvar:OMERO_SERVER to the :file:`.bash_profile` which points
+   to the location of the OMERO executabale::
 
     # OMERO Server distribution directory
-    export OMERO_SERVER=~/Omero/server
+    export OMERO_SERVER=~/Projects/Omero/server
 
-   and add the OMERO executbale to the OSX :envvar:`PATH`::
+   and add the OMERO executabale to the OS X :envvar:`PATH`::
 
     # Add the OMERO distribution to PATH
     export PATH=OMERO_SERVER/bin:$PATH
 
-   Using the command-line Terminal reload .bash_profile in OSX::
+   Using the command-line terminal reload :file:`.bash_profile` in OS X::
 
     $ source ~/.bash_profile
 
-   To ensure OMERO is correctly linked into your OSX :envvar:`PATH`, type the following in Terminal and ensure
+   To ensure OMERO is correctly linked into your OS X :envvar:`PATH`, type the following in terminal and ensure
    you get a similar output::
 
     $ which omero
-    /Omero/server/bin/omero
+    /Projects/Omero/server/bin/omero
 
-3. Activate the VirtualEnv enviorment that we created earlier in the "Requirements"
+3. Activate the Virtualenv enviornment that we created earlier in the "Requirements"
    section::
 
     $ source ~/Virtual/Omero/bin/activate
@@ -229,8 +229,8 @@ Local built server
 
 1. Prepare a place for your OMERO code to live, e.g.::
 
-    $ mkdir -p ~/Omero/code/projects
-    $ cd ~/Omero/code/projects
+    $ mkdir -p ~/Projects/Omero/code/projects
+    $ cd ~/Projects/Omero/code/projects
 
 2. Clone the source code from the project's GitHub account to build locally::
 
@@ -253,14 +253,14 @@ Local built server
     :doc:`/developers/build-system`
         Developer documentation page on how to build the OMERO.server
 
-3. Once the build completes, the OMERO server build output will be located in :file:`~/Omero/code/projects/openmicroscopy/dist`.
+3. Once the build completes, the OMERO server build output will be located in :file:`~/Projects/Omero/code/projects/openmicroscopy/dist`.
    Prepend the :file:`bin` directory to your :envvar:`PATH`::
 
     $ export PATH=~/code/projects/openmicroscopy/dist/bin:$PATH
 
    and follow the steps for setting up the database and OMERO data directory as mentioned in the previous section.
 
-4. Activate the VirtualEnv enviorment that we created earlier in the "Requirements"
+4. Activate the Virtualenv enviornment that we created earlier in the "Requirements"
    section::
 
     $ source ~/Virtual/Omero/bin/activate
@@ -279,10 +279,10 @@ OMERO configuration
 
     $ pg_ctl -D /usr/local/var/postgres -l /usr/local/var/postgres/server.log -w start
 
-.. note: To make life easier, you can add an ```alias``` to your .bash_profile
-   to make starting a VirtualEnv enviorment easier::
+.. note: To make life easier, you can add an ```alias``` to your :file:`.bash_profile`
+   to make starting a Virtualenv enviornment easier::
     
-    # Start VirtualEnv for OMERO
+    # Start Virtualenv for OMERO
     alias startVmOmero=Virtual/Omero/bin/activate
 
    You can also add an `alias` to start and stop the Postgres service::
@@ -290,7 +290,7 @@ OMERO configuration
     alias startPg='pg_ctl -D /usr/local/var/postgres -l /usr/local/var/postgres/server.log -w start'
     alias stopPg='pg_ctl -D /usr/local/var/postgres -l /usr/local/var/postgres/server.log -w stop'
 
-   Reload bash_profile in OSX::
+   Reload :file:`.bash_profile` in OS X::
 
     $ source ~/.bash_profile
 
@@ -302,15 +302,15 @@ OMERO configuration
 
 3. Create directory for OMERO to store its data::
 
-    $ mkdir -p ~/Omero/data
+    $ mkdir -p ~/Projects/Omero/data
 
-4. Start your VirtaulEnv enviorment we created earlier::
+4. Start your Virtualenv enviornment we created earlier::
 
     $ source ~/Virtual/omero/bin/activate
 
 5. Now set the OMERO configuration::
 
-    $ omero config set omero.data.dir ~/Omero/data
+    $ omero config set omero.data.dir ~/Projects/Omero/data
     $ omero config set omero.db.name omero_database
     $ omero config set omero.db.user db_user
     $ omero config set omero.db.pass db_password
@@ -380,18 +380,18 @@ Common issues
 Example .bash_profile
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Open your .bash_profile in your favourite text editor, such as the built in TextEdit app::
+Open your :file:`.bash_profile` in a text editor, such as the built-in TextEdit app::
 
     $ open -a TextEdit.app ~/.bash_profile
 
-If you've followed this guide your bash profile should look similar to the follwoing::
+If you have followed this guide your :file:`.bash_profile` should look similar to the following::
 
     # UTF-8 and US language settings for Postgres
     export LANG=en_US.UTF-8
     export LANGUAGE=en_US:en
 
     # OMERO Server distribution directory
-    export OMERO_SERVER=Omero/server
+    export OMERO_SERVER=Projects/Omero/server
 
     # OMERO python libraries
     export OMERO_PYTHON_LIBS=${OMERO_SERVER}/lib/python

--- a/omero/sysadmins/unix/server-install-homebrew.rst
+++ b/omero/sysadmins/unix/server-install-homebrew.rst
@@ -156,7 +156,8 @@ Requirements
    :file:`~/Virtual/omero/bin` and any Pip libraries you install, whilst the Virtualenv is activated, 
    will be installed to :file:`source ~/Virtual/omero/lib`.
 
-7. **(Optional)** To make starting a Virtualenv enviornment easier, 
+  .. note::
+   **(Optional)** To make starting a Virtualenv enviornment easier, 
    you can add an `alias` to your :file:`.bash_profile`::
 
     alias startVmOmero="source ~/Virtual/omero/bin/activate"
@@ -256,7 +257,7 @@ Local built server
 
    Prepend the :file:`bin` directory to your :envvar:`PATH`::
 
-    export PATH=~/Projects/omero/code/openmicroscopy/dist/bin:$PATH
+    export PATH=~/Projects/Omero/code/openmicroscopy/dist/bin:$PATH
 
    Using the command-line terminal, reload your :file:`.bash_profile` using::
 
@@ -286,10 +287,10 @@ OMERO configuration
     $ pg_ctl -D /usr/local/var/postgres -l /usr/local/var/postgres/server.log -w start
 
   .. note::
-   To make life easier, you can add an ```alias``` to your :file:`.bash_profile`::
+   **(Optional)** To make life easier, you can add an ```alias``` to your :file:`.bash_profile`::
     
     # Start Virtualenv for OMERO
-    alias startVmOmero=Virtual/Omero/bin/activate
+    alias startVmOmero="source ~/Virtual/Omero/bin/activate"
 
    You can also add an `alias` to start and stop the Postgres service::
 

--- a/omero/sysadmins/unix/server-install-homebrew.rst
+++ b/omero/sysadmins/unix/server-install-homebrew.rst
@@ -67,7 +67,7 @@ To open your .bash_profile in a text editor, such as the built in TextEdit app, 
 
     $ open -a TextEdit.app ~/.bash_profile
 
-.. note: 
+.. note::
    If you want to see changes to your .bash_profile take affect without restarting
    OSX, run::
 
@@ -273,7 +273,7 @@ Local built server
 
 
 OMERO configuration
-------------------
+-------------------
 
 1. Start the database server::
 

--- a/omero/sysadmins/unix/server-install-homebrew.rst
+++ b/omero/sysadmins/unix/server-install-homebrew.rst
@@ -188,7 +188,7 @@ Pre-built server
    and add the OMERO executable to the OS X :envvar:`PATH`::
 
     # Add the OMERO distribution to PATH
-    export PATH=OMERO_SERVER/bin:$PATH
+    export PATH=$OMERO_SERVER/bin:$PATH
 
    Using the command-line terminal, reload your :file:`.bash_profile` using::
 
@@ -380,19 +380,13 @@ If you have followed this guide your :file:`.bash_profile` should look similar t
     export LANGUAGE=en_US:en
 
     # OMERO Server distribution directory
-    export OMERO_SERVER=Projects/Omero/server
-
-    # OMERO python libraries
-    export OMERO_PYTHON_LIBS=${OMERO_SERVER}/lib/python
-
-    # OMERO ice configuration
-    export OMERO_ICE_CONFIG=${OMERO_SERVER}/etc/ice.config
+    export OMERO_SERVER=/path/to/OMERO.server-x.x.x-ice36-bxx
 
     # Homebrew Python path
     export BREW_PYTHON=/usr/local/opt/python/libexec/bin
 
     # Full path
-    export PATH=$OMERO_SERVER/bin:$OMERO_ICE_CONFIG:BREW_PYTHON:$PATH
+    export PATH=$OMERO_SERVER/bin:BREW_PYTHON:$PATH
 
     # Start a virtual environment for developing Python
     alias startVmOmero='source ~/Virtual/omero/bin/activate'

--- a/omero/sysadmins/unix/server-install-homebrew.rst
+++ b/omero/sysadmins/unix/server-install-homebrew.rst
@@ -63,10 +63,15 @@ To create a .bash_profile from terminal, if one does not already exist::
 
     $ touch ~/.bash_profile
 
-Open your .bash_profile in a text editor, such as the built in TextEdit app::
+To open your .bash_profile in a text editor, such as the built in TextEdit app, use::
 
     $ open -a TextEdit.app ~/.bash_profile
 
+.. note: 
+   If you want to see changes to your .bash_profile take affect without restarting
+   OSX, run::
+
+   $ source ~/.bash_profile
 
 Requirements
 ------------
@@ -79,6 +84,12 @@ Requirements
 
     $ brew install postgresql
 
+   To ensure PostgreSQL uses UTF-8 encoding, open your bash profile and 
+   add the following enviorment variables::
+
+    export LANG=en_US.UTF-8
+    export LANGUAGE=en_US:en
+
 3. OMERO depends on ICE 3.6 and unfortuently does not run with 
    the latest version of ICE at this time (ICE 3.7.3). To obtain 
    ICE 3.6, we need to add a *tap* to Homebrew::
@@ -87,7 +98,8 @@ Requirements
     $ brew install zeroc-ice/tap/ice36
 
 .. Note::
-   If you already have a version of ICE thats not 3.6 installed, you can instruct Homebrew to *unlink* it using ```$ brew unlink ice```. You can then instruct Homebrew to link to ICE 3.6 using ```$ brew link ice@36```
+   If you already have a version of ICE thats not 3.6 installed, you can instruct Homebrew to *unlink* it using 
+   ```$ brew unlink ice```. You can then instruct Homebrew to link to ICE 3.6 using ```$ brew link ice@36```
 
 4. Install Python provided by Homebrew::
 
@@ -97,18 +109,18 @@ Requirements
 
     '/usr/local/opt/python/libexec/bin'
 
-   Follow the instructions from the brew python install and set the homebrew version of Python 
-   to be used rather than the Python shipped with OSX::
+   Follow the instructions from the brew python install and set the Homebrew version of Python 
+   to be used rather than the Python shipped with OSX. Add the following line to your .bash_profile::
 
     export PATH="/usr/local/opt/python/libexec/bin:$PATH"
 
-.. **(OPTIONAL)** To keep things a little cleaner, add the following 
-.. enviorment variable to your .bash_profile::
+.. note:: 
+   To keep things a little cleaner, add the following enviorment variable to your .bash_profile::
 
     # Environment variable pointing to Homebrew Python location
     export PYTHON_BREW=/usr/local/opt/python/libexec/bin
- 
-.. and set the :envvar:`PATH` to be::
+
+   and append it to the :envvar:`PATH`::
 
     export PATH="$PYTHON_BREW:$PATH"
 
@@ -174,7 +186,7 @@ Pre-built server
 
    Extract the :file:`server.zip`
 
-2. Once extracted, open your .bash_profile in your favourite text editor, 
+2. Once extracted, open your .bash_profile in a text editor, 
    such as the built in TextEdit app::
 
     $ open -a TextEdit.app ~/.bash_profile

--- a/omero/sysadmins/unix/server-install-homebrew.rst
+++ b/omero/sysadmins/unix/server-install-homebrew.rst
@@ -97,9 +97,8 @@ Requirements
 
     '/usr/local/opt/python/libexec/bin'
 
-   Follow the instructions from the brew python install and 
-   set the homebrew version of Python to be used rather than the Python version shipped
-   with OSX::
+   Follow the instructions from the brew python install and set the homebrew version of Python 
+   to be used rather than the Python shipped with OSX::
 
     export PATH="/usr/local/opt/python/libexec/bin:$PATH"
 
@@ -121,21 +120,15 @@ Requirements
     $ python --version
     Python 2.7.13
 
-   For developing with OMERO, or Python in general, we would recommend you 
-   use VirtaulEnv.
+6. For developing with OMERO, or Python in general, we would recommend you use VirtaulEnv.
    VirtualEnv allows us to develop python applications without having to 
-   worry about clashing thirdparty packages for different Python
-   projects. 
-   For example, OMERO requires Django 1.8 but you might have a project
-   that uses Django 1.9. With Django 1.9 present on your system, you won't be
-   able to run OMERO.
+   worry about clashing thirdparty packages for different Python projects.
 
-6. If everything looks okay, go ahead and use pip to get `VirtualEnv <https://virtualenv.pypa.io/en/stable/>`__::
+   Use pip to get `VirtualEnv <https://virtualenv.pypa.io/en/stable/>`__::
 
     $ pip install virtualenv
 
-   Using the command-line Terminal use VirtualEnv to create a virtual
-   enviorment location::
+   With VirtualEnv installed, create a virtual enviorment::
 
     $ virtualenv ~/Virtual/omero
 
@@ -315,8 +308,8 @@ OMERO configuration
     $ omero db script --password omero -f - | psql -h localhost -U db_user omero_database
 
 
-OMERO example bash_profile
-------------------
+OMERO example .bash_profile
+--------------------------
 
 Open your .bash_profile in your favourite text editor, such as the built in TextEdit app::
 
@@ -496,15 +489,3 @@ installed any Python packages using :program:`pip`. In the case where
 and then try running :file:`python_deps.sh` again. That should install
 :program:`pip` via Homebrew and put the Python packages in correct
 locations.
-
-This will install the OMERO server to :file:`/usr/local/Cellar/omero`, which means you
-will find the log files in :file:`/usr/local/Cellar/omero/|release|/var/log`.
-The binaries will be linked to :file:`/usr/local/bin`::
-
-
-   You should install OMERO using Python 2.7 provided by
-   Homebrew since it makes using Homebrew-provided modules
-   simpler, for example the Ice python bindings needed by OMERO. For a
-   more thorough description of the Homebrew solution, see the `Homebrew
-   and Python`_ page. Note that the automated script linked above tests
-   the OMERO installation using the Homebrew Python.

--- a/omero/sysadmins/unix/server-install-homebrew.rst
+++ b/omero/sysadmins/unix/server-install-homebrew.rst
@@ -4,8 +4,9 @@ OMERO.server installation on OS X with Homebrew
 .. topic:: Overview
 
     This walkthrough demonstrates how to install OMERO on a clean Mac
-    OS X system (10.9 or later) using Homebrew.  Note that this
-    demonstrates how to install OMERO.server *from the source code*
+    OS X system (10.9 or later) using Homebrew.  This demonstrates how to install
+    OMERO.server, either from the downloaded OMERO.server.zip
+    or *from the source code*
     via Homebrew, in addition to all its prerequisites. It is aimed at **developers**
     since typically MacOS X is not suited for serious server deployment.
 
@@ -68,7 +69,7 @@ To open your :file:`.bash_profile` in a text editor, such as the built-in TextEd
     $ open -a TextEdit.app ~/.bash_profile
 
 .. note::
-   If you want to see changes to your :file:`.bash_profile` take effect without restarting
+   If you want changes to your :file:`.bash_profile` to take effect without restarting
    OS X, run::
 
    $ source ~/.bash_profile
@@ -85,7 +86,7 @@ Requirements
     $ brew install postgresql
 
    To ensure PostgreSQL uses UTF-8 encoding, open your bash profile and 
-   add the following enviornment variables::
+   add the following environment variables::
 
     export LANG=en_US.UTF-8
     export LANGUAGE=en_US:en
@@ -110,20 +111,10 @@ Requirements
 
     '/usr/local/opt/python/libexec/bin'
 
-   Follow the instructions from the brew Python install and set the Homebrew version of Python 
-   to be used rather than the Python shipped with OS X. Add the following line to your :file:`.bash_profile`::
+   Follow the instructions from the brew Python install and set your system to use the Homebrew version of Python 
+   rather than the Python shipped with OS X. Add the following line to your :file:`.bash_profile`::
 
     export PATH="/usr/local/opt/python/libexec/bin:$PATH"
-
-  .. note::
-   **(Optional)** To keep things a little cleaner, add the following enviornment variable to your :file:`.bash_profile`::
-
-    # Environment variable pointing to Homebrew Python location
-    export PYTHON_BREW=/usr/local/opt/python/libexec/bin
-
-   and append it to the :envvar:`PATH`::
-
-    export PATH=$PYTHON_BREW:$PATH
 
 5. Check that Python is working and is version 2.7.x::
 
@@ -133,22 +124,22 @@ Requirements
     $ python --version
     Python 2.7.13
 
-6. For developing with OMERO, or Python in general, we would recommend you use Virtualenv.
-   Virtualenv allows us to develop Python applications without having to 
+6. For developing with OMERO, or Python in general, we recommend the use of Virtualenv.
+   Virtualenv allows development of Python applications without having to
    worry about clashing third-party packages for different Python projects.
 
    Use pip to get `Virtualenv <https://virtualenv.pypa.io/en/stable/>`__::
 
     $ pip install virtualenv
 
-   With Virtualenv installed, create a virtual enviornment::
+   With Virtualenv installed, create a virtual environment::
 
     $ virtualenv ~/Virtual/omero
 
    This will create a folder to hold Python libraries in the the directory :file:`~/Virtual/omero/lib`
 
   .. note:: 
-   You can activate the Virtualenv enviornment that we created using::
+   You can activate the Virtualenv environment that we created using::
 
     $ source ~/Virtual/omero/bin/activate
 
@@ -157,7 +148,7 @@ Requirements
    will be installed to :file:`source ~/Virtual/omero/lib`.
 
   .. note::
-   **(Optional)** To make starting a Virtualenv enviornment easier, 
+   **(Optional)** To make starting a Virtualenv environment easier,
    you can add an `alias` to your :file:`.bash_profile`::
 
     alias startVmOmero="source ~/Virtual/omero/bin/activate"
@@ -166,7 +157,7 @@ Requirements
 
     $ source ~/.bash_profile
 
-   Now you can activate the Virtualenv enviornment using::
+   Now you can activate the Virtualenv environment using::
 
     $ startVmOmero
 
@@ -177,28 +168,24 @@ Pre-built server
 ^^^^^^^^^^^^^^^^
 
 1. Using the command-line terminal, prepare a place for your OMERO server to 
-   be downloaded to. We suggest a folder on your user directory called 'Omero'::
+   be downloaded to.
 
-    $ mkdir -p ~/Projects/Omero
-
-   Run the following command to download a build of OMERO.Server::
-
-    $ curl https://downloads.openmicroscopy.org/omero/5.3.4/artifacts/OMERO.server-5.3.4-ice36-b69.zip > ~/Projects/Omero/server.zip
-
-   Extract the :file:`server.zip`
+   Find the current OMERO.server zip from the
+   `downloads page <https://downloads.openmicroscopy.org/latest/omero/artifacts/>`_.
+   Download and extract the OMERO.server-x.x.x-ice36-bxx.zip.
 
 2. Once extracted, open your :file:`.bash_profile` in a text editor, 
    such as the built-in TextEdit app::
 
     $ open -a TextEdit.app ~/.bash_profile
 
-   Add an enviornment variable :envvar:OMERO_SERVER to the :file:`.bash_profile` which points
-   to the location of the OMERO executabale::
+   Add an environment variable :envvar:OMERO_SERVER to the :file:`.bash_profile` which points
+   to the location of the OMERO executable::
 
     # OMERO Server distribution directory
-    export OMERO_SERVER=~/Projects/Omero/server
+    export OMERO_SERVER=/path/to/OMERO.server-x.x.x-ice36-bxx
 
-   and add the OMERO executabale to the OS X :envvar:`PATH`::
+   and add the OMERO executable to the OS X :envvar:`PATH`::
 
     # Add the OMERO distribution to PATH
     export PATH=OMERO_SERVER/bin:$PATH
@@ -211,20 +198,20 @@ Pre-built server
    you get a similar output::
 
     $ which omero
-    /Projects/Omero/server/bin/omero
+    /path/to/OMERO.server-x.x.x-ice36-bxx/bin/omero
 
-3. Activate the Virtualenv enviornment that we created earlier in the "Requirements"
+3. Activate the Virtualenv environment that we created earlier in the "Requirements"
    section::
 
     $ source ~/Virtual/Omero/bin/activate
 
 4. Install Python dependencies using pip::
 
-    $ pip install -r ~Omero/server/share/web/requirements-py27-all.txt
+    $ pip install -r "${OMERO_SERVER}/share/web/requirements-py27-all.txt"
 
 
-Local built server
-^^^^^^^^^^^^^^^^^^
+Locally built server
+^^^^^^^^^^^^^^^^^^^^
 
 1. Prepare a place for your OMERO code to live, e.g.::
 
@@ -269,7 +256,7 @@ Local built server
     $ which omero
     /Projects/omero/code/openmicroscopy/dist/bin/omero
 
-6. Activate the Virtualenv enviornment that we created earlier in the "Requirements"
+6. Activate the Virtualenv environment that we created earlier in the "Requirements"
    section::
 
     $ source ~/Virtual/Omero/bin/activate
@@ -287,12 +274,8 @@ OMERO configuration
     $ pg_ctl -D /usr/local/var/postgres -l /usr/local/var/postgres/server.log -w start
 
   .. note::
-   **(Optional)** To make life easier, you can add an ```alias``` to your :file:`.bash_profile`::
-    
-    # Start Virtualenv for OMERO
-    alias startVmOmero="source ~/Virtual/Omero/bin/activate"
-
-   You can also add an `alias` to start and stop the Postgres service::
+   **(Optional)** To make life easier, you can add an ```alias``` to your :file:`.bash_profile`
+   to start and stop the Postgres service::
 
     alias startPg='pg_ctl -D /usr/local/var/postgres -l /usr/local/var/postgres/server.log -w start'
     alias stopPg='pg_ctl -D /usr/local/var/postgres -l /usr/local/var/postgres/server.log -w stop'
@@ -309,15 +292,15 @@ OMERO configuration
 
 3. Create directory for OMERO to store its data::
 
-    $ mkdir -p ~/Projects/Omero/data
+    $ mkdir -p ~/OMERO
 
-4. Start your Virtualenv enviornment we created earlier::
+4. Start your Virtualenv environment we created earlier::
 
     $ source ~/Virtual/omero/bin/activate
 
 5. Now set the OMERO configuration::
 
-    $ omero config set omero.data.dir ~/Projects/Omero/data
+    $ omero config set omero.data.dir ~/OMERO
     $ omero config set omero.db.name omero_database
     $ omero config set omero.db.user db_user
     $ omero config set omero.db.pass db_password

--- a/omero/sysadmins/unix/server-install-homebrew.rst
+++ b/omero/sysadmins/unix/server-install-homebrew.rst
@@ -1,7 +1,6 @@
 OMERO.server installation on OS X with Homebrew
 ===============================================
 
-
 .. topic:: Overview
 
     This walkthrough demonstrates how to install OMERO on a clean Mac
@@ -57,77 +56,64 @@ OSX Basics
 ------------
 
 In order to develop on OMERO, we recommend you ensure you have your MAC setup for
-developement. This first step to achieving this, is to create a bash_profile file in the
+developement. The first step to achieving this is to create a .bash_profile file in the
 root directory of your user folder.
 
 To create a .bash_profile from terminal, if one does not already exist::
 
     $ touch ~/.bash_profile
 
-OMERO enviorment variables
-------------------
-
-Open your .bash_profile in your favourite text editor, such as the built in TextEdit app::
+Open your .bash_profile in a text editor, such as the built in TextEdit app::
 
     $ open -a TextEdit.app ~/.bash_profile
+
 
 Requirements
 ------------
 
-Install git if not already present::
+1. Open a command-line terminal and install git if not already present::
 
     $ brew install git
 
-Install PostgreSQL database server::
+2. Install PostgreSQL database server::
 
     $ brew install postgresql
 
-OMERO depends on ICE 3.6 and unfortuently does not run with
-the latest version of ICE at this time (ICE 3.7.3). To obtain
-ICE 3.6, we need to add a *tap* to Homebrew::
+3. OMERO depends on ICE 3.6 and unfortuently does not run with 
+   the latest version of ICE at this time (ICE 3.7.3). To obtain 
+   ICE 3.6, we need to add a *tap* to Homebrew::
 
     $ brew tap zeroc-ice/tap
     $ brew install zeroc-ice/tap/ice36
 
-.. Note:
-If you already have a version of ICE thats not 3.6 installed, you can instruct Homebrew to *unlink*
-it using ```$ brew unlink ice```. You can then instruct Homebrew to link to ICE 3.6 using
-```$ brew link ice@36```.
+.. Note::
+   If you already have a version of ICE thats not 3.6 installed, you can instruct Homebrew to *unlink* it using ```$ brew unlink ice```. You can then instruct Homebrew to link to ICE 3.6 using ```$ brew link ice@36```
 
-.. _`Homebrew and Python`: https://github.com/Homebrew/brew/blob/master/docs/Homebrew-and-Python.md
-
-You should install OMERO using Python 2.7 provided by
-Homebrew since it makes using Homebrew-provided modules
-simpler, for example the Ice python bindings needed by OMERO. For a
-more thorough description of the Homebrew solution, see the `Homebrew
-and Python`_ page. Note that the automated script linked above tests
-the OMERO installation using the Homebrew Python.
-
-To install the Python provided by Homebrew::
+4. Install Python provided by Homebrew::
 
     $ brew install python
 
-Homebrew installs Python in the follwing location::
+   Homebrew installs Python in the follwing location::
 
     '/usr/local/opt/python/libexec/bin'
 
-Follow the instructions from the brew python install and 
-set the homebrew version of Python to be used rather than the Python version shipped
-with OSX::
+   Follow the instructions from the brew python install and 
+   set the homebrew version of Python to be used rather than the Python version shipped
+   with OSX::
 
     export PATH="/usr/local/opt/python/libexec/bin:$PATH"
 
-**(OPTIONAL)** OR alternativly, to keep things a little cleaner, add the following 
-enviorment variable to your .bash_profile:
+.. **(OPTIONAL)** To keep things a little cleaner, add the following 
+.. enviorment variable to your .bash_profile::
 
     # Environment variable pointing to Homebrew Python location
     export PYTHON_BREW=/usr/local/opt/python/libexec/bin
  
-and set the *PATH* to be::
+.. and set the :envvar:`PATH` to be::
 
     export PATH="$PYTHON_BREW:$PATH"
 
-Check that Python is working and is version 2.7.x::
+5. Check that Python is working and is version 2.7.x::
 
     $ which python
     /usr/local/opt/python/libexec/bin/python
@@ -135,104 +121,113 @@ Check that Python is working and is version 2.7.x::
     $ python --version
     Python 2.7.13
 
-For developing with OMERO, or Python in general, we would recommend you 
-use VirtaulEnv.
-VirtualEnv allows us to develop python applications without having to 
-worry about clashing thirdparty packages for different Python
-projects. 
-For example, OMERO requires Django 1.8 but you might have a project
-that uses Django 1.9. With Django 1.9 present on your system, you won't be
-able to run OMERO.
+   For developing with OMERO, or Python in general, we would recommend you 
+   use VirtaulEnv.
+   VirtualEnv allows us to develop python applications without having to 
+   worry about clashing thirdparty packages for different Python
+   projects. 
+   For example, OMERO requires Django 1.8 but you might have a project
+   that uses Django 1.9. With Django 1.9 present on your system, you won't be
+   able to run OMERO.
 
-If everything looks okay, go ahead and use pip to get VirtaulEnv
+6. If everything looks okay, go ahead and use pip to get `VirtualEnv <https://virtualenv.pypa.io/en/stable/>`__::
 
     $ pip install virtualenv
 
-See the :download:`step01_deps.sh <walkthrough/osx/step01_deps.sh>` script for
-the steps described above.
+   Using the command-line Terminal use VirtualEnv to create a virtual
+   enviorment location::
 
+    $ virtualenv ~/Virtual/omero
 
-OMERO pre-built installation
+   This will create a folder to hold Python libraries in the the directory :file:`~Virtual/omero/lib`
+
+.. note:: You can activate the VirtualEnv enviorment that we created using::
+
+    $ source ~/Virtual/omero/bin/activate
+
+   This will swtich to using pip and python in the VirtualEnv directory 
+   :file:`~/Virtual/omero/bin` and any pip libraries you install, whilst the VirtaulEnv
+   is activated, will be installed to :file:`source ~/Virtual/omero/lib`.
+
+   .. note:: (OPTIONAL) You can add an `alias` to your .bash_profile file to make this step easier::
+
+        alias startVmOmero="source ~/Virtual/omero/bin/activate"
+
+      Reload bash_profile in OSX::
+
+        $ source ~/.bash_profile
+
+      Now you can activate the VirtualEnv enviorment using::
+
+        $ startVmOmero
+
+.. Note::
+   See the :download:`step01_deps.sh <walkthrough/osx/step01_deps.sh>` script for the steps described above.
+
+OMERO installation
 ------------------
 
-OMERO |release| server
-^^^^^^^^^^^^^^^^^^^^^^
+Pre-built server
+^^^^^^^^^^^^^^^^
 
-Using the Terminal, prepare a place for your OMERO server to be downloaded to.
-We suggest a folder on your user directory called 'Omero':
+1. Using the command-line Terminal, prepare a place for your OMERO server to 
+   be downloaded to. We suggest a folder on your user directory called 'Omero'::
 
     $ mkdir -p ~/Omero
 
-Run the following command to download a build of OMERO Server:
+   Run the following command to download a build of OMERO.Server::
 
-    $ curl https://downloads.openmicroscopy.org/omero/5.3.4/artifacts/OMERO.server-5.3.4-ice36-b69.zip > ~/Omero/OMERO.server.zip
+    $ curl https://downloads.openmicroscopy.org/omero/5.3.4/artifacts/OMERO.server-5.3.4-ice36-b69.zip > ~/Omero/server.zip
 
-Extract the OMERO.zip
+   Extract the :file:`server.zip`
 
-Once extracted, open your .bash_profile in your favourite text editor, such as the built in TextEdit app::
+2. Once extracted, open your .bash_profile in your favourite text editor, 
+   such as the built in TextEdit app::
 
     $ open -a TextEdit.app ~/.bash_profile
 
-This will install the OMERO server to /usr/local/Cellar/omero, which means you
-will find the log files in :file:`/usr/local/Cellar/omero/|release|/var/log`.
-The binaries will be linked to :file:`/usr/local/bin`::
+   Add an enviorment variable OMERO_SERVER to the .bash_profile which points
+   to the location of the OMERO executbale::
+
+    # OMERO Server distribution directory
+    export OMERO_SERVER=~/Omero/server
+
+   and add the OMERO executbale to the OSX :envvar:`PATH`::
+
+    # Add the OMERO distribution to PATH
+    export PATH=OMERO_SERVER/bin:$PATH
+
+   Using the command-line Terminal reload .bash_profile in OSX::
+
+    $ source ~/.bash_profile
+
+   To ensure OMERO is correctly linked into your OSX :envvar:`PATH`, type the following in Terminal and ensure
+   you get a similar output::
 
     $ which omero
-    /usr/local/bin/omero
+    /Omero/server/bin/omero
 
-Install Ice 3.6 extension for Python and OMERO python dependencies::
+3. Activate the VirtualEnv enviorment that we created earlier in the "Requirements"
+   section::
 
-    $ pip install -r ~Omero/share/web/requirements-py27-all.txt
+    $ source ~/Virtual/Omero/bin/activate
+
+4. Install Python dependencies using pip::
+
+    $ pip install -r ~Omero/server/share/web/requirements-py27-all.txt
     $ cd /usr/local
     $ bash bin/omero_python_deps
 
-Start database server::
 
-    $ pg_ctl -D /usr/local/var/postgres -l /usr/local/var/postgres/server.log -w start
-
-
-OMERO configuration
-------------------
-
-1. To use Omero, we need to first needt to setup Postgres.
-Open a command-line terminal and run the following commands to create a 
-user called *db_user* and database called *omero_database*::
-
-    $ createuser -w -D -R -S db_user
-    $ createdb -E UTF8 -O db_user omero_database
-
-2. Now we need to hSet database parameters in OMERO::
-
-    $ omero config set omero.db.name omero_database
-    $ omero config set omero.db.user db_user
-    $ omero config set omero.db.pass db_password
-
-Create and run script to initialize the OMERO database::
-
-    $ export ROOT_PASSWORD=${ROOT_PASSWORD:-omero}
-    $ omero db script --password $ROOT_PASSWORD -f - | psql -h localhost -U db_user omero_database
-
-Set up OMERO data directory::
-
-    $ export OMERO_DATA_DIR=${OMERO_DATA_DIR:-~/OMERO.data}
-    $ mkdir -p $OMERO_DATA_DIR
-    $ omero config set omero.data.dir $OMERO_DATA_DIR
-
-See the OMERO installation script :download:`step02_omero.sh <walkthrough/osx/step02_omero.sh>`
-
-Development server
+Local built server
 ^^^^^^^^^^^^^^^^^^
 
-The default version of Ice installed by the OMERO formula is currently
-Ice 3.6.
-
-Prepare a place for your OMERO code to live, e.g.::
+1. Prepare a place for your OMERO code to live, e.g.::
 
     $ mkdir -p ~/Omero/code/projects
     $ cd ~/Omero/code/projects
 
-If you want the development version of OMERO.server, you can clone the source
-code from the project's GitHub account to build locally::
+2. Clone the source code from the project's GitHub account to build locally::
 
     $ git clone --recursive git://github.com/openmicroscopy/openmicroscopy
     $ cd openmicroscopy && ./build.py
@@ -240,9 +235,7 @@ code from the project's GitHub account to build locally::
 .. note::
     If you have a GitHub account and you plan to develop code for OMERO, you
     should make a fork into your own account and then clone this fork to your
-    local development machine, e.g.
-
-    ::
+    local development machine, e.g. ::
 
         $ git remote add  git://github.com/YOURNAMEHERE/openmicroscopy
         $ cd openmicroscopy && ./build.py
@@ -255,14 +248,72 @@ code from the project's GitHub account to build locally::
     :doc:`/developers/build-system`
         Developer documentation page on how to build the OMERO.server
 
-
-
-Then prepend the development :file:`bin` directory to your :envvar:`PATH` to
-pick the right executbale::
+3. Once the build completes, the OMERO server build output will be located in :file:`~/Omero/code/projects/openmicroscopy/dist`.
+   Prepend the :file:`bin` directory to your :envvar:`PATH`::
 
     $ export PATH=~/code/projects/openmicroscopy/dist/bin:$PATH
 
-and follow the steps for setting up the database and OMERO data directory as mentioned in the previous section.
+   and follow the steps for setting up the database and OMERO data directory as mentioned in the previous section.
+
+4. Activate the VirtualEnv enviorment that we created earlier in the "Requirements"
+   section::
+
+    $ source ~/Virtual/Omero/bin/activate
+
+5. Install Python dependencies using pip::
+
+    $ pip install -r ~Omero/server/share/web/requirements-py27-all.txt
+    $ cd /usr/local
+    $ bash bin/omero_python_deps
+
+
+OMERO configuration
+------------------
+
+1. Start the database server::
+
+    $ pg_ctl -D /usr/local/var/postgres -l /usr/local/var/postgres/server.log -w start
+
+.. note: To make life easier, you can add an ```alias``` to your .bash_profile
+   to make starting a VirtualEnv enviorment easier::
+    
+    # Start VirtualEnv for OMERO
+    alias startVmOmero=Virtual/Omero/bin/activate
+
+   You can also add an `alias` to start and stop the Postgres service::
+
+    alias startPg='pg_ctl -D /usr/local/var/postgres -l /usr/local/var/postgres/server.log -w start'
+    alias stopPg='pg_ctl -D /usr/local/var/postgres -l /usr/local/var/postgres/server.log -w stop'
+
+   Reload bash_profile in OSX::
+
+    $ source ~/.bash_profile
+
+2. To use Omero, we need to first setup Postgres. Open a command-line terminal and run the 
+   following commands to create a user called *db_user* and database called *omero_database*::
+
+    $ createuser -w -D -R -S db_user
+    $ createdb -E UTF8 -O db_user omero_database
+
+3. Create directory for OMERO to store its data::
+
+    $ mkdir -p ~/Omero/data
+
+4. Start your VirtaulEnv enviorment we created earlier::
+
+    $ source ~/Virtual/omero/bin/activate
+
+5. Now set the OMERO configuration::
+
+    $ omero config set omero.data.dir ~/Omero/data
+    $ omero config set omero.db.name omero_database
+    $ omero config set omero.db.user db_user
+    $ omero config set omero.db.pass db_password
+
+6. Create and run script to initialize the OMERO database::
+
+    $ omero db script --password omero -f - | psql -h localhost -U db_user omero_database
+
 
 OMERO example bash_profile
 ------------------
@@ -271,7 +322,7 @@ Open your .bash_profile in your favourite text editor, such as the built in Text
 
     $ open -a TextEdit.app ~/.bash_profile
 
-Your bash profile should look similar to the follwoing::
+If you've followed this guide your bash profile should look similar to the follwoing::
 
     # UTF-8 and US language settings for Postgres
     export LANG=en_US.UTF-8
@@ -445,3 +496,15 @@ installed any Python packages using :program:`pip`. In the case where
 and then try running :file:`python_deps.sh` again. That should install
 :program:`pip` via Homebrew and put the Python packages in correct
 locations.
+
+This will install the OMERO server to :file:`/usr/local/Cellar/omero`, which means you
+will find the log files in :file:`/usr/local/Cellar/omero/|release|/var/log`.
+The binaries will be linked to :file:`/usr/local/bin`::
+
+
+   You should install OMERO using Python 2.7 provided by
+   Homebrew since it makes using Homebrew-provided modules
+   simpler, for example the Ice python bindings needed by OMERO. For a
+   more thorough description of the Homebrew solution, see the `Homebrew
+   and Python`_ page. Note that the automated script linked above tests
+   the OMERO installation using the Homebrew Python.

--- a/omero/sysadmins/unix/server-install-homebrew.rst
+++ b/omero/sysadmins/unix/server-install-homebrew.rst
@@ -6,7 +6,7 @@ OMERO.server installation on OS X with Homebrew
     This walkthrough demonstrates how to install OMERO on a clean Mac
     OS X system (10.9 or later) using Homebrew.  This demonstrates how to install
     OMERO.server, either from the downloaded OMERO.server.zip
-    or *from the source code*
+    or from the source code
     via Homebrew, in addition to all its prerequisites. It is aimed at **developers**
     since typically MacOS X is not suited for serious server deployment.
 
@@ -143,7 +143,7 @@ Requirements
 
     $ source ~/Virtual/omero/bin/activate
 
-   This will swtich to using Pip and Python in the Virtualenv directory 
+   This will switch to using Pip and Python in the Virtualenv directory
    :file:`~/Virtual/omero/bin` and any Pip libraries you install, whilst the Virtualenv is activated, 
    will be installed to :file:`source ~/Virtual/omero/lib`.
 
@@ -179,7 +179,7 @@ Pre-built server
 
     $ open -a TextEdit.app ~/.bash_profile
 
-   Add an environment variable :envvar:OMERO_SERVER to the :file:`.bash_profile` which points
+   Add an environment variable :envvar:`OMERO_SERVER` to the :file:`.bash_profile` which points
    to the location of the OMERO executable::
 
     # OMERO Server distribution directory
@@ -238,7 +238,7 @@ Locally built server
         Developer documentation page on how to build the OMERO.server
 
 5. Once the build completes, the OMERO server build output will be located in :file:`~/Projects/Omero/code/openmicroscopy/dist`.
-   If it is not already open, open your :file:`.bash_profie`::
+   If it is not already open, open your :file:`.bash_profile`::
 
     $ open -a TextEdit.app ~/.bash_profile
 
@@ -284,7 +284,7 @@ OMERO configuration
 
     $ source ~/.bash_profile
 
-2. To use Omero, we need to first setup Postgres. Open a command-line terminal and run the 
+2. To use Omero, we need to first set up Postgres. Open a command-line terminal and run the
    following commands to create a user called *db_user* and database called *omero_database*::
 
     $ createuser -w -D -R -S db_user

--- a/omero/sysadmins/unix/server-install-homebrew.rst
+++ b/omero/sysadmins/unix/server-install-homebrew.rst
@@ -80,12 +80,9 @@ Install PostgreSQL database server::
 
     $ brew install postgresql
 
-Add the following lines to your .bash_profile::
 
-    export LANG=en_US.UTF-8
-    export LANGUAGE=en_US:en
 
-.. _`Homebrew and Python`: https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Homebrew-and-Python.md
+.. _`Homebrew and Python`: https://github.com/Homebrew/brew/blob/master/docs/Homebrew-and-Python.md
 
 You should install OMERO using Python 2.7 provided by
 Homebrew since it makes using Homebrew-provided modules
@@ -112,16 +109,44 @@ Check that Python is working and is version 2.7::
     $ python --version
     Python 2.7.13
 
-.. note::
+If everything looks okay, go ahead and use pip to get VirtaulEnv
 
-    The Homebrew formulae used below provide Python bindings. As
-    described in `Homebrew and Python`_, you should **not** be in an
-    active virtual environment when you ``brew install`` them.
+    $ pip install virtualenv
+
+VirtualEnv, eseentially, allows us to develop python applications
+without having to worry about clashing thirdparty package versions.
+
+
+
 
 See the :download:`step01_deps.sh <walkthrough/osx/step01_deps.sh>` script for
 the steps described above.
 
-OMERO installation
+OMERO enviorment variables
+------------------
+
+Make sure you have the following lines in your .bash_profile::
+
+    # UTF-8 and US language settings for Postgres
+    export LANG=en_US.UTF-8
+    export LANGUAGE=en_US:en
+
+    # OMERO Server distribution directory
+    export OMERO_SERVER=Omero/Server
+
+    # OMERO python libraries
+    export OMERO_PYTHON_LIBS=${OMERO_SERVER}/lib/python
+
+    # OMERO ice configuration
+    export OMERO_ICE_CONFIG=${OMERO_SERVER}/etc/ice.config
+
+    # Full path
+    export PATH=$OMERO_SERVER/bin:$OMERO_ICE_CONFIG:$PATH
+
+
+
+
+OMERO pre-built installation
 ------------------
 
 OMERO |release| server
@@ -129,13 +154,15 @@ OMERO |release| server
 
 Run the following command to download a build of OMERO Server to a folder called '/OMERO'
 
-    mkdir -p Omero && curl https://downloads.openmicroscopy.org/omero/5.3.4/artifacts/OMERO.server-5.3.4-ice36-b69.zip > Omero/OMERO.server.zip
+    $ mkdir -p Omero
+    $ curl https://downloads.openmicroscopy.org/omero/5.3.4/artifacts/OMERO.server-5.3.4-ice36-b69.zip > Omero/OMERO.server.zip
 
 Extract the OMERO.server.zip
 
     $ brew install omero53 --with-nginx --with-cpp
-    $ export PYTHONPATH=$(brew --prefix omero53)/lib/python
-    $ export ICE_CONFIG=$(brew --prefix omero53)/etc/ice.config
+    $ export OMERO_SERVER=Omero/Server
+    $ export OMERO_PYTHON_LIBS=Omero/Server/lib/python
+    $ export OMERO_ICE_CONFIG=Omero/Server/etc/ice.config
 
 This will install the OMERO server to /usr/local/Cellar/omero, which means you
 will find the log files in :file:`/usr/local/Cellar/omero/|release|/var/log`.
@@ -153,6 +180,12 @@ Install Ice 3.6 extension for Python and OMERO python dependencies::
 Start database server::
 
     $ pg_ctl -D /usr/local/var/postgres -l /usr/local/var/postgres/server.log -w start
+
+
+OMERO configuration
+------------------
+
+
 
 Create database and user::
 

--- a/omero/sysadmins/unix/server-install-homebrew.rst
+++ b/omero/sysadmins/unix/server-install-homebrew.rst
@@ -97,9 +97,10 @@ Requirements
     $ brew tap zeroc-ice/tap
     $ brew install zeroc-ice/tap/ice36
 
-.. Note::
-   If you already have a version of Ice that is not 3.6 installed, you can instruct Homebrew to *unlink* it using 
-   ```$ brew unlink ice```. You can then instruct Homebrew to link to Ice 3.6 using ```$ brew link ice@36```
+  .. note::
+   If you already have a version of Ice that is not 3.6 installed, 
+   you can instruct Homebrew to *unlink* it using ```$ brew unlink ice```. 
+   You can then instruct Homebrew to link to Ice 3.6 using ```$ brew link ice@36```
 
 4. Install Python provided by Homebrew::
 
@@ -114,15 +115,15 @@ Requirements
 
     export PATH="/usr/local/opt/python/libexec/bin:$PATH"
 
-.. note:: 
-   To keep things a little cleaner, add the following enviornment variable to your :file:`.bash_profile`::
+  .. note::
+   **(Optional)** To keep things a little cleaner, add the following enviornment variable to your :file:`.bash_profile`::
 
     # Environment variable pointing to Homebrew Python location
     export PYTHON_BREW=/usr/local/opt/python/libexec/bin
 
    and append it to the :envvar:`PATH`::
 
-    export PATH="$PYTHON_BREW:$PATH"
+    export PATH=$PYTHON_BREW:$PATH
 
 5. Check that Python is working and is version 2.7.x::
 
@@ -144,30 +145,29 @@ Requirements
 
     $ virtualenv ~/Virtual/omero
 
-   This will create a folder to hold Python libraries in the the directory :file:`~Virtual/omero/lib`
+   This will create a folder to hold Python libraries in the the directory :file:`~/Virtual/omero/lib`
 
-.. note:: You can activate the Virtualenv enviornment that we created using::
+  .. note:: 
+   You can activate the Virtualenv enviornment that we created using::
 
     $ source ~/Virtual/omero/bin/activate
 
    This will swtich to using Pip and Python in the Virtualenv directory 
-   :file:`~/Virtual/omero/bin` and any Pip libraries you install, whilst the Virtualenv
-   is activated, will be installed to :file:`source ~/Virtual/omero/lib`.
+   :file:`~/Virtual/omero/bin` and any Pip libraries you install, whilst the Virtualenv is activated, 
+   will be installed to :file:`source ~/Virtual/omero/lib`.
 
-   .. note:: (OPTIONAL) You can add an `alias` to your :file:`.bash_profile` to make this step easier::
+7. **(Optional)** To make starting a Virtualenv enviornment easier, 
+   you can add an `alias` to your :file:`.bash_profile`::
 
-        alias startVmOmero="source ~/Virtual/omero/bin/activate"
+    alias startVmOmero="source ~/Virtual/omero/bin/activate"
 
-      Reload :file:`.bash_profile` in OS X::
+   Using the command-line terminal, reload your :file:`.bash_profile`::
 
-        $ source ~/.bash_profile
+    $ source ~/.bash_profile
 
-      Now you can activate the Virtualenv enviornment using::
+   Now you can activate the Virtualenv enviornment using::
 
-        $ startVmOmero
-
-.. Note::
-   See the :download:`step01_deps.sh <walkthrough/osx/step01_deps.sh>` script for the steps described above.
+    $ startVmOmero
 
 OMERO installation
 ------------------
@@ -202,7 +202,7 @@ Pre-built server
     # Add the OMERO distribution to PATH
     export PATH=OMERO_SERVER/bin:$PATH
 
-   Using the command-line terminal reload :file:`.bash_profile` in OS X::
+   Using the command-line terminal, reload your :file:`.bash_profile` using::
 
     $ source ~/.bash_profile
 
@@ -220,8 +220,6 @@ Pre-built server
 4. Install Python dependencies using pip::
 
     $ pip install -r ~Omero/server/share/web/requirements-py27-all.txt
-    $ cd /usr/local
-    $ bash bin/omero_python_deps
 
 
 Local built server
@@ -229,58 +227,66 @@ Local built server
 
 1. Prepare a place for your OMERO code to live, e.g.::
 
-    $ mkdir -p ~/Projects/Omero/code/projects
-    $ cd ~/Projects/Omero/code/projects
+    $ mkdir -p ~/Projects/Omero/code
+    $ cd ~/Projects/Omero/code
 
 2. Clone the source code from the project's GitHub account to build locally::
 
     $ git clone --recursive git://github.com/openmicroscopy/openmicroscopy
-    $ cd openmicroscopy && ./build.py
 
-.. note::
-    If you have a GitHub account and you plan to develop code for OMERO, you
-    should make a fork into your own account and then clone this fork to your
-    local development machine, e.g. ::
+3. Navigate terminal into the :file:`openmicroscopy` that was just created by performing
+   the previous step::
 
-        $ git remote add  git://github.com/YOURNAMEHERE/openmicroscopy
-        $ cd openmicroscopy && ./build.py
+    $ cd openmicroscopy
 
-.. seealso::
+4. Execute the build script *(this will take a few minutes, depending on how fast your Mac is)* :: 
 
-    :doc:`/developers/installation`
+    $ ./build.py
+
+  .. seealso::
+   :doc:`/developers/installation`
         Developer documentation page on how to check out to source code
-
-    :doc:`/developers/build-system`
+   :doc:`/developers/build-system`
         Developer documentation page on how to build the OMERO.server
 
-3. Once the build completes, the OMERO server build output will be located in :file:`~/Projects/Omero/code/projects/openmicroscopy/dist`.
+5. Once the build completes, the OMERO server build output will be located in :file:`~/Projects/Omero/code/openmicroscopy/dist`.
+   If it is not already open, open your :file:`.bash_profie`::
+
+    $ open -a TextEdit.app ~/.bash_profile
+
    Prepend the :file:`bin` directory to your :envvar:`PATH`::
 
-    $ export PATH=~/code/projects/openmicroscopy/dist/bin:$PATH
+    export PATH=~/Projects/omero/code/openmicroscopy/dist/bin:$PATH
 
-   and follow the steps for setting up the database and OMERO data directory as mentioned in the previous section.
+   Using the command-line terminal, reload your :file:`.bash_profile` using::
 
-4. Activate the Virtualenv enviornment that we created earlier in the "Requirements"
+    $ source ~/.bash_profile
+
+   To ensure OMERO is correctly linked into your OS X :envvar:`PATH`, type the following in terminal and ensure
+   you get a similar output::
+
+    $ which omero
+    /Projects/omero/code/openmicroscopy/dist/bin/omero
+
+6. Activate the Virtualenv enviornment that we created earlier in the "Requirements"
    section::
 
     $ source ~/Virtual/Omero/bin/activate
 
-5. Install Python dependencies using pip::
+7. Install Python dependencies using pip::
 
-    $ pip install -r ~Omero/server/share/web/requirements-py27-all.txt
-    $ cd /usr/local
-    $ bash bin/omero_python_deps
+    $ pip install -r ~/Projects/omero/code/openmicroscopy/dist/share/web/requirements-py27-all.txt
 
 
 OMERO configuration
 -------------------
 
-1. Start the database server::
+1. From a fresh command-line terminal, start the database server::
 
     $ pg_ctl -D /usr/local/var/postgres -l /usr/local/var/postgres/server.log -w start
 
-.. note: To make life easier, you can add an ```alias``` to your :file:`.bash_profile`
-   to make starting a Virtualenv enviornment easier::
+  .. note::
+   To make life easier, you can add an ```alias``` to your :file:`.bash_profile`::
     
     # Start Virtualenv for OMERO
     alias startVmOmero=Virtual/Omero/bin/activate
@@ -318,7 +324,6 @@ OMERO configuration
 6. Create and run script to initialize the OMERO database::
 
     $ omero db script --password omero -f - | psql -h localhost -U db_user omero_database
-
 
 OMERO.web
 ^^^^^^^^^

--- a/omero/sysadmins/unix/server-install-homebrew.rst
+++ b/omero/sysadmins/unix/server-install-homebrew.rst
@@ -41,6 +41,21 @@ running::
     $ javac -version
     javac 1.8.0_51
 
+OSX Basics
+------------
+
+In order to develop on OMERO, we recommend you ensure you have your MAC setup for
+developement. This first step to achieving this, is to create a bash_profile file in the
+root directory of your user folder.
+
+To create a ~/.bash_profile from terminal, if one does not already exist::
+
+    $ touch ~/.bash_profile
+
+Open your .bash_profile in your favourite text editor, such as the built in TextEdit app::
+
+    $ open -a TextEdit.app ~/.bash_profile
+
 Requirements
 ------------
 
@@ -48,11 +63,9 @@ Requirements
 
 All the requirements for OMERO will be installed under :file:`/usr/local`. See also: Installation instructions on the `Homebrew wiki`_.
 
-Install Homebrew and make sure :file:`/usr/local/bin` is prepended to your
-:envvar:`PATH`::
+Install Homebrew using the following command in terminal::
 
     $ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-    $ export PATH=/usr/local/bin:$PATH
 
 Update Homebrew and run 'brew doctor' to fix potential issues beforehand::
 
@@ -61,13 +74,16 @@ Update Homebrew and run 'brew doctor' to fix potential issues beforehand::
 
 Install git if not already present::
 
-    $ brew list | grep "\bgit\b" || brew install git
+    $ brew install git
 
 Install PostgreSQL database server::
 
-    $ export LANG=${LANG:-en_US.UTF-8}
-    $ export LANGUAGE=${LANGUAGE:-en_US:en}
     $ brew install postgresql
+
+Add the following lines to your .bash_profile::
+
+    export LANG=en_US.UTF-8
+    export LANGUAGE=en_US:en
 
 .. _`Homebrew and Python`: https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Homebrew-and-Python.md
 
@@ -82,21 +98,19 @@ To install the Python provided by Homebrew::
 
     $ brew install python
 
+(OPTIONAL) If you haven't already, follow the instructions from the brew python install and 
+set the homebrew version of Python to be used rather than the Python version shipped
+with OSX::
+
+    export PATH="/usr/local/opt/python/libexec/bin:$PATH"
+
 Check that Python is working and is version 2.7::
 
     $ which python
-    /usr/local/bin/python
+    /usr/local/opt/python/libexec/bin/python
+
     $ python --version
-    Python 2.7.9
-
-The installation of OMERO via Homebrew depends upon two alternate
-repositories containing extra formulae:
-https://github.com/Homebrew/homebrew-science for the HDF5 formula and
-https://github.com/ome/homebrew-alt for all the OME-provided formulae
-and older versions of Ice. To add these, run::
-
-    $ brew tap homebrew/science
-    $ brew tap ome/alt
+    Python 2.7.13
 
 .. note::
 

--- a/omero/sysadmins/unix/server-install-homebrew.rst
+++ b/omero/sysadmins/unix/server-install-homebrew.rst
@@ -26,7 +26,7 @@ installed it, make sure all the latest updates are installed.
 Homebrew
 ^^^^^^^^
 
-.. _`Homebrew wiki`: https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Installation.md
+.. _`Homebrew wiki`: https://github.com/Homebrew/brew/blob/master/docs/Installation.md
 
 Homebrew will install all packages under :file:`/usr/local`. See also: Installation instructions on the `Homebrew wiki`_.
 


### PR DESCRIPTION
Additional work on top of ongoing #1766.

Should address most of the comments on that PR, as well as a few other fixes noticed on the way.

 - Told users to download OMERO.server.. from downloads page, not putting version number in docs since this will be out of date very soon.
 - Addressed path issues in a couple of ways.