### PR TITLE
Document reversing the SV4 workaround when upgrading

### DIFF
--- a/omero/sysadmins/omeroweb-upgrade.rst
+++ b/omero/sysadmins/omeroweb-upgrade.rst
@@ -144,7 +144,7 @@ Migrating from Apache to NGINX
 
 Support for Apache and mod_wsgi deployment was deprecated
 in OMERO 5.2.6 and dropped in 5.3.0.
-It is recommended to use a WSGI capable server such as
+It is recommended to use a WSGI-capable server such as
 :doc:`NGINX and Gunicorn </sysadmins/unix/install-web/web-deployment>`.
 
 .. seealso::

--- a/omero/sysadmins/omeroweb-upgrade.rst
+++ b/omero/sysadmins/omeroweb-upgrade.rst
@@ -144,8 +144,8 @@ Migrating from Apache to NGINX
 
 Support for Apache and mod_wsgi deployment was deprecated
 in OMERO 5.2.6 and dropped in 5.3.0.
-It is recommended to use
-:doc:`/sysadmins/unix/install-web/web-deployment`.
+It is recommended to use a WSGI capable server such as
+:doc:`NGINX and Gunicorn </sysadmins/unix/install-web/web-deployment>`.
 
 .. seealso::
 

--- a/omero/sysadmins/omeroweb-upgrade.rst
+++ b/omero/sysadmins/omeroweb-upgrade.rst
@@ -107,6 +107,15 @@ The best way to do this without changing the ordering of the options is to
 
     $ bin/omero config set omero.web.open_with '[["Image viewer", "webgateway", {"supported_objects": ["image"], "scr....'
 
+Re-enabling the version checker
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you used the workaround for :secvuln:`2017-SV4-guest-user` then you should
+revert the change to ``omero.web.check_version`` configuration property::
+
+   $ bin/omero config set omero.web.check_version true
+
+
 Troubleshooting
 ^^^^^^^^^^^^^^^
 

--- a/omero/sysadmins/server-upgrade.rst
+++ b/omero/sysadmins/server-upgrade.rst
@@ -276,14 +276,15 @@ Remove the guest user password (optional)
 """""""""""""""""""""""""""""""""""""""""
 
 If a password was set on the `guest` user to work around
-:secvuln:`2017-SV4-guest-user` then you may now wish to remove it so
-that a correct password is not needed to log in as that user:
+:secvuln:`2017-SV4-guest-user` then you will need to remove it to restore the
+forgotten password reset functionality in OMERO.web:
 
 .. parsed-literal::
 
     $ psql -h localhost -U **db_user** **omero_database** < sql/psql/|current_dbver|/allow-guest-user-without-password.sql
 
-This can be done at any time during the OMERO 5.4 series.
+This can be done at any time during the OMERO 5.4 series and is optional if
+you do not deploy OMERO.web.
 
 .. note::
 

--- a/omero/sysadmins/troubleshooting.rst
+++ b/omero/sysadmins/troubleshooting.rst
@@ -354,8 +354,9 @@ OMERO.web migrating from Apache to NGINX
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Support for Apache and mod_wsgi deployment was deprecated
-in OMERO 5.2.6 and dropped in 5.3.0. It is recommended to use
-:doc:`/sysadmins/unix/install-web/web-deployment`.
+in OMERO 5.2.6 and dropped in 5.3.0. It is recommended to use a WSGI capable 
+server such as
+:doc:`NGINX and Gunicorn </sysadmins/unix/install-web/web-deployment>`.
 
 ::
 

--- a/omero/sysadmins/troubleshooting.rst
+++ b/omero/sysadmins/troubleshooting.rst
@@ -354,7 +354,7 @@ OMERO.web migrating from Apache to NGINX
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Support for Apache and mod_wsgi deployment was deprecated
-in OMERO 5.2.6 and dropped in 5.3.0. It is recommended to use a WSGI capable 
+in OMERO 5.2.6 and dropped in 5.3.0. It is recommended to use a WSGI-capable
 server such as
 :doc:`NGINX and Gunicorn </sysadmins/unix/install-web/web-deployment>`.
 


### PR DESCRIPTION
Rephrases the section on removing the guest password to make it clear this step is needed to fix the password reset functionality for OMERO.web and also documents reversing the version checker config change.

While I was reviewing the pages I spotted a couple of links to the web installation page where the link text doesn't make sense since the page title was changed so I've updated those too.