### PR TITLE
Mac osx nginx

### DIFF
--- a/omero/sysadmins/unix/server-install-homebrew.rst
+++ b/omero/sysadmins/unix/server-install-homebrew.rst
@@ -213,7 +213,7 @@ OMERO configuration
     # Pre-built server...
     export OMERO_SERVER=/path/to/OMERO.server-x.x.x-ice36-bxx
     # ...OR locally built server
-    export OMERO_SERVER=/path/to/openmicroscopy/bin
+    export OMERO_SERVER=/path/to/openmicroscopy/dist
 
    and add the OMERO executable to the OS X :envvar:`PATH`::
 

--- a/omero/sysadmins/unix/server-install-homebrew.rst
+++ b/omero/sysadmins/unix/server-install-homebrew.rst
@@ -4,10 +4,9 @@ OMERO.server installation on OS X with Homebrew
 .. topic:: Overview
 
     This walkthrough demonstrates how to install OMERO on a clean Mac
-    OS X system (10.9 or later) using Homebrew.  This demonstrates how to install
-    OMERO.server, either from the downloaded OMERO.server.zip
-    or from the source code
-    via Homebrew, in addition to all its prerequisites. It is aimed at **developers**
+    OS X system (10.9 or later). Dependencies are installed with Homebrew.
+    The OMERO.server can be downloaded as a pre-built zip,
+    or built from the source code. It is aimed at **developers**
     since typically MacOS X is not suited for serious server deployment.
 
 Prerequisites
@@ -175,7 +174,35 @@ Pre-built server
    `downloads page <https://downloads.openmicroscopy.org/latest/omero/artifacts/>`_.
    Download and extract the OMERO.server-x.x.x-ice36-bxx.zip.
 
-2. Once extracted, open your :file:`.bash_profile` in a text editor, 
+Locally built server
+^^^^^^^^^^^^^^^^^^^^
+
+1. Clone the source code from the project's GitHub account to build locally::
+
+    $ git clone --recursive git://github.com/openmicroscopy/openmicroscopy
+
+2. Navigate terminal into the :file:`openmicroscopy` that was just created by performing
+   the previous step::
+
+    $ cd openmicroscopy
+
+3. Execute the build script *(this will take a few minutes, depending on how fast your Mac is)* :: 
+
+    $ ./build.py
+
+  .. seealso::
+   :doc:`/developers/installation`
+        Developer documentation page on how to check out to source code
+   :doc:`/developers/build-system`
+        Developer documentation page on how to build the OMERO.server
+
+4. Once the build completes, the OMERO server build output will be located in :file:`openmicroscopy/dist`.
+
+
+OMERO configuration
+-------------------
+
+1. Open your :file:`.bash_profile` in a text editor, 
    such as the built-in TextEdit app::
 
     $ open -a TextEdit.app ~/.bash_profile
@@ -183,8 +210,10 @@ Pre-built server
    Add an environment variable :envvar:`OMERO_SERVER` to the :file:`.bash_profile` which points
    to the location of the OMERO executable::
 
-    # OMERO Server distribution directory
+    # Pre-built server...
     export OMERO_SERVER=/path/to/OMERO.server-x.x.x-ice36-bxx
+    # ...OR locally built server
+    export OMERO_SERVER=/path/to/openmicroscopy/bin
 
    and add the OMERO executable to the OS X :envvar:`PATH`::
 
@@ -210,65 +239,8 @@ Pre-built server
 
     $ pip install -r "${OMERO_SERVER}/share/web/requirements-py27-all.txt"
 
-
-Locally built server
-^^^^^^^^^^^^^^^^^^^^
-
-1. Prepare a place for your OMERO code to live, e.g.::
-
-    $ mkdir -p ~/Projects/Omero/code
-    $ cd ~/Projects/Omero/code
-
-2. Clone the source code from the project's GitHub account to build locally::
-
-    $ git clone --recursive git://github.com/openmicroscopy/openmicroscopy
-
-3. Navigate terminal into the :file:`openmicroscopy` that was just created by performing
-   the previous step::
-
-    $ cd openmicroscopy
-
-4. Execute the build script *(this will take a few minutes, depending on how fast your Mac is)* :: 
-
-    $ ./build.py
-
-  .. seealso::
-   :doc:`/developers/installation`
-        Developer documentation page on how to check out to source code
-   :doc:`/developers/build-system`
-        Developer documentation page on how to build the OMERO.server
-
-5. Once the build completes, the OMERO server build output will be located in :file:`~/Projects/Omero/code/openmicroscopy/dist`.
-   If it is not already open, open your :file:`.bash_profile`::
-
-    $ open -a TextEdit.app ~/.bash_profile
-
-   Prepend the :file:`bin` directory to your :envvar:`PATH`::
-
-    export PATH=~/Projects/Omero/code/openmicroscopy/dist/bin:$PATH
-
-   Using the command-line terminal, reload your :file:`.bash_profile` using::
-
-    $ source ~/.bash_profile
-
-   To ensure OMERO is correctly linked into your OS X :envvar:`PATH`, type the following in terminal and ensure
-   you get a similar output::
-
-    $ which omero
-    /Projects/omero/code/openmicroscopy/dist/bin/omero
-
-6. Activate the Virtualenv environment that we created earlier in the "Requirements"
-   section::
-
-    $ source ~/Virtual/Omero/bin/activate
-
-7. Install Python dependencies using pip::
-
-    $ pip install -r ~/Projects/omero/code/openmicroscopy/dist/share/web/requirements-py27-all.txt
-
-
-OMERO configuration
--------------------
+Database
+^^^^^^^^
 
 1. From a fresh command-line terminal, start the database server::
 
