### PR TITLE
Update omerodocs.py for Sphinx 1.7

### DIFF
--- a/common/_ext/omerodocs.py
+++ b/common/_ext/omerodocs.py
@@ -42,7 +42,7 @@ try:
 except:
     from sphinx.writers.html import HTMLTranslator
 from sphinx.util.console import bold
-from sphinx.util.compat import Directive
+from docutils.parsers.rst import Directive
 
 # RE for option descriptions without a '--' prefix
 simple_option_desc_re = re.compile(


### PR DESCRIPTION
See https://trello.com/c/uyNZDHhJ/47-sphinx-170

This builds fine with my local version of Sphinx 1.6.3 so should be backwards compatible that far at least.

Used for the config glossary /sysadmins/config.html