### PR TITLE
Remove plone links & update CI job docs

### DIFF
--- a/contributing/ci-bio-formats.rst
+++ b/contributing/ci-bio-formats.rst
@@ -7,7 +7,7 @@ All jobs are listed under the :jenkinsview:`Bio-Formats` view tab of Jenkins.
         :header-rows: 1
 
         -       * Job task
-                * 5.3.x series
+                * 5.x series
 
         -       * Builds the latest Bio-Formats artifacts using Ant
                 * | :term:`BIOFORMATS-DEV-latest`
@@ -45,10 +45,10 @@ All jobs are listed under the :jenkinsview:`Bio-Formats` view tab of Jenkins.
         -       * Installs Bio-Formats using Homebrew
                 * :term:`BIOFORMATS-DEV-merge-homebrew`
 
-5.3.x series
+5.x.x series
 ^^^^^^^^^^^^
 
-The branch for the 5.3.x series of Bio-Formats is develop.
+The branch for the 5.x series of Bio-Formats is develop.
 
 .. glossary::
 

--- a/contributing/ci-consortium.rst
+++ b/contributing/ci-consortium.rst
@@ -16,14 +16,6 @@ Jenkins.
 		*
 		* :term:`MTOOLS-release-downloads`
 
-
-FLIMfit
-^^^^^^^
-
-The source code for the FLIMfit is hosted under
-https://github.com/imperial-photonics/FLIMfit. Since 4.11.1, the downloads are
-hosted at http://flimfit.org/.
-
 OMERO.mtools
 ^^^^^^^^^^^^
 
@@ -37,9 +29,3 @@ OMERO.mtools
 		#. Build the OMERO.mtools downloads pages using :command:`make mtools`
 		#. Copy the OMERO.mtools downloads page over SSH to
 		   :file:`/ome/www/download.openmicroscopy.org/mtools/RELEASE`
-
-OMERO.webtagging
-^^^^^^^^^^^^^^^^
-
-The source code for OMERO.webtagging is hosted under
-https://github.com/MicronOxford/webtagging/. Since 3.0.0, the Web app is released under :pypi:`omero-webtagging-tagsearch` and :pypi:`omero-webtagging-autotag`.

--- a/contributing/ci-docs.rst
+++ b/contributing/ci-docs.rst
@@ -115,13 +115,11 @@ bundle.
 Configuration
 ^^^^^^^^^^^^^
 
-For all jobs building documentation using Sphinx, the HTML documentation theme
-hosted at https://github.com/openmicroscopy/sphinx_theme repository is copied
-to the relevant :file:`themes/` folder. The following environment variables
-are then used:
+For all jobs building documentation using Sphinx, the following environment
+variables are used:
 
 - the Sphinx building options, :envvar:`SPHINXOPTS`, is set to
-  ``-W -D html_theme=sphinx_theme``
+  ``-Dsphinx.opts="-W"``
 
 - the release number of the documentation is set by :envvar:`OMERO_RELEASE`,
   :envvar:`BF_RELEASE` or by the relevant POM
@@ -130,6 +128,9 @@ are then used:
 
 - for the Bio-Formats and OMERO sets of documentation, the name of the
   Jenkins job is set by :envvar:`JENKINS_JOB`.
+
+Note that the https://github.com/openmicroscopy/sphinx_theme repository is no
+longer used, this hosted the theme to match the old plone website.
 
 OMERO 5.x series
 ^^^^^^^^^^^^^^^^

--- a/contributing/ci-docs.rst
+++ b/contributing/ci-docs.rst
@@ -2,7 +2,10 @@ Documentation jobs
 ------------------
 
 All documentation jobs are listed under the :jenkinsview:`Docs <Docs>` view
-tab of Jenkins.
+tab of Jenkins. A :guilabel:`GitHub`
+button in the left-side panel of the job window links to the code repository
+the job is building from (alternatively, the console output for the build will
+indicate where the changes are being fetched from).
 
 .. list-table::
 	:header-rows: 1
@@ -92,8 +95,9 @@ the help builds.
 	-	* Publish the OME help website
 		* :term:`OME-help-release`
 
