### PR TITLE
Use OMERO.CLI as the search term for OMERO CLI plugins

### DIFF
--- a/omero/developers/cli/extending.rst
+++ b/omero/developers/cli/extending.rst
@@ -14,7 +14,7 @@ Alternatively, plugins can be added to any directory ending with
 `omero-cli-render <https://github.com/ome/omero-cli-render/>`_.
 
 Team-supported |CLI| plugins will be pip-installable. Search for
-"`omero cli <https://pypi.python.org/pypi?%3Aaction=search&term=omero+cli&submit=search>`_"
+"`omero cli <https://pypi.python.org/pypi?%3Aaction=search&term=OMERO.CLI&submit=search>`_"
 on PyPI_.
 
 Thread-safety


### PR DESCRIPTION
Since all our plugins deployed on PyPI are standardized on using `OMERO.CLI` as a keyword, this URL should give a more targetted list of results.