### PR TITLE
Histogram example - Python

### DIFF
--- a/omero/developers/Python.rst
+++ b/omero/developers/Python.rst
@@ -386,6 +386,14 @@ Raw data access
     for i, p in enumerate(planes):
         print "plane zct:", zct_list[i], " min:", p.min(), " max:", p.max()
 
+-  **Retrieve a histogram**
+
+::
+
+    # Get a 256 bin histogram for channel 0 and plane z=0/t=0:
+    hist = pixels.getHistogram(0, 0, 0, 256)
+    print hist
+
 
 Write data
 ^^^^^^^^^^

--- a/omero/developers/Python.rst
+++ b/omero/developers/Python.rst
@@ -391,7 +391,7 @@ Raw data access
 ::
 
     # Get a 256 bin histogram for channel 0 and plane z=0/t=0:
-    hist = pixels.getHistogram(0, 0, 0, 256)
+    hist = image.getHistogram([0], 256, False, 0, 0)
     print hist
 
 


### PR DESCRIPTION
Adds a histogram example to the Python training examples.

See also:
- https://trello.com/c/5SjwyaM4/112-histogram-api
- https://github.com/openmicroscopy/openmicroscopy/pull/5566
