### PR TITLE
Add note about systemd umask for in-place import

### DIFF
--- a/omero/sysadmins/in-place-import.rst
+++ b/omero/sysadmins/in-place-import.rst
@@ -181,6 +181,9 @@ was done for one of our test servers in Dundee:
     [omero_system_user@ome-server ManagedRepository]$
 
 
+If you are controlling OMERO.server with systemd you should add ``UMask=0002`` to the ``Service`` section of your :download:`systemd service file <unix/walkthrough/omero-systemd.service>`.
+
+
 Getting started
 ---------------
 


### PR DESCRIPTION
See https://github.com/ome/omero-install/pull/173#issuecomment-358233940:
> I don't think we specify anywhere assumptions about the omero(-server) user's group, therefore assuming that 0002 is safe on all servers is probably an issue. Without digging deeper, I'd err on the side of making that an addition to the in-place documentation, i.e. a sysadmin is knowingly opening up permissions on a system because of a level of trust granted to the in-place group.

Background: http://lists.openmicroscopy.org.uk/pipermail/ome-users/2018-January/006865.html