### PR TITLE
Update auto-generated documentation

### DIFF
--- a/omero/downloads/ldap/setdn.out
+++ b/omero/downloads/ldap/setdn.out
@@ -32,6 +32,8 @@ Login arguments:
                       Default: $OMERO_USERDIR/sessions
     OMERO_TMPDIR      Set the base directory containing temporary files.
                       Default: $OMERO_USERDIR/tmp
+    OMERO_PASSWORD    Set the user's password for creating new sessions.
+                      Ignored if -w or --password is used.
   
   
   Optional session arguments:

--- a/omero/sysadmins/config.rst
+++ b/omero/sysadmins/config.rst
@@ -1123,6 +1123,23 @@ should wait for an image to be ready to view.
 
 Default: `ome.io.nio.SimpleBackOff`
 
+.. property:: omero.pixeldata.backoff.default
+
+omero.pixeldata.backoff.default
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+A default value for the backoff time.
+
+Default: `1000`
+
+.. property:: omero.pixeldata.backoff.maxpixels
+
+omero.pixeldata.backoff.maxpixels
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The maximum number of pixels (in any dimension),
+if exceeded the default value will be used.
+
+Default: `1000000`
+
 .. property:: omero.pixeldata.batch
 
 omero.pixeldata.batch

--- a/omero/sysadmins/unix/install-web/walkthrough/omeroweb-install-centos7-ice3.6.rst
+++ b/omero/sysadmins/unix/install-web/walkthrough/omeroweb-install-centos7-ice3.6.rst
@@ -1,3 +1,6 @@
+.. walkthroughs are generated using ansible, see 
+.. https://github.com/ome/omeroweb-install
+
 OMERO.web installation separately from OMERO.server on CentOS 7 and IcePy 3.6
 =============================================================================
 

--- a/omero/sysadmins/unix/install-web/walkthrough/omeroweb-install-debian-ice3.6.rst
+++ b/omero/sysadmins/unix/install-web/walkthrough/omeroweb-install-debian-ice3.6.rst
@@ -1,3 +1,6 @@
+.. walkthroughs are generated using ansible, see 
+.. https://github.com/ome/omeroweb-install
+
 OMERO.web installation separately from OMERO.server on Debian 9 and IcePy 3.6
 =============================================================================
 

--- a/omero/sysadmins/unix/install-web/walkthrough/omeroweb-install-osx-ice3.6.rst
+++ b/omero/sysadmins/unix/install-web/walkthrough/omeroweb-install-osx-ice3.6.rst
@@ -1,3 +1,6 @@
+.. walkthroughs are generated using ansible, see 
+.. https://github.com/ome/omeroweb-install
+
 OMERO.web installation on Mac OS X and IcePy 3.6
 ================================================
 

--- a/omero/sysadmins/unix/install-web/walkthrough/omeroweb-install-ubuntu-ice3.6.rst
+++ b/omero/sysadmins/unix/install-web/walkthrough/omeroweb-install-ubuntu-ice3.6.rst
@@ -1,3 +1,6 @@
+.. walkthroughs are generated using ansible, see 
+.. https://github.com/ome/omeroweb-install
+
 OMERO.web installation separately from OMERO.server on Ubuntu 16.04 and IcePy 3.6
 =================================================================================
 

--- a/omero/sysadmins/unix/walkthrough/walkthrough_debian9.sh
+++ b/omero/sysadmins/unix/walkthrough/walkthrough_debian9.sh
@@ -94,7 +94,7 @@ OMERO.server/bin/omero web config nginx --http "$WEBPORT" > OMERO.server/nginx.c
 #end-configure-nginx
 # As root, install nginx
 #start-nginx-install
-apt-get -y install nginx
+apt-get -y install nginx gunicorn
 #end-nginx-install
 #start-nginx-admin
 mv /etc/nginx/sites-available/default /etc/nginx/sites-available/default.disabled

--- a/omero/users/history.rst
+++ b/omero/users/history.rst
@@ -5,6 +5,40 @@
 OMERO version history
 =====================
 
+5.4.1 (November 2017)
+---------------------
+
+This is a bug-fix release.
+
+Improvements include:
+
+-  labelled zoom slider bars in the UI to differentiate from horizontal
+   scrollbars and make clear thumbnails can be zoomed (including Plate and
+   Well thumbnails)
+-  fixes for installation walkthrough documentation - installation of script
+   dependencies and gunicorn, and clarification of which user account to use
+   for ``pip install`` actions
+-  fixed checking of "guest" user
+-  update to fetch third-party artifacts over https to allow OMERO to build
+   even without a local Maven cache already populated
+-  added ``javax.activation`` dependency to allow OMERO.insight to work with
+   Java 9
+-  import of files reporting extreme pixel sizes now fail rather than hanging
+-  pyramid-making now aborts when a tile fails
+-  various test fixes
+-  CLI fixes:
+
+   * improved help output for graphs commands to make it clearer that
+     ``--include`` and ``--exclude`` expect class names not object IDs
+   * allowed setting the ``OMERO_PASSWORD`` environment variable instead of
+     using the ``-w`` command-line option
+   * made passwords hidden by default when running ``omero config get``
+   * fixed the CLI metadata tablestest plugin to not use an empty list of
+     Columns
+
+This release also upgrades the version of Bio-Formats which OMERO uses to
+5.7.2.
+
 5.4.0 (October 2017)
 --------------------
 


### PR DESCRIPTION
Repository: openmicroscopy/ome-documentation
Already up-to-date.



Generated by build [OMERO-DEV-latest-docs-autogen#1109](https://ci.openmicroscopy.org/job/OMERO-DEV-latest-docs-autogen/1109/).

----
--no-rebase