### PR TITLE
remove mentions of windefault.xml

### DIFF
--- a/omero/developers/logging.rst
+++ b/omero/developers/logging.rst
@@ -64,8 +64,8 @@ For example, the config file for Processor-0 can be found in
 :file:`etc/grid/templates.xml`.
 
 All the "omero.logging.\*" properties can be overwritten in your
-:file:`etc/grid/default.xml` file.
-See the "Profile" properties block for how to configure for your site.
+:file:`etc/grid/default.xml` file. See the "Profile" properties block
+for how to configure for your site.
 
 Similar to logback, logging is configured to be written to
 ``var/log/<servername>.log`` and to maintain 9 backups of at most 500MB.

--- a/omero/developers/logging.rst
+++ b/omero/developers/logging.rst
@@ -64,8 +64,7 @@ For example, the config file for Processor-0 can be found in
 :file:`etc/grid/templates.xml`.
 
 All the "omero.logging.\*" properties can be overwritten in your
-:file:`etc/grid/default.xml` file (or on Windows,
-:file:`etc/grid/windefault.xml`).
+:file:`etc/grid/default.xml` file.
 See the "Profile" properties block for how to configure for your site.
 
 Similar to logback, logging is configured to be written to

--- a/omero/sysadmins/server-security.rst
+++ b/omero/sysadmins/server-security.rst
@@ -181,12 +181,12 @@ will be unencrypted, and the only critical data which is passed in
 the clear is your session id.
 
 Administrators can configure OMERO such that unencrypted connections are
-not allowed, and the user's choice will be silently ignored. The |SSL| and
-non-SSL ports are configured in the :file:`etc/grid/default.xml`
-file, and as described above, default to 4064
-and 4063 respectively, and can be modified using the
-:ref:`ports_configuration` configuration properties. For instance, to prefix
-all ports with 1, use :property:`omero.ports.prefix`::
+not allowed, and the user's choice will be silently ignored. The |SSL|
+and non-SSL ports are configured in the :file:`etc/grid/default.xml`
+file, and as described above, default to 4064 and 4063 respectively, and
+can be modified using the :ref:`ports_configuration` configuration
+properties. For instance, to prefix all ports with 1, use
+:property:`omero.ports.prefix`::
 
     $ bin/omero config set omero.ports.prefix 1
 

--- a/omero/sysadmins/server-security.rst
+++ b/omero/sysadmins/server-security.rst
@@ -182,8 +182,8 @@ the clear is your session id.
 
 Administrators can configure OMERO such that unencrypted connections are
 not allowed, and the user's choice will be silently ignored. The |SSL| and
-non-SSL ports are configured in the :file:`etc/grid/default.xml` and
-:file:`etc/grid/windefault.xml` files, and as described above, default to 4064
+non-SSL ports are configured in the :file:`etc/grid/default.xml`
+file, and as described above, default to 4064
 and 4063 respectively, and can be modified using the
 :ref:`ports_configuration` configuration properties. For instance, to prefix
 all ports with 1, use :property:`omero.ports.prefix`::

--- a/omero/sysadmins/server-security.rst
+++ b/omero/sysadmins/server-security.rst
@@ -183,7 +183,7 @@ the clear is your session id.
 Administrators can configure OMERO such that unencrypted connections are
 not allowed, and the user's choice will be silently ignored. The |SSL|
 and non-SSL ports are configured in the :file:`etc/grid/default.xml`
-file, and as described above, default to 4064 and 4063 respectively, and
+file and, as described above, default to 4064 and 4063 respectively and
 can be modified using the :ref:`ports_configuration` configuration
 properties. For instance, to prefix all ports with 1, use
 :property:`omero.ports.prefix`::


### PR DESCRIPTION
OMERO.server is no longer supported on Microsoft Windows so this PR removes mention of the related configuration file. Staged at,

* https://ci.openmicroscopy.org/job/OMERO-DEV-merge-docs/ws/src/omero/_build/html/developers/logging.html#python-servers
* https://ci.openmicroscopy.org/job/OMERO-DEV-merge-docs/ws/src/omero/_build/html/sysadmins/server-security.html#ssl