### PR TITLE
Fix OMERO broken links

### DIFF
--- a/omero/conf.py
+++ b/omero/conf.py
@@ -139,6 +139,7 @@ linkcheck_ignore += [r'http://localhost:\d+/?', 'http://localhost/',
     'http://www.jboss.org',
     'https://code.google.com/archive/p/luke/',
     'https://www.youtube.com/channel/UCyySB9ZzNi8aBGYqcxSrauQ',
+    'https://httpd.apache.org/docs/current/mod/mod_proxy.html',
     r'https?://www\.openmicroscopy\.org/site/team/.*',
     r'.*[.]?example\.com/.*',
     r'https://spreadsheets.google.com/.*']

--- a/omero/conf.py
+++ b/omero/conf.py
@@ -137,6 +137,7 @@ html_theme_path.extend(['themes'])
 linkcheck_ignore += [r'http://localhost:\d+/?', 'http://localhost/',
     'http://www.hibernate.org',
     'http://www.jboss.org',
+    'https://code.google.com/archive/p/luke/',
     r'https?://www\.openmicroscopy\.org/site/team/.*',
     r'.*[.]?example\.com/.*',
     r'https://spreadsheets.google.com/.*']

--- a/omero/conf.py
+++ b/omero/conf.py
@@ -140,6 +140,7 @@ linkcheck_ignore += [r'http://localhost:\d+/?', 'http://localhost/',
     'https://code.google.com/archive/p/luke/',
     'https://www.youtube.com/channel/UCyySB9ZzNi8aBGYqcxSrauQ',
     'https://httpd.apache.org/docs/current/mod/mod_proxy.html',
+    'https://access.redhat.com/articles/3078',
     r'https?://www\.openmicroscopy\.org/site/team/.*',
     r'.*[.]?example\.com/.*',
     r'https://spreadsheets.google.com/.*']

--- a/omero/conf.py
+++ b/omero/conf.py
@@ -136,6 +136,7 @@ html_theme_path.extend(['themes'])
 # Regular expressions that match URIs that should not be checked when doing a linkcheck build
 linkcheck_ignore += [r'http://localhost:\d+/?', 'http://localhost/',
     'http://www.hibernate.org',
+    'http://www.jboss.org',
     r'https?://www\.openmicroscopy\.org/site/team/.*',
     r'.*[.]?example\.com/.*',
     r'https://spreadsheets.google.com/.*']

--- a/omero/conf.py
+++ b/omero/conf.py
@@ -138,6 +138,7 @@ linkcheck_ignore += [r'http://localhost:\d+/?', 'http://localhost/',
     'http://www.hibernate.org',
     'http://www.jboss.org',
     'https://code.google.com/archive/p/luke/',
+    'https://www.youtube.com/channel/UCyySB9ZzNi8aBGYqcxSrauQ',
     r'https?://www\.openmicroscopy\.org/site/team/.*',
     r'.*[.]?example\.com/.*',
     r'https://spreadsheets.google.com/.*']

--- a/omero/developers/Modules/Search.rst
+++ b/omero/developers/Modules/Search.rst
@@ -250,5 +250,5 @@ it is possible to extract more information specific to your site.
     :doc:`/developers/Search/FileParsers`,
     `Query Parser Syntax <http://lucene.apache.org/core/3_6_0/queryparsersyntax.html>`_,
 
-    ` Luke <https://code.google.com/p/luke/>`_
+    `Luke <https://code.google.com/archive/p/luke/>`_
         a Java application which you can download and point at your ``/OMERO/FullText`` directory to get a better feeling for Lucene queries.

--- a/omero/sysadmins/UpgradeCheck.rst
+++ b/omero/sysadmins/UpgradeCheck.rst
@@ -24,7 +24,7 @@ statement at WARN level.
 
 .. parsed-literal::
 
-    2011-09-01 12:21:32,070 WARN  [                 ome.system.UpgradeCheck] (      main) UPGRADE AVAILABLE:Please upgrade to |release| See https://trac.openmicroscopy.org.uk/omero for the latest version
+    2017-09-01 12:21:32,070 WARN  [                 ome.system.UpgradeCheck] (      main) UPGRADE AVAILABLE:Please upgrade to |release| See http://downloads.openmicroscopy.org/latest/omero for the latest version
 
 Future versions may also send emails and/or IMs to administrators. In
 the case of critical upgrades, the server may refuse to start.

--- a/omero/sysadmins/server-setup-examples.rst
+++ b/omero/sysadmins/server-setup-examples.rst
@@ -31,7 +31,7 @@ Micron, Oxford
 --------------
 
 The OMERO server at
-`Micron, Oxford <http://www2.bioch.ox.ac.uk/microngroup/micron_home.php>`_
+`Micron, Oxford <http://www2.bioch.ox.ac.uk/microngroup/home.php>`_
 houses two OMERO instances, the databases for both these instances, and a
 single OMERO.web instance which serves them both. The second OMERO instance
 (Raff OMERO) originated from another group's private OMERO server, which is

--- a/omero/sysadmins/version-requirements.rst
+++ b/omero/sysadmins/version-requirements.rst
@@ -301,7 +301,7 @@ Linux (CentOS and RHEL)
 -----------------------
 
 General overview for `RHEL
-<https://access.redhat.com/site/articles/3078>`__ and `CentOS
+<https://access.redhat.com/articles/3078>`__ and `CentOS
 <http://wiki.centos.org/FAQ/General#head-fe8a0be91ee3e7dea812e8694491e1dde5b75e6d>`__
 
 .. list-table::

--- a/omero/sysadmins/version-requirements.rst
+++ b/omero/sysadmins/version-requirements.rst
@@ -853,12 +853,12 @@ If no version is provided, a suitable repository is indicated.
       - N/A
       - N/A
     * - 1.10
-      - 6 (`EPEL <https://dl.fedoraproject.org/pub/epel/6/x86_64/>`__), 7 (`EPEL <https://dl.fedoraproject.org/pub/epel/7/x86_64/n/>`__)
+      - 6 (`EPEL <https://dl.fedoraproject.org/pub/epel/6/x86_64/>`__), 7 (`EPEL <https://dl.fedoraproject.org/pub/epel/7/x86_64/>`__)
       - 14.04 (`nginx <https://launchpad.net/~nginx/+archive/ubuntu/stable>`__), 16.04
       - Yes
       - Yes
     * - 1.12
-      - 6 (`EPEL <https://dl.fedoraproject.org/pub/epel/6/x86_64/>`__), 7 (`EPEL <https://dl.fedoraproject.org/pub/epel/7/x86_64/n/>`__)
+      - 6 (`EPEL <https://dl.fedoraproject.org/pub/epel/6/x86_64/>`__), 7 (`EPEL <https://dl.fedoraproject.org/pub/epel/7/x86_64/>`__)
       - 14.04 (`nginx <https://launchpad.net/~nginx/+archive/ubuntu/stable>`__), 16.04
       - Yes
       - Yes


### PR DESCRIPTION
Should make https://ci.openmicroscopy.org/view/Docs/job/OMERO-DEV-merge-docs/ green again.

JBoss is very slow to load but does work so I've added it to the ignore list.