### PR TITLE
Fix version replacement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,6 +137,9 @@ To modify this value set the environment variable ``OMERO_RELEASE`` e.g.::
     cd omero && OMERO_RELEASE=5.2.6 make clean html
     cd omero && OMERO_RELEASE=5.2.6 ant clean html
 
+This variable needs to be set to build all the version-dependent content
+used in the system administrator documentation correctly.
+
 The Contributing Developer documentation has the release version removed as
 the intention is to update these files as and when necessary, so that they
 always reflect our current practices.
@@ -152,14 +155,14 @@ By default, running ``ant`` will build as a zipped bundle.
 
 From the top level directory::
 
-    ant zip -Domero.release="5.3.0"
+    OMERO_RELEASE=5.3.0 ant zip -Domero.release="5.3.0"
 
 will generate the HTML documentation for OMERO and Contributing and bundle
 just the OMERO documentation into an OMERO.doc-5.3.0.zip under omero/_build.
 
 From omero directory::
 
-    ant zip -Domero.release="5.3.0"
+    OMERO_RELEASE=5.3.0 ant zip -Domero.release="5.3.0"
 
 will generate the HTML documentation for OMERO and create an
 OMERO.doc-5.3.0.zip under omero/_build.

--- a/README.rst
+++ b/README.rst
@@ -134,8 +134,8 @@ Release number
 The release number of the OMERO documentation is `UNKNOWN` by default.
 To modify this value set the environment variable ``OMERO_RELEASE`` e.g.::
 
-    cd omero && OMERO_RELEASE=5.2.6 make clean html
-    cd omero && OMERO_RELEASE=5.2.6 ant clean html
+    cd omero && OMERO_RELEASE=5.4.0 make clean html
+    cd omero && OMERO_RELEASE=5.4.0 ant clean html
 
 This variable needs to be set to build all the version-dependent content
 used in the system administrator documentation correctly.
@@ -155,24 +155,24 @@ By default, running ``ant`` will build as a zipped bundle.
 
 From the top level directory::
 
-    OMERO_RELEASE=5.3.0 ant zip -Domero.release="5.3.0"
+    OMERO_RELEASE=5.4.0 ant zip -Domero.release="5.4.0"
 
 will generate the HTML documentation for OMERO and Contributing and bundle
-just the OMERO documentation into an OMERO.doc-5.3.0.zip under omero/_build.
+just the OMERO documentation into an OMERO.doc-5.4.0.zip under omero/_build.
 
 From omero directory::
 
-    OMERO_RELEASE=5.3.0 ant zip -Domero.release="5.3.0"
+    OMERO_RELEASE=5.4.0 ant zip -Domero.release="5.4.0"
 
 will generate the HTML documentation for OMERO and create an
-OMERO.doc-5.3.0.zip under omero/_build.
+OMERO.doc-5.4.0.zip under omero/_build.
 
 From the contributing directory::
 
-    ant zip -Domero.release="5.3.0"
+    ant zip -Domero.release="5.4.0"
 
 will generate the HTML documentation for Contributing and create a
-CONTRIBUTING.doc-5.3.0.zip under contributing/_build.
+CONTRIBUTING.doc-5.4.0.zip under contributing/_build.
 
 Auto-generated content
 ----------------------

--- a/common/rules.xml
+++ b/common/rules.xml
@@ -42,8 +42,6 @@ Type "ant -p" for a list of targets.
       <exec executable="${sphinx.build}" failonerror="true">
         <arg value="-D"/>
         <arg value="release=${omero.release}"/>
-        <arg value="-D"/>
-        <arg value="version=${omero.shortversion}"/>
         <arg value="-b"/>
         <arg value="@{buildtype}"/>
         <arg line="@{opts}"/>


### PR DESCRIPTION
See https://trello.com/c/OUY9xIlY/613-missing-version-number-from-541-sysadmin-docs
|version| wasn't working on http://docs.openmicroscopy.org/omero/5.4.1/sysadmins/server-upgrade.html (even though |previousversion| is) because this file was overriding conf.py
