### PR TITLE
disable the chown-all targetusers feature

### DIFF
--- a/omero/sysadmins/whatsnew.rst
+++ b/omero/sysadmins/whatsnew.rst
@@ -14,8 +14,7 @@ What's new for OMERO 5.4 for sysadmins
   facility managers, image analysts etc. to organize users and data in OMERO
   without having to be granted full administrator privileges. Full
   administrators and administrators with restricted privileges can now create
-  Project/Dataset/Screen on behalf of other users in OMERO.web or transfer all
-  the data of a given user using the :program:`chown` command.
+  Project/Dataset/Screen on behalf of other users in OMERO.web.
 
 - The Public user is restricted to GET requests by default. This can be
   changed by setting the new configuration property

--- a/omero/users/cli/chown.rst
+++ b/omero/users/cli/chown.rst
@@ -133,6 +133,11 @@ the following form of the user specifier is used.
 Here ownership of all the objects belonging to users 1, 3 and 7
 would be transferred to user 10.
 
+.. warning::
+
+    This advanced featured of chown is temporarily disabled while a bug is
+    addressed. A proposed fix is under review.
+
 Including and excluding objects
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/omero/users/cli/chown.rst
+++ b/omero/users/cli/chown.rst
@@ -130,7 +130,7 @@ the following form of the user specifier is used.
 
     $ bin/omero chown 10 Experimenter:1,3,7
 
-Here ownership of all the objects belonging to users 1,3 and 7
+Here ownership of all the objects belonging to users 1, 3 and 7
 would be transferred to user 10.
 
 Including and excluding objects


### PR DESCRIPTION
While https://trello.com/c/DaJKgLoY/40-chown-all-scriptjob-failures remains in play it's easiest to disable the chown-all feature for now. Can probably revert the last commit for OMERO 5.4.3, we'll see. Staged at https://ci.openmicroscopy.org/job/OMERO-DEV-merge-docs/ws/src/omero/_build/html/users/cli/chown.html.