### PR TITLE
Add contributing page codifying C++ components development

### DIFF
--- a/contributing/conf.py
+++ b/contributing/conf.py
@@ -65,6 +65,9 @@ graphviz_output_format = 'svg'
 
 rst_epilog += """
 .. _GitHub: https://github.com
+.. _Git: https://git-scm.com/
+.. _Semantic Versioning: http://semver.org
+.. _CMake: https://cmake.org/
 .. _openmicroscopy.git: https://github.com/openmicroscopy/openmicroscopy
 .. _bioformats.git: https://github.com/openmicroscopy/bioformats
 .. _ome-documentation.git: https://github.com/openmicroscopy/ome-documentation

--- a/contributing/cpp-development.rst
+++ b/contributing/cpp-development.rst
@@ -124,7 +124,6 @@ Prior to a source release, a PR should be opened and merged to:
 - update the top-level :file:`NEWS.md` if it exists with the list of changes
   and the release date
 
-
 A PGP-signed tag should be created for the released version e.g.
 using :command:`scc tag-release` or more simply :command:`git tag -s`::
 
@@ -137,12 +136,15 @@ member of the team::
     $ git push <fork_name> vx.y.z
 
 
-Once the tag is created, a source release can be created by archiving the
-repository::
+Once the tag is created, run the ``<COMPONENT>-release`` job under the
+:jenkinsview:`Release` view tab. This job will create an archive of
+the repository using :command:`git archive`::
 
     $ git archive -v --format=tar "--prefix=${project}-${version}/" -o "${dest}/${project}-${version}.tar" "${tag}"
     $ xz "{dest}/${project}-${version}.tar"
     $ git archive -v --format=zip "--prefix=${project}-${version}/" -o "${dest}/${project}-${version}.zip" "${tag}"
+
+and copy the source archives under \https://downloads.openmicroscopy.org/<component>/<version>.
 
 Next development version
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/contributing/cpp-development.rst
+++ b/contributing/cpp-development.rst
@@ -1,0 +1,132 @@
+C++ components
+==============
+
+This document describes the conventions and process used by the OME team for
+developing, maintaining and releasing its C++ components.
+
+The set of rules and procedures described below applies to all the following
+C++ libraries.
+
+.. list-table::
+    :header-rows: 1
+
+    -   * Component name
+        * GitHub URL
+        * CMake project name
+
+    -   * OME Common C++
+        * https://github.com/ome/ome-common-cpp
+        * `ome-common`
+
+    -   * OME Data model
+        * https://github.com/ome/ome-model
+        * `ome-model`
+
+    -   * OME Files C++
+        * https://github.com/ome/ome-files-cpp
+        * `ome-files-cpp`
+
+    -   * OME Qt widgets
+        * https://github.com/ome/ome-qtwidgets
+        * `ome-qtwidgets`
+
+    -   * OME CMake Superbuild
+        * https://github.com/ome/ome-cmake-superbuild
+        * `ome-cmake-superbuild`
+
+    -   * OME Files Performance
+        * https://github.com/openmicroscopy/ome-files-performance
+        * `ome-files-performance`
+
+
+Conventions
+-----------
+
+Source code and build system
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The source code of a C++ library should be maintained under version control
+using Git_ and hosted on GitHub_.
+
+CMake_ should be used as the primary build system. There is no standard CMake
+directory layout. C++-only components like 
+[ome-common-cpp](https://github.com/ome/ome-common-cpp) use a flattened
+directory layout::
+
+   cmake/
+   CMakeLists.txt
+   docs/
+     sphinx/
+     doxygen/
+   lib/
+   test/
+
+Components containing both Java and C++ code like
+[ome-model](https://github.com/ome/ome-model) organize the C++
+sources according to the Maven recommended layout i.e.::
+
+   src/main/cpp             Contains the C++ code
+   src/main/java            Contains the Java code
+
+Additionally, header files should be maintained alongside the source files.
+
+Development
+^^^^^^^^^^^
+
+C++ components use `Semantic Versioning`_ i.e. given a version number
+MAJOR.MINOR.PATCH, increment the:
+
+- MAJOR version when you make incompatible API changes,
+- MINOR version when you add functionality in a backwards-compatible manner,
+  and
+- PATCH version when you make backwards-compatible bug fixes.
+
+Code contributions should follow the guidelines highlighted in :doc:`code-contributions`.
+
+Distribution
+^^^^^^^^^^^^
+
+All the C++ sources and binaries are hosted on the OME downloads according to
+the process described in the next section.
+
+Release process
+---------------
+
+Maintainer prerequisites
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+To be able to maintain a C++ component, a developer must:
+
+- have a GitHub_ account and have push rights to the GitHub source code
+  repository
+- have a valid PGP key for signing the tags
+
+Source release
+^^^^^^^^^^^^^^
+
+The first step of the C++ component release is to prepare a source release
+from the Git_ repository.
+
+A PGP-signed tag should be created for the released version e.g.
+using :command:`scc tag-release` or more simply :command:`git tag -s`::
+
+    $ scc tag-release -s x.y.z --prefix v
+
+Push the master branch and the tag to your fork for validation by another
+member of the team::
+
+    $ git push <fork_name> master
+    $ git push <fork_name> vx.y.z
+
+
+Once the tag is created, a source release can be created by archiving the
+repository::
+
+    $ git archive -v --format=tar "--prefix=${project}-${version}/" -o "${dest}/${project}-${version}.tar" "${tag}"
+    $ xz "{dest}/${project}-${version}.tar"
+    $ git archive -v --format=zip "--prefix=${project}-${version}/" -o "${dest}/${project}-${version}.zip" "${tag}"
+
+Next development version
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Once the release is accepted, the version number of `release-version` in :file:`CMakeLists.txt` should be incremented to the next patch number i.e. `x.y.z+1`.

--- a/contributing/cpp-development.rst
+++ b/contributing/cpp-development.rst
@@ -117,6 +117,14 @@ Source release
 The first step of the C++ component release is to prepare a source release
 from the Git_ repository.
 
+Prior to a source release, a PR should be opened and merged to:
+
+- review the ``release-version`` variable in :file:`CMakeLists.txt` and drop
+  the ``# unreleased`` comment
+- update the top-level :file:`NEWS.md` if it exists with the list of changes
+  and the release date
+
+
 A PGP-signed tag should be created for the released version e.g.
 using :command:`scc tag-release` or more simply :command:`git tag -s`::
 
@@ -139,4 +147,14 @@ repository::
 Next development version
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Once the release is accepted, the version number of `release-version` in :file:`CMakeLists.txt` should be incremented to the next patch number i.e. `x.y.z+1`.
+Once the release is accepted, the version number of `release-version` in
+:file:`CMakeLists.txt` should be incremented to the next patch number i.e.
+`x.y.z+1` and a suffixed with an `# unreleased` comment. If a top-level
+:file:`NEWS.md` file exists, an entry should be added for the next patch
+release.
+
+.. seealso::
+
+    https://github.com/ome/ome-common-cpp/pull/55
+       Example Pull Request incrementing the patch number of ome-common-cpp
+       and updating :file:`NEWS.md` following the 5.5.0 source release

--- a/contributing/cpp-development.rst
+++ b/contributing/cpp-development.rst
@@ -39,7 +39,7 @@ C++ libraries.
         * `ome-files-performance`
 
     -   * OME Files Python bindings†
-        * https://github.com/openmicroscopy/ome-files-py
+        * https://github.com/ome/ome-files-py
         * `ome-files-py`
 
 \*

--- a/contributing/cpp-development.rst
+++ b/contributing/cpp-development.rst
@@ -65,7 +65,7 @@ directory layout::
 
    cmake/
    CMakeLists.txt
-   docs/
+   docs/                    If applicable
      sphinx/
      doxygen/
    lib/
@@ -75,8 +75,8 @@ Components containing both Java and C++ code like
 `ome-model <https://github.com/ome/ome-model>`_ organize the C++
 sources according to the Maven-recommended layout i.e.::
 
-   src/main/cpp             Contains the C++ code
-   src/main/java            Contains the Java code
+   <module>/src/main/cpp             Contains the C++ code
+   <module>/src/main/java            Contains the Java code
 
 Additionally, header files should be maintained alongside the source files.
 
@@ -149,7 +149,7 @@ Next development version
 
 Once the release is accepted, the version number of `release-version` in
 :file:`CMakeLists.txt` should be incremented to the next patch number i.e.
-`x.y.z+1` and a suffixed with an `# unreleased` comment. If a top-level
+``x.y.z+1`` and a suffixed with an ``# unreleased`` comment. If a top-level
 :file:`NEWS.md` file exists, an entry should be added for the next patch
 release.
 

--- a/contributing/cpp-development.rst
+++ b/contributing/cpp-development.rst
@@ -60,7 +60,7 @@ using Git_ and hosted on GitHub_.
 
 CMake_ should be used as the primary build system. There is no standard CMake
 directory layout. C++-only components like 
-[ome-common-cpp](https://github.com/ome/ome-common-cpp) use a flattened
+`ome-common-cpp <https://github.com/ome/ome-common-cpp>`_ use a flattened
 directory layout::
 
    cmake/
@@ -72,7 +72,7 @@ directory layout::
    test/
 
 Components containing both Java and C++ code like
-[ome-model](https://github.com/ome/ome-model) organize the C++
+`ome-model <https://github.com/ome/ome-model>`_ organize the C++
 sources according to the Maven-recommended layout i.e.::
 
    src/main/cpp             Contains the C++ code
@@ -107,7 +107,7 @@ Maintainer prerequisites
 
 To be able to maintain a C++ component, a developer must:
 
-- have a GitHub_ account and have push rights to the GitHub source code
+- have a GitHub account and have push rights to the GitHub source code
   repository
 - have a valid PGP key for signing the tags
 
@@ -115,7 +115,7 @@ Source release
 ^^^^^^^^^^^^^^
 
 The first step of the C++ component release is to prepare a source release
-from the Git_ repository.
+from the Git repository.
 
 Prior to a source release, a PR should be opened and merged to:
 

--- a/contributing/cpp-development.rst
+++ b/contributing/cpp-development.rst
@@ -135,7 +135,6 @@ member of the team::
     $ git push <fork_name> master
     $ git push <fork_name> vx.y.z
 
-
 Once the tag is created, run the ``<COMPONENT>-release`` job under the
 :jenkinsview:`Release` view tab. This job will create an archive of
 the repository using :command:`git archive`::

--- a/contributing/cpp-development.rst
+++ b/contributing/cpp-development.rst
@@ -18,7 +18,7 @@ C++ libraries.
         * https://github.com/ome/ome-common-cpp
         * `ome-common`
 
-    -   * OME Data model
+    -   * OME Data Model*
         * https://github.com/ome/ome-model
         * `ome-model`
 
@@ -37,6 +37,16 @@ C++ libraries.
     -   * OME Files Performance
         * https://github.com/openmicroscopy/ome-files-performance
         * `ome-files-performance`
+
+    -   * OME Files Python bindings†
+        * https://github.com/openmicroscopy/ome-files-py
+        * `ome-files-py`
+
+\*
+  Contains both Java and C++ code - see :doc:`java-development`
+
+†
+  Contains both Python and C++ code
 
 
 Conventions
@@ -63,7 +73,7 @@ directory layout::
 
 Components containing both Java and C++ code like
 [ome-model](https://github.com/ome/ome-model) organize the C++
-sources according to the Maven recommended layout i.e.::
+sources according to the Maven-recommended layout i.e.::
 
    src/main/cpp             Contains the C++ code
    src/main/java            Contains the Java code

--- a/contributing/index.rst
+++ b/contributing/index.rst
@@ -16,6 +16,7 @@ be valuable to a wider audience.
     team-communication
     team-workflow
     java-development
+    cpp-development
     development-tools
     deployment-tools
     continuous-integration


### PR DESCRIPTION
See https://trello.com/c/8l4Rgg6a/547-codify-c-components-development-process

Following the [release of OME Files](https://www.openmicroscopy.org/2017/12/04/ome-files-0-5-0.html), this page documents the current guidelines for the C++ repositories including source control management, build system and development lifecycle.