### PR TITLE
Document removepyramids on upgrade page

### DIFF
--- a/omero/sysadmins/server-upgrade.rst
+++ b/omero/sysadmins/server-upgrade.rst
@@ -46,6 +46,20 @@ to enable successful upgrading of the database, otherwise the upgrade
 script aborts with a message saying that your database server version is
 less than the OMERO prerequisite.
 
+Corrupted pyramids
+^^^^^^^^^^^^^^^^^^
+
+A bug introduced in OMERO 5.2 meant that corrupted pyramids were generated for
+large TIFF files, ignoring the little endian encoding. This bug was fixed in
+OMERO 5.4.4 and corrupted pyramids need to be deleted to allow new ones to be
+generated::
+
+   bin/omero admin removepyramids
+
+You can specify little-endian files only and a cut-off date (e.g. the date you
+upgraded to 5.2) so the command has less files to process; use ``-h`` for
+details of the additional arguments possible.
+
 File limits
 ^^^^^^^^^^^
 

--- a/omero/sysadmins/server-upgrade.rst
+++ b/omero/sysadmins/server-upgrade.rst
@@ -54,9 +54,9 @@ large TIFF files, ignoring the little endian encoding. This bug was fixed in
 OMERO 5.4.4 and corrupted pyramids need to be deleted to allow new ones to be
 generated::
 
-   bin/omero admin removepyramids
+   bin/omero admin removepyramids --little-endian
 
-You can specify little-endian files only and a cut-off date (e.g. the date you
+You can use ``--dry-run`` and specify a cut-off date (e.g. the date you
 upgraded to 5.2) so the command has less files to process; use ``-h`` for
 details of the additional arguments possible.
 

--- a/omero/sysadmins/server-upgrade.rst
+++ b/omero/sysadmins/server-upgrade.rst
@@ -49,16 +49,18 @@ less than the OMERO prerequisite.
 Corrupted pyramids
 ^^^^^^^^^^^^^^^^^^
 
-A bug introduced in OMERO 5.2 meant that corrupted pyramids were generated for
-large TIFF files, ignoring the little endian encoding. This bug was fixed in
+A bug introduced in OMERO 5.2.0 meant that corrupted pyramids were generated
+for large TIFF files with little endian encoding. This bug was fixed in
 OMERO 5.4.4 and corrupted pyramids need to be deleted to allow new ones to be
 generated::
 
    bin/omero admin removepyramids --little-endian
 
-You can use ``--dry-run`` and specify a cut-off date (e.g. the date you
-upgraded to 5.2) so the command has less files to process; use ``-h`` for
-details of the additional arguments possible.
+We recommend you run the command with ``--dry-run`` first to list the pyramids
+that will be deleted. If there are a large number of pyramids, you may need to
+run the command more than once. You can also specify a cut-off date (e.g. the
+date you upgraded to 5.2) so the command has fewer files to process; use
+``-h`` for details of the additional arguments possible.
 
 File limits
 ^^^^^^^^^^^

--- a/omero/sysadmins/server-upgrade.rst
+++ b/omero/sysadmins/server-upgrade.rst
@@ -54,7 +54,7 @@ for large TIFF files with little endian encoding. This bug was fixed in
 OMERO 5.4.4 and corrupted pyramids need to be deleted to allow new ones to be
 generated::
 
-   bin/omero admin removepyramids --little-endian
+   bin/omero admin removepyramids --endian=little
 
 We recommend you run the command with ``--dry-run`` first to list the pyramids
 that will be deleted. If there are a large number of pyramids, you may need to


### PR DESCRIPTION
This documents https://github.com/openmicroscopy/openmicroscopy/pull/5659 for the 5.4.4 release.

I'll add a reference to the version history telling sysadmins this is where to find the info.

cc @jburel 