### PR TITLE
Debian dependency

### DIFF
--- a/omero/sysadmins/unix/install-web/walkthrough/omeroweb-install-with-server-debian-ice3.6.rst
+++ b/omero/sysadmins/unix/install-web/walkthrough/omeroweb-install-with-server-debian-ice3.6.rst
@@ -24,7 +24,7 @@ Install Pillow and Numpy:
     :start-after: #start-web-dependencies
     :end-before: #end-web-dependencies
 
-Install NGINX:
+Install NGINX and Gunicorn:
 
 .. literalinclude:: ../../walkthrough/walkthrough_debian9.sh
     :start-after: #start-nginx-install


### PR DESCRIPTION


Copy manually walkthrough

This PR is solely to show the change made in https://github.com/ome/omero-install/pull/172

Do not merge this PR, the change will be done by running the autogen job when https://github.com/ome/omero-install/pull/172 is merged

To review:

* Make sure the dependency is correctly displayed in the web installation with server page for debian9