@@ -285,30 +257,29 @@ OMERO configuration
 
     $ source ~/.bash_profile
 
-2. To use Omero, we need to first set up Postgres. Open a command-line terminal and run the
+2. To use OMERO, we need to first set up Postgres. Open a command-line terminal and run the
    following commands to create a user called *db_user* and database called *omero_database*::
 
     $ createuser -w -D -R -S db_user
     $ createdb -E UTF8 -O db_user omero_database
 
-3. Create directory for OMERO to store its data::
+3. Now set the OMERO configuration::
 
-    $ mkdir -p ~/OMERO
-
-4. Start your Virtualenv environment we created earlier::
-
-    $ source ~/Virtual/omero/bin/activate
-
-5. Now set the OMERO configuration::
-
-    $ omero config set omero.data.dir ~/OMERO
     $ omero config set omero.db.name omero_database
     $ omero config set omero.db.user db_user
     $ omero config set omero.db.pass db_password
 
-6. Create and run script to initialize the OMERO database::
+4. Create and run script to initialize the OMERO database::
 
     $ omero db script --password omero -f - | psql -h localhost -U db_user omero_database
+
+Binary Repository
+^^^^^^^^^^^^^^^^^
+
+1. Create directory for OMERO to store its data::
+
+    $ mkdir -p ~/OMERO
+    $ omero config set omero.data.dir ~/OMERO
 
 OMERO.web
 ^^^^^^^^^
@@ -330,8 +301,8 @@ Basic setup for OMERO using NGINX::
 
 .. _install_homebrew_common_issues:
 
-Startup/Shutdown
-^^^^^^^^^^^^^^^^
+Startup and shutdown
+--------------------
 
 If necessary start PostgreSQL database server::
 

--- a/omero/sysadmins/unix/server-install-homebrew.rst
+++ b/omero/sysadmins/unix/server-install-homebrew.rst
@@ -228,7 +228,10 @@ OMERO configuration
    you get a similar output::
 
     $ which omero
+    # Pre-built server...
     /path/to/OMERO.server-x.x.x-ice36-bxx/bin/omero
+    # ...OR locally built server
+    /path/to/openmicroscopy/dist/bin/omero
 
 3. Activate the Virtualenv environment that we created earlier in the "Requirements"
    section::

--- a/omero/sysadmins/unix/server-install-homebrew.rst
+++ b/omero/sysadmins/unix/server-install-homebrew.rst
@@ -325,7 +325,6 @@ Now connect to your OMERO.server using OMERO.insight or OMERO.web with the follo
 
 Stop OMERO.web::
 
-    $ nginx -c $(brew --prefix omero53)/etc/nginx.conf -s stop
     $ omero web stop
 
 Stop OMERO::

--- a/omero/sysadmins/unix/server-install-homebrew.rst
+++ b/omero/sysadmins/unix/server-install-homebrew.rst
@@ -157,6 +157,11 @@ Requirements
 
     $ startVmOmero
 
+7. Install nginx::
+
+    $ brew install nginx
+
+
 OMERO installation
 ------------------
 
@@ -313,10 +318,10 @@ Basic setup for OMERO using NGINX::
     $ export HTTPPORT=${HTTPPORT:-8080}
     $ omero web config nginx-development --http $HTTPPORT > $(brew --prefix omero53)/etc/nginx.conf
 
-See installation script :download:`step03_nginx.sh <walkthrough/osx/step03_nginx.sh>`
-
-For detailed instructions on how to deploy OMERO.web in a production
-environment such as NGINX please see :doc:`install-web`.
+    $ mv /usr/local/etc/nginx/nginx.conf /usr/local/etc/nginx/nginx.conf.orig
+    $ bin/omero web config nginx-development > /usr/local/etc/nginx/nginx.conf
+    $ nginx -t
+    $ nginx
 
 .. note::
     The internal Django webserver can be used for evaluation and development.
