### PR TITLE
Crossref new pyramid doc

### DIFF
--- a/omero/developers/Clients/ImportLibrary.rst
+++ b/omero/developers/Clients/ImportLibrary.rst
@@ -53,7 +53,9 @@ by writing the metadata into the database. After import, pixel data is
 accessed directly from the original files using Bio-Formats. This means that
 data files are no longer duplicated and any nested directory structure is
 preserved. It also allows OMERO to take advantage of pre-generated pyramids
-available in some formats e.g. SVS.
+available in some formats e.g. dedicated whole slide imaging formats such as
+:bf_v_doc:`SVS <formats/aperio-svs-tiff.html>` (instead of generating
+:model_doc:`OMERO pyramids <omero-pyramid/>`).
 
 For full details of the import workflow see :doc:`/developers/ImportFS`.
 

--- a/omero/sysadmins/in-place-import.rst
+++ b/omero/sysadmins/in-place-import.rst
@@ -80,7 +80,8 @@ in-place import at your high-content screening facility, we thus
 recommend time profiling with representative data, and alerting us to
 any significant disappointments.
 
-Also, there is still some data duplication when pyramids are generated. We are
+Also, there is still some data duplication when
+:model_doc:`pyramids <omero-pyramid/>` are generated. We are
 hoping to find a work-around for this in the future.
 
 .. _safety_tips:

--- a/omero/sysadmins/limitations.rst
+++ b/omero/sysadmins/limitations.rst
@@ -82,16 +82,16 @@ File format support
 Large images with floating-point pixel data
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Pyramids of image tiles are currently not generated for images with
-floating-point pixel data, meaning the imported image will be scrambled if it
-is over a certain size (configurable using
+:model_doc:`Pyramids <omero-pyramid/>` of image tiles are currently not
+generated for images with floating-point pixel data, meaning the imported
+image will be scrambled if it is over a certain size (configurable using
 :property:`omero.pixeldata.max_plane_height` and
 :property:`omero.pixeldata.max_plane_width` but set to 3192x3192 pixels by
 default). This primarily affects the following file formats:
 
-*  Gatan DM3
-*  MRC
-*  TIFF
+*  :bf_v_doc:`Gatan DM3 <formats/gatan-digital-micrograph.html>`
+*  :bf_v_doc:`MRC <formats/mrc.html>`
+*  :bf_v_doc:`TIFF <formats/tiff.html>`
 
 .. _minmax_limitation:
 


### PR DESCRIPTION
See https://trello.com/c/LAmAnmOc/591-cross-reference-new-pyramid-doc-in-omero-docs

This adds references to the new Pyramid page - http://docs.openmicroscopy.org/ome-model/5.6.0/omero-pyramid/index.html to the OMERO docs where relevant. I also checked that the info from https://github.com/ome/ome-model/pull/55/commits/a4a51d9871500c985b2028a7b61c0204f17d1147 existed in these docs and added links to BF for the formats mentioned.