### PR TITLE
Add sudo example for the java gateway

### DIFF
--- a/omero/developers/Java.rst
+++ b/omero/developers/Java.rst
@@ -993,12 +993,13 @@ in OMERO. Similar approach can be applied when uploading an image.
 Sudo (working within another user's context)
 --------------------------------------------
 
-The next example shows how one can work within another user's context. For example
-a data analyst doing some analysis on behalf of a user and attaching the results
-to the user's data. The important point is that the user will be the owner of
-these results and can work with them as usual. The user and analyst don't have to be
-member of a read-annotate group. But the 'analyst' user has to be a 'light admin'
-user with 'sudo' permission.
+The next code snippet shows how you can work within another user's context. This
+could for example be a data analyst doing some analysis on behalf of a user and
+attaching the results to the user's data. The important point is that the user will
+be the owner of these results and can work with them as usual. The user and 'analyst'
+do not have to be member of a read-annotate group (see :doc:`Server/Permissions`),
+but the 'analyst' has to be a 'light administrator' with 'sudo' permission,
+see :doc:`Server/LightAdmins`.
 
 ::
 

--- a/omero/developers/Java.rst
+++ b/omero/developers/Java.rst
@@ -1006,7 +1006,7 @@ see :doc:`Server/LightAdmins`.
     AdminFacility admin = gateway.getFacility(AdminFacility.class);
 
     // Look up the experimenter to sudo for
-    ExperimenterData sudoUser = admin.lookupExperimenter(ctx, sudoUserName);
+    ExperimenterData sudoUser = admin.lookupExperimenter(ctx, sudoUsername);
 
     // Create a SecurityContext for this user within the user's default group
     // and set the 'sudo' flag (i.e. all operations using this context will
@@ -1015,26 +1015,18 @@ see :doc:`Server/LightAdmins`.
     sudoCtx.setExperimenter(sudoUser);
     sudoCtx.sudo();
 
-    // Get the sudouser's datasets
+    // Get a sudouser's dataset (assume the user has at least one dataset)
     BrowseFacility browse = gateway.getFacility(BrowseFacility.class);
     Collection<DatasetData> datasets = browse.getDatasets(sudoCtx, sudoUser.getId());
-    Iterator<DatasetData> i = datasets.iterator();
-    DatasetData first = null;
-    while (i.hasNext()) {
-        DatasetData dataset = i.next();
-        System.out.println(dataset.getName()+" ("+dataset.getId()+")");
+    DatasetData sudoDataset = datasets.iterator().next();
 
-        if (first == null)
-            first = dataset;
-    }
-
-    // Add a tag to the first dataset on behalf of the sudouser (i.e. the sudouser will be
-    // the owner of tag). 
+    // Add a tag to the dataset on behalf of the sudouser (i.e. the sudouser will be
+    // the owner of tag).
     DataManagerFacility dm = gateway.getFacility(DataManagerFacility.class);
-    TagAnnotationData sudoUserTag = new TagAnnotationData(sudoUserName+"'s tag");
-    dm.attachAnnotation(sudoCtx, sudoUserTag, first);
+    TagAnnotationData sudoUserTag = new TagAnnotationData(sudoUsername+"'s tag");
+    dm.attachAnnotation(sudoCtx, sudoUserTag, sudoDataset);
     System.out.println("Added '"+sudoUserTag.getContentAsString()+"' "
-            + "to dataset "+first.getName()+" on behalf of "+sudoUserName);
+        + "to dataset "+sudoDataset.getName()+" on behalf of "+sudoUsername);
 
     // Add a tag to the same dataset as logged in user (i. e. the logged in user will be
     // the owner of the tag). Note: This only works in a read-annotate group where the
@@ -1044,9 +1036,9 @@ see :doc:`Server/LightAdmins`.
     // Have to use a SecurityContext for the correct group, otherwise this would fail
     // with a security violation
     SecurityContext groupContext = new SecurityContext(sudoUser.getGroupId());
-    dm.attachAnnotation(groupContext, adminTag, first);
+    dm.attachAnnotation(groupContext, adminTag, sudoDataset);
     System.out.println("Added '"+adminTag.getContentAsString()+"'"
-            + " to dataset "+first.getName()+" as admin.");
+        + " to dataset "+sudoDataset.getName()+" as admin.");
 
 Further information
 -------------------


### PR DESCRIPTION
Adds an example for using 'sudo' with the Java Gateway to the Java examples, as @bramalingam recently tried to do something similar and noticed that there's actually no example/documentation about it.

~~I just tested the code manually against eel. There's no working example in the 'training' examples, as it's quite a hassle to set that up (first have to create the user to sudo for, then  create a dataset for that user (while actually already using 'sudo'), etc.).~~ - See https://github.com/openmicroscopy/openmicroscopy/pull/5652 

Staged at https://ci.openmicroscopy.org/job/OMERO-DEV-merge-docs/ws/src/omero/_build/html/developers/Java.html 