@@ -357,7 +362,11 @@ Stop OMERO::
 
     $ omero admin stop
 
-See example script for a basic functionality test: :download:`step04_test.sh <walkthrough/osx/step04_test.sh>`
+
+Web configuration and maintenance
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For more configuration options and maintenance advice for OMERO.web see :doc:`install-web`.
 
 Common issues
 -------------

--- a/omero/sysadmins/unix/server-install-homebrew.rst
+++ b/omero/sysadmins/unix/server-install-homebrew.rst
@@ -156,7 +156,7 @@ Requirements
 
     $ startVmOmero
 
-7. Install nginx::
+7. Install NGINX::
 
     $ brew install nginx
 
@@ -257,8 +257,8 @@ Database
 
     $ source ~/.bash_profile
 
-2. To use OMERO, we need to first set up Postgres. Open a command-line terminal and run the
-   following commands to create a user called *db_user* and database called *omero_database*::
+2. To use OMERO, we need to first set up PostgreSQL. Open a command-line terminal and run the
+   following commands to create a user called *db_user* and a database called *omero_database*::
 
     $ createuser -w -D -R -S db_user
     $ createdb -E UTF8 -O db_user omero_database

--- a/omero/sysadmins/unix/server-install-homebrew.rst
+++ b/omero/sysadmins/unix/server-install-homebrew.rst
@@ -290,7 +290,7 @@ OMERO.web
 Basic setup for OMERO using NGINX::
 
     $ mv /usr/local/etc/nginx/nginx.conf /usr/local/etc/nginx/nginx.conf.orig
-    $ bin/omero web config nginx-development > /usr/local/etc/nginx/nginx.conf
+    $ omero web config nginx-development > /usr/local/etc/nginx/nginx.conf
     $ nginx -t
     $ nginx
 
@@ -315,7 +315,6 @@ Start OMERO::
 Start OMERO.web::
 
     $ omero web start
-    $ nginx -c $(brew --prefix omero53)/etc/nginx.conf
 
 Now connect to your OMERO.server using OMERO.insight or OMERO.web with the following credentials:
 

--- a/omero/sysadmins/unix/server-install-homebrew.rst
+++ b/omero/sysadmins/unix/server-install-homebrew.rst
@@ -278,8 +278,8 @@ Binary Repository
 
 1. Create directory for OMERO to store its data::
 
-    $ mkdir -p ~/OMERO
-    $ omero config set omero.data.dir ~/OMERO
+    $ mkdir /OMERO
+    $ omero config set omero.data.dir /OMERO
 
 OMERO.web
 ^^^^^^^^^

--- a/omero/sysadmins/unix/server-install-homebrew.rst
+++ b/omero/sysadmins/unix/server-install-homebrew.rst
@@ -289,9 +289,6 @@ OMERO.web
 
 Basic setup for OMERO using NGINX::
 
-    $ export HTTPPORT=${HTTPPORT:-8080}
-    $ omero web config nginx-development --http $HTTPPORT > $(brew --prefix omero53)/etc/nginx.conf
-
     $ mv /usr/local/etc/nginx/nginx.conf /usr/local/etc/nginx/nginx.conf.orig
     $ bin/omero web config nginx-development > /usr/local/etc/nginx/nginx.conf
     $ nginx -t

--- a/omero/sysadmins/unix/server-installation.rst
+++ b/omero/sysadmins/unix/server-installation.rst
@@ -26,12 +26,8 @@ more specific walk-through listed below.
 
     :doc:`server-install-homebrew`
         Instructions for installing and building OMERO.server on Mac
-        OS X with Homebrew using our special formulas (i.e. from the
-        source code via Homebrew). It is aimed at **developers**
+        OS X with dependencies installed using Homebrew. It is aimed at **developers**
         since typically MacOS X is not suited for serious server deployment.
-        **You do not need to refer to this
-        page to install the prerequisites with Homebrew and then
-        install the server zip from the downloads page.**
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
Adds steps to get nginx started on Mac OSX.

See discussion at https://github.com/openmicroscopy/ome-documentation/pull/1766#discussion_r141269079

Also I have refactored the page to reduce duplication between the pre-built server and locally built server sections.

e.g. we previously had
```
export PATH=$OMERO_SERVER/bin:$PATH
...
source ~/.bash_profile
...
$ pip install -r "${OMERO_SERVER}/share/web/requirements-py27-all.txt"
```
and
```
export PATH=~/Projects/Omero/code/openmicroscopy/dist/bin:$PATH
...
source ~/.bash_profile
..
$ pip install -r ~/Projects/omero/code/openmicroscopy/dist/share/web/requirements-py27-all.txt
```