-OME Files comprises OME Files C++ and OME CMake Super-Build Sphinx manuals,
-which are taken from separate repositories but built and hosted as a bundle.
+OME Files comprises OME Model, OME Files C++ and OME CMake Super-Build Sphinx
+manuals, which are taken from separate repositories but built and hosted as a
+bundle.
 
 .. list-table::
 	:header-rows: 1
@@ -137,7 +141,7 @@ The branch for the 5.x series of the OMERO documentation is develop.
 	:jenkinsjob:`OMERO-DEV-latest-docs`
 
 		This job is used to review the PRs opened against the develop branch
-		of the OMERO 5.4.x documentation
+		of the OMERO 5.x documentation
 
 		#. |merge|
 		#. |sphinxbuild|
@@ -146,7 +150,7 @@ The branch for the 5.x series of the OMERO documentation is develop.
 	:jenkinsjob:`OMERO-DEV-merge-docs`
 
 		This job is used to review the PRs opened against the develop branch
-		of the OMERO 5.4.x documentation
+		of the OMERO 5.x documentation
 
 		#. |merge|
 		#. Pushes the branch to :omedoc_scc_branch:`develop/merge/daily`
@@ -335,17 +339,19 @@ The following set of jobs is used to review or publish the content of the
 OME Files
 ^^^^^^^^^
 
-This bundle of Sphinx documentation has two components: OME Files C++
+This bundle of Sphinx documentation has three components: OME Model
+documentation is located in the ome-model repository; OME Files C++
 documentation is located in the ome-files-cpp repository; OME CMake
 Super-Build documentation is located in the ome-cmake-superbuild repository.
-Both are currently built from the master branches despite the build names.
+All are currently built from the master branches despite the build names.
 
 .. glossary::
 
      :jenkinsjob:`OME-FILES-CPP-DEV-release-bundle-docs`
 
-	    This job is used to publish the master branches of the OME Files C++
-	    and OME CMake Super-Build Sphinx documentation as a single bundle
+	    This job is used to publish the master branches of the OME Model, OME
+	    Files C++ and OME CMake Super-Build Sphinx documentation as a single
+	    bundle
 
 	    #. |buildFilesSB|
 	    #. |deploy-doc| https://www.openmicroscopy.org/site/support/ome-files-cpp/

--- a/contributing/ci-omero.rst
+++ b/contributing/ci-omero.rst
@@ -119,10 +119,10 @@ clients of the deployment jobs described above:
         * http://web-dev-breaking.openmicroscopy.org/webclient/login/
 
 
-5.3.x series
+5.4.x series
 ^^^^^^^^^^^^
 
-The branch for the 5.3.x series of OMERO is develop. All jobs are listed
+The branch for the 5.4.x series of OMERO is develop. All jobs are listed
 under the :jenkinsview:`DEV` view tab of Jenkins.
 
 .. glossary::
@@ -138,12 +138,12 @@ under the :jenkinsview:`DEV` view tab of Jenkins.
 
     :jenkinsjob:`OMERO-DEV-latest-deploy`
 
-        This job deploys the latest 5.3.x server (see
+        This job deploys the latest 5.4.x server (see
         :ref:`deployment_servers`)
 
     :jenkinsjob:`WEB-DEV-latest-deploy`
 
-        This job deploys the latest 5.3.x webclient (see
+        This job deploys the latest 5.4.x webclient (see
         :ref:`deployment_servers`)
 
     :jenkinsjob:`OMERO-DEV-latest-submods`
@@ -185,12 +185,12 @@ under the :jenkinsview:`DEV` view tab of Jenkins.
 
     :jenkinsjob:`OMERO-DEV-merge-deploy`
 
-        This job deploys the merge 5.3.x server (see
+        This job deploys the merge 5.4.x server (see
         :ref:`deployment_servers`)
 
     :jenkinsjob:`WEB-DEV-merge-deploy`
 
-        This job deploys the merge 5.3.x web (see
+        This job deploys the merge 5.4.x web (see
         :ref:`deployment_servers`)
 
     :jenkinsjob:`OMERO-DEV-merge-integration`
@@ -235,7 +235,7 @@ under the :jenkinsview:`DEV` view tab of Jenkins.
 
     :jenkinsjob:`WEB-DEV-integration-deploy`
 
-        This job deploys the merge 5.3.x web (see
+        This job deploys the merge 5.4.x web (see
         :ref:`deployment_servers`)
 
     :jenkinsjob:`OMERO-DEV-merge-integration-Python27`

--- a/contributing/conf.py
+++ b/contributing/conf.py
@@ -51,10 +51,7 @@ contributing_extlinks = {
     
     # Doc links
     'omero_doc' : (docs_root + '/latest/omero/%s', ''),
-    'bf_doc' : (docs_root + '/latest/bio-formats/%s', ''),
-    #Remaining plone links
-    'community_plone' : (oo_site_root + '/community/%s', ''),
-    'team_plone' : (oo_site_root + '/team/%s', '')
+    'bf_doc' : (docs_root + '/latest/bio-formats/%s', '')
     }
 extlinks.update(contributing_extlinks)
 

--- a/contributing/continuous-integration.rst
+++ b/contributing/continuous-integration.rst
@@ -9,7 +9,10 @@ The following sections summarize the main continuous integration jobs used for
 the development of OMERO, Bio-Formats and the OME documentation sets. Note
 this is not an exhaustive list of all jobs in the project. To know more about
 a particular job, click on the :guilabel:`Configure` button on the left-side
-panel of the job window.
+panel of the job window. This panel should also include a :guilabel:`GitHub`
+button linking to the code repository the job is building from (alternatively,
+the console output for the build will indicate where the changes are being
+fetched from).
 
 
 .. toctree::

--- a/contributing/team-communication.rst
+++ b/contributing/team-communication.rst
@@ -6,27 +6,20 @@ how to get plugged in. There is a fairly extensive amount of
 communication flying around related to the project, and being able to
 find and track it may take some time.
 
-.. note:: Some of the links below go to private pages on openmicroscopy.org.
-    New hires in the core development team will be given
-    access to these automatically but you can also request a log-in as an
-    external collaborator.
-
 Instant messaging and video conferencing
 ----------------------------------------
 
-On a day-to-day level, the team meets in a Slack chatroom (see the list of
-:team_plone:`addresses <addresses>` for the specifics). Slack can be used in
-your internet browser or via an app; you will be invited to join the team by
-an admin.
+On a day-to-day level, the team meets in a Slack chatroom. Slack can be used
+in your internet browser or via an app; you will be invited to join the team
+by an admin.
 
 The daily stand-up meeting is managed via the '#general' channel, with notes
 in google docs that are edited throughout the day as people complete the tasks
 assigned to them.
 
-Slightly less frequently, the team meets on Zoom for voice discussions. These
-subgroup, or “mini group”, meetings are organized as needed, but should
-provide feedback (tickets, notes, etc). More information is available under
-:community_plone:`conference-calls <minutes/conference-calls>`.
+Slightly less frequently, members of the team meet on Zoom for voice
+discussions. These meetings are organized as needed, but should provide
+feedback where appropriate (tickets, notes, etc).
 
 Other IM tools
 ^^^^^^^^^^^^^^
@@ -43,6 +36,10 @@ and responded to.
 Trac
 ----
 
+.. note:: The team is increasingly moving away from Trac and towards using
+    Trello, especially for managing 'story'-level items, documentation and
+    testing.
+
 The Trac server is available under https://trac.openmicroscopy.org/ome and
 uses your LDAP account for authentication. Trac is used to record all tickets
 and allows hierarchical groups of “tasks” in “requirements” and “stories”
@@ -56,9 +53,7 @@ summary, as the official Trac "Bug" tickets only allow limited functionality.
 
 Trac is also used for the milestone pages which summarize the tickets
 completed for each release (as opposed to the GitHub milestone pages
-which show all the code changes). Increasingly however, the team is moving
-away from using it for managing 'story'-level items and for tasks such as
-documentation and testing.
+which show all the code changes).
 
 Trello
 ------
@@ -163,8 +158,8 @@ also:
   vacation, etc.
 
 * a number of mail-aliases reserved for automated messages from
-  various pieces of development machinery so do not send mail directly
-  to these :team_plone:`addresses <addresses>`, instead use ome-nitpick.
+  various pieces of development machinery (do not send mail directly
+  to these, instead use ome-nitpick).
 
 Internal servers
 ----------------
@@ -181,9 +176,6 @@ available in case you do.
   data which can be mounted if you are on VPN or within the UoD
   system. It contains test data for various file formats.
 
-* The official OME website is run using Plone
-  (https://www.openmicroscopy.org/site) (LDAP-based)
-
 * The OME `QA <http://qa.openmicroscopy.org.uk/>`_ system is an in-house
   system for collecting feedback from users, including failing files,
   stack traces, etc. Like our community feedback, QA feedback should
@@ -195,9 +187,9 @@ available in case you do.
 
   For anyone who has been hired to work at the University of
   Dundee, you will be provided with a
-  :team_plone:`new start tasklist <new-start-tasklist>` which itemizes all
-  the things that need to be done to get you set up in RL (building
-  access, a chair, etc.).
+  `new start tasklist <https://trello.com/c/GmuPPLAi/5-start-tasks>`_ which
+  itemizes all the things that need to be done to get you set up in RL
+  (building access, a chair, etc.).
 
 Google Docs
 -----------
@@ -217,26 +209,19 @@ email if any changes are made.
 Meetings
 --------
 
-Weekly meetings are held online with all members of the team. Agendas
-are posted on the appropriate page under :community_plone:`conference-calls
-<minutes/conference-calls>` before hand. Notes are taken
-collaboratively in a Google doc in the “OME Docs > Notes”
-collection. Once finished, they are added to the page on Plone, and
-anyone who missed the meeting is expected to review the notes and
-raise any issues during the next meeting. You should also send an
-email to ome-nitpick if you will not be attending the meeting since it
-may change what others can discuss for that week.
+Weekly meetings are held online with all members of the team. Notes are taken
+collaboratively in a **public** Google doc in the “OME Docs > Notes > Tuesday
+meetings” collection.
+Anyone who missed the meeting is expected to review the notes and
+raise any issues during the next meeting.
 
 Periodically, a technical presentation is held during the weekly
 meeting. This can be used to either introduce an external tool for
-suggested use by the team or as a peer review of in-progress work. See
-:team_plone:`meetings <meetings>` for more information.
+suggested use by the team or as a peer review of in-progress work.
 
 Mini group meetings can either be regularly scheduled (e.g. weekly) or
-on an as-needed basis. Notes from such meetings, however, should be
-posted centrally to :community_plone:`Mini Group meetings <minutes/minigroup>`
-for review by the team. Either an email should be sent to ome-nitpick
-with a link to the mini group notes, or it should be brought up during
-the weekly meeting.
+on an as-needed basis. Notes from such meetings should be recorded in gdocs or
+on Trello as appropriate and if necessary matters arising should be covered in
+the weekly meeting for the rest of the team.
 
 .. _DevContactList spreadsheet: https://docs.google.com/spreadsheets/d/1oHHU1GdEQq03dDf1FzUe0xoEi1RK1BOLOaL0HhMAeEA/edit

--- a/contributing/team-communication.rst
+++ b/contributing/team-communication.rst
@@ -25,9 +25,8 @@ Other IM tools
 ^^^^^^^^^^^^^^
 
 Slack is the only IM tool used by the entire OME team. Some team members do
-also use IRC (#ome on irc.freenode.net) and provide support via that channel
-but all significant conversations should be documented formally via Trac
-tickets or Trello. In general, all external requests for help are best
+also use IRC (#ome on irc.freenode.net) and **may** provide support via that
+channel but in general, all external requests for help are best
 submitted and dealt with via the forums or mailing lists (see below) so they
 are available for the whole community. In particular, the various Gitter
 channels associated with OME projects on GitHub are not routinely monitored


### PR DESCRIPTION
See https://trello.com/c/esoA5qL5/590-update-team-comms-page-in-contributing-docs and https://trello.com/c/yVcZIVWh/582-which-repos-for-which-ci-jobs

This removes the remaining plone links from the team communication page, adds a note about which gh repos are being used by which jobs & a few other little updates to the CI docs, like current versions etc.