### PR TITLE
add links from group/user management to relevant data pages

### DIFF
--- a/omero/sysadmins/cli/usergroup.rst
+++ b/omero/sysadmins/cli/usergroup.rst
@@ -4,6 +4,11 @@ User/group management
 The :program:`omero user` and :program:`omero group` commands provide
 functionalities to add and manage users and groups on your database.
 
+.. seealso::
+
+   * :doc:`/users/cli/chgrp`
+   * :doc:`/users/cli/chown`
+
 User creation
 ^^^^^^^^^^^^^
 


### PR DESCRIPTION
I could imagine an admin clicking onto this page, which is more about managing users and groups, when wanting to adjust the user and/or group of model objects. Staged at https://ci.openmicroscopy.org/job/OMERO-DEV-merge-docs/ws/src/omero/_build/html/sysadmins/cli/usergroup.html.