### PR TITLE
Fix broken & redirecting contributing links

### DIFF
--- a/contributing/ci-docs.rst
+++ b/contributing/ci-docs.rst
@@ -358,7 +358,7 @@ All are currently built from the master branches despite the build names.
 	    bundle
 
 	    #. |buildFilesSB|
-	    #. |deploy-doc| https://www.openmicroscopy.org/site/support/ome-files-cpp/
+	    #. |deploy-doc| https://docs.openmicroscopy.org/ome-files-cpp/
 
 The merge and latest builds for this documentation set are detailed on the
 :doc:`ci-ome-files` page.

--- a/contributing/ci-ome-files.rst
+++ b/contributing/ci-ome-files.rst
@@ -129,8 +129,7 @@ The branch for the development series of OME Files is develop.
                 This job builds the documentation for merge branches of OME Files components
 
                 #. |buildFilesSB|
-                #. Updates https://www.openmicroscopy.org/site/support/ome-files-cpp-staging/
-
+                
                 See :jenkinsjob:`the build graph <OME-FILES-CPP-DEV-merge-docs/lastSuccessfulBuild/BuildGraph>`
 
 .. _files_breaking:

--- a/contributing/conf.py
+++ b/contributing/conf.py
@@ -47,7 +47,7 @@ contributing_extlinks = {
     'bf_scc_branch' : (scc_github_root + '/bioformats/tree/%s', ''),
     'omedoc_scc_branch' : (scc_github_root + '/ome-documentation/tree/%s', ''),
     'omehelp_scc_branch' : (scc_github_root + '/ome-help/tree/%s', ''),
-    'figure_scc_branch' : (scc_github_root + '/figure/tree/%s', ''),
+    'figure_scc_branch' : (scc_github_root + '/omero-figure/tree/%s', ''),
     
     # Doc links
     'omero_doc' : (docs_root + '/latest/omero/%s', ''),

--- a/contributing/scc.rst
+++ b/contributing/scc.rst
@@ -24,8 +24,8 @@ this may also install the **argparse** package.
 Github connection
 -----------------
 
-.. _About Two-Factor Authentication: http://help.github.com/articles/about-two-factor-authentication
-.. _Creating an access token for command-line use: http://help.github.com/articles/creating-an-access-token-for-command-line-use
+.. _About Two-Factor Authentication: https://help.github.com/articles/about-two-factor-authentication/
+.. _Creating an access token for command-line use: https://help.github.com/articles/creating-an-access-token-for-command-line-use/
 
 Most of the scc commands instantiate a Github connection using the PyGithub
 package. GitHub strongly recommends to turn on two-factor authentification

--- a/contributing/using-git.rst
+++ b/contributing/using-git.rst
@@ -12,7 +12,7 @@ commands and configuration you need for doing most Git tasks.
 Installing Git
 --------------
 
-In general, see the Git `downloads page <http://git-scm.com/download>`_ for
+In general, see the Git `downloads page <https://git-scm.com/download>`_ for
 installation options.
 
 Linux
@@ -26,26 +26,25 @@ example, on Debian or Ubuntu::
 Mac OS X
 ^^^^^^^^
 
-You can install Git using `Homebrew <https://github.com/mxcl/homebrew/>`_::
+You can install Git using `Homebrew <https://github.com/Homebrew>`_::
 
     brew install git
 
-Or you can use the `binary installer <http://git-scm.com/download>`_.
+Or you can use the `binary installer <https://git-scm.com/download>`_.
 
 Windows
 ^^^^^^^
 
-We recommend using either msysGit_ for a basic Git installation, or Cygwin_
+We recommend using either `Git for Windows <https://git-for-windows.github.io>`_ for a basic Git installation, or Cygwin_
 for a full-featured Unix-style environment that includes Git. You can also use
 TortoiseGit_ for Git shell integration. You may also want to consider
 installing VirtualBox_ with a Linux guest OS to make your life easier. Lastly,
 when using Git on Windows, please be aware of the `CRLF conversion issue`_.
 
-.. _msysGit: http://code.google.com/p/msysgit
 .. _Cygwin: http://www.cygwin.com/
-.. _TortoiseGit: http://code.google.com/p/tortoisegit/
+.. _TortoiseGit: https://tortoisegit.org
 .. _VirtualBox: https://www.virtualbox.org/
-.. _CRLF conversion issue: http://help.github.com/articles/dealing-with-line-endings
+.. _CRLF conversion issue: https://help.github.com/articles/dealing-with-line-endings/
 
 
 Git configuration
@@ -191,7 +190,7 @@ The flip-side of pushing your own branches is being aware that other OME
 developers will also be pushing theirs. GitHub provides a number of ways
 of monitoring either a user or a repository. Notifications about what
 watched users and repositories are doing can be seen in your GitHub
-inbox or via RSS feeds. See `Be social <http://help.github.com/articles/be-social>`_ for more information.
+inbox or via RSS feeds. See `Be social <https://help.github.com/articles/be-social/>`_ for more information.
 
 Even if you do not feel able to watch the everyone's repository, you will
 likely want to periodically check in on the current `Pull Requests


### PR DESCRIPTION
This should hopefully make https://ci.openmicroscopy.org/view/Docs/job/CONTRIBUTING-merge-docs/ green and also clean up redirecting URLs and references to old docs URLs.

Once the doc job migration and reconfiguration is complete, I'll also need to remove references to the linkchecker parser from the ci-docs page unless we find a way to get that working again.