### PR TITLE
Python java examples page fixes

### DIFF
--- a/omero/developers/Java.rst
+++ b/omero/developers/Java.rst
@@ -5,6 +5,9 @@ Using the :zerocdoc:`Ice Java language mapping
 <display/Ice/Hello+World+Application>` from ZeroC_, OMERO provides access to
 your data within an :doc:`/developers/server-blitz` server from Java code.
 
+All the code examples below can be found at
+:sourcedir:`examples/Training/java/src/training`.
+
 Writing client apps
 -------------------
 

--- a/omero/developers/Java.rst
+++ b/omero/developers/Java.rst
@@ -439,6 +439,25 @@ Using the Java API directly:
     link.setParent(new ProjectI(info.getProjectId(), false));
     r = dm.saveAndReturnObject(ctx, link);
 
+-  **Create a map annotation (list of key: value pairs) and link it to an existing project.**
+
+::
+
+    List<NamedValue> result = new ArrayList<NamedValue>();
+    result.add(new NamedValue("mitomycin-A", "20mM"));
+    result.add(new NamedValue("PBS", "10mM"));
+    result.add(new NamedValue("incubation", "5min"));
+    result.add(new NamedValue("temperature", "37"));
+    result.add(new NamedValue("Organism", "Homo sapiens"));
+    MapAnnotationData data = new MapAnnotationData();
+    data.setContent(result);
+    data.setDescription("Training Example");
+    //Use the following namespace if you want the annotation to be editable
+    //in the webclient and insight
+    data.setNameSpace(MapAnnotationData.NS_CLIENT_CREATED);
+    DataManagerFacility fac = gateway.getFacility(DataManagerFacility.class);
+    fac.attachAnnotation(ctx, data, new ProjectData(new ProjectI(projectId, false)));
+
 -  **Create a file annotation and link to an image.**
 
 To attach a file to an object e.g. an image, few objects need to be

--- a/omero/developers/Model/KeyValuePairs.rst
+++ b/omero/developers/Model/KeyValuePairs.rst
@@ -91,6 +91,8 @@ presented by the clients, and can be edited with the
 appropriate permissions. See :help:`Managing Data
 <managing-data.html#keyvalue>` on :help:`OMERO User Help<>`
 for more information.
+See examples of creating MapAnnotations in :doc:`Java </developers/Java>`
+and :doc:`Python </developers/Python>` pages.
 
 Storage and queries
 -------------------

--- a/omero/developers/Model/StructuredAnnotations.rst
+++ b/omero/developers/Model/StructuredAnnotations.rst
@@ -100,20 +100,11 @@ annotation.
        TextAnnotation description = …;
        fileAnnotation.linkAnnotation(description);
 
-Immutability
-------------
-
-The actual content value of an annotation -- the text, long, double,
-file value, etc -- is immutable. Links to and from the annotation,
-however, can be modified.
-
-Currently the namespace field of annotations is mutable. See
-:ticket:`878` for discussion.
-
-
-
 Examples
 --------
+
+Examples of creating various type of Annotations can also be found on the
+:doc:`Java </developers/Java>` and :doc:`Python </developers/Python>` pages.
 
 Basics
 ^^^^^^

--- a/omero/developers/Python.rst
+++ b/omero/developers/Python.rst
@@ -158,9 +158,7 @@ Read data
 
 ::
 
-    # The only_owned=True parameter limits the Projects which are returned.
-    # If the parameter is omitted or the value is False, then all Projects
-    # visible in the current group are returned.
+    # Load first 5 Projects, filtering by default group and owner
     my_exp_id = conn.getUser().getId()
     default_group_id = conn.getEventContext().groupId
     for project in conn.getObjects("Project", opts={'owner': my_exp_id,


### PR DESCRIPTION
See: https://trello.com/c/afGMBCvP/50-remove-onlyowned-docstring-from-omero-python-examples-page
and https://trello.com/c/0q8yyo3E/71-java-training-examples-link-needs-to-be-added-to-java-bindings-page

Added Java MapAnnotation example from https://github.com/openmicroscopy/openmicroscopy/pull/5601