### PR TITLE
Remove OMERO breaking jobs

### DIFF
--- a/contributing/ci-bio-formats.rst
+++ b/contributing/ci-bio-formats.rst
@@ -33,17 +33,13 @@ All jobs are listed under the :jenkinsview:`Bio-Formats` view tab of Jenkins.
                 * :term:`BIOFORMATS-DEV-merge-matlab`
 
         -       * Runs automated tests against the full repository on squig
-                * | :term:`BIOFORMATS-DEV-merge-full-repository`
-                    :term:`BIOFORMATS-DEV-merge-full-repository-win`
+                * :term:`BIOFORMATS-DEV-merge-full-repository`
 
         -       * Runs automated tests against a subset of the data repository on squig
                 * :term:`BIOFORMATS-DEV-merge-repository-subset`
 
         -       * Runs performance tests
                 * :term:`BIOFORMATS-DEV-merge-performance`
-
-        -       * Installs Bio-Formats using Homebrew
-                * :term:`BIOFORMATS-DEV-merge-homebrew`
 
 5.x.x series
 ^^^^^^^^^^^^
@@ -125,15 +121,6 @@ The branch for the 5.x series of Bio-Formats is develop.
                 #. Checks out :bf_scc_branch:`develop/merge/daily`
                 #. Runs automated tests against :file:`/ome/data_repo/curated/`
 
-        :jenkinsjob:`BIOFORMATS-DEV-merge-full-repository-win`
-
-                This job runs the automated tests against the curated data
-                repository on Windows
-
-                #. Checks out :bf_scc_branch:`develop/merge/daily`
-                #. Runs automated tests against
-                   :file:`\\\\squig.openmicroscopy.org.uk\\ome-data-repo\\curated`
-
         :jenkinsjob:`BIOFORMATS-DEV-merge-repository-subset`
 
                 This job runs the automated tests against a subset of the data
@@ -152,7 +139,3 @@ The branch for the 5.x series of Bio-Formats is develop.
                 #. Checks out the :bf_scc_branch:`develop/merge/daily`
                 #. Runs file-handles and openbytes-performance tests against
                    files specified by :file:`performance_files.txt`
-
-        :jenkinsjob:`BIOFORMATS-DEV-merge-homebrew`
-
-                This job builds Bio-Formats using MacOS X Homebrew

--- a/contributing/ci-introduction.rst
+++ b/contributing/ci-introduction.rst
@@ -55,8 +55,6 @@ Multiple labels are used in the PR reviewing process:
   merge builds.
 - the "on hold" label allows you to signal that a PR should not be
   reviewed or merged, even though it is not excluded.
-- the "breaking" label allows you to mark a PR as containing breaking changes,
-  usually model and/or DB changes (see :ref:`omero_breaking`).
 
 Job names
 ^^^^^^^^^
@@ -73,8 +71,6 @@ All core OME job names take the form
     `origin/dev_5_0`;
   * `merge`: build from the tip of the development branch with all
     PRs merged using :ref:`scc merge` with the `org` default filter set;
-  * `breaking`: build from the tip of the development branch with
-    all PRs labeled as `breaking` merged using :ref:`scc merge`;
   * `release`: build from and optionally create a tag at the tip of
     a development branch, e.g. `v5.0.1-rc4`.
 

--- a/contributing/ci-omero.rst
+++ b/contributing/ci-omero.rst
@@ -6,70 +6,52 @@ OMERO jobs
 
     -   * Job task
         * DEV series
-        * Breaking series
 
     -   * Builds the latest OMERO artifacts
         * :term:`OMERO-DEV-latest`
-        *
 
     -   * Deploys the latest OMERO server
         * :term:`OMERO-DEV-latest-deploy`
-        *
 
     -   * Deploys the latest OMERO web
         * :term:`WEB-DEV-latest-deploy`
-        *
 
     -   * Updates submodules
         * :term:`OMERO-DEV-latest-submods`
-        *
 
     -   * Runs the daily OMERO merge builds
         * :term:`OMERO-DEV-merge-daily`
-        * :term:`OMERO-DEV-breaking-trigger`
 
     -   * Merges the PRs
         * :term:`OMERO-DEV-merge-push`
-        * :term:`OMERO-DEV-breaking-push`
 
     -   * Builds the merge OMERO artifacts
         * :term:`OMERO-DEV-merge-build`
-        * :term:`OMERO-DEV-breaking-build`
 
     -   * Deploys the merge OMERO server
         * :term:`OMERO-DEV-merge-deploy`
-        * :term:`OMERO-DEV-breaking-deploy`
 
     -   * Deploys the merge OMERO web
         * :term:`WEB-DEV-merge-deploy`
-        * :term:`WEB-DEV-breaking-deploy`
 
     -   * Runs the OMERO integration tests
         * | :term:`OMERO-DEV-merge-integration`
           | :term:`OMERO-DEV-merge-integration-broken`
           | :term:`OMERO-DEV-merge-integration-java`
           | :term:`OMERO-DEV-merge-integration-python`
-        * | :term:`OMERO-DEV-breaking-integration`
-          | :term:`OMERO-DEV-breaking-integration-broken`
-          | :term:`OMERO-DEV-breaking-integration-java`
-          | :term:`OMERO-DEV-breaking-integration-python`
-
+       
     -   * Deploys the integration OMERO web and runs Robot tests using first server from the list
         * :term:`WEB-DEV-integration-deploy`
-        *
 
     -   * Runs the OMERO.matlab tests
         * :term:`OMERO-DEV-merge-matlab`
-        *
 
     -   * Runs the robot framework tests
         * :term:`OMERO-DEV-merge-robotframework`
-        *
 
     -   * Pushes SNAPSHOTS to Maven
         * | :term:`OMERO-DEV-latest-maven`
           | :term:`OMERO-DEV-merge-maven`
-        *
 
 .. _deployment_servers:
 
@@ -110,13 +92,6 @@ clients of the deployment jobs described above:
         * 24064
         * :term:`WEB-DEV-integration-deploy`
         * http://web-dev-integration.openmicroscopy.org/webclient/login/
-
-    -   * Breaking
-        * :term:`OMERO-DEV-breaking-deploy`
-        * carp.openmicroscopy.org
-        * 34064
-        * :term:`WEB-DEV-breaking-deploy`
-        * http://web-dev-breaking.openmicroscopy.org/webclient/login/
 
 
 5.4.x series
@@ -282,87 +257,3 @@ under the :jenkinsview:`DEV` view tab of Jenkins.
         #. Cleans :file:`/usr/local`
         #. Installs Homebrew from https://github.com/ome/omero-install
         #. Installs OMERO via :file:`osx/install_homebrew.sh`
-
-.. _omero_breaking:
-
-Breaking jobs
-^^^^^^^^^^^^^
-
-Breaking jobs are jobs containing breaking, irreversible changes typically
-database upgrade. The branch for the breaking series of OMERO is develop.
-
-.. glossary::
-
-    :jenkinsjob:`OMERO-DEV-breaking-trigger`
-
-        This job triggers all the breaking jobs listed below
-
-        #. Triggers :term:`OMERO-DEV-breaking-push`
-        #. Triggers :term:`OMERO-DEV-breaking-build` and
-           :term:`OMERO-DEV-breaking-integration`
-        #. Triggers :term:`OMERO-DEV-breaking-deploy`
-        #. Triggers :term:`WEB-DEV-breaking-deploy`
-        #. Triggers other downstream breaking jobs
-
-    :jenkinsjob:`OMERO-DEV-breaking-push`
-
-        This job merges all the breaking PRs
-
-        #. |merge| including only PRs labeled as `breaking`
-        #. Pushes the branch to :omero_scc_branch:`develop/breaking/trigger` 
-
-    :jenkinsjob:`OMERO-DEV-breaking-build`
-
-        This matrix jobs builds the OMERO components with Ice 3.5 or 3.6
-
-        #. Checks out :omero_scc_branch:`develop/breaking/trigger` 
-        #. |buildOMERO| for each version of Ice
-        #. |archiveOMEROartifacts|
-
-    :jenkinsjob:`OMERO-DEV-breaking-deploy`
-
-        This job deploys the breaking server (see :ref:`deployment_servers`)
-
-    :jenkinsjob:`WEB-DEV-breaking-deploy`
-
-        This job deploys the breaking web (see :ref:`deployment_servers`)
-
-    :jenkinsjob:`OMERO-DEV-breaking-integration`
-
-        This job runs the integration tests of OMERO
-
-        #. Checks out :omero_scc_branch:`develop/breaking/trigger` 
-        #. Builds OMERO.server and starts it
-        #. Runs the OMERO.java and OMERO.py integration tests
-        #. Archives the results
-        #. Triggers downstream collection jobs:
-           :term:`OMERO-DEV-breaking-integration-broken`,
-           :term:`OMERO-DEV-breaking-integration-java`,
-           :term:`OMERO-DEV-breaking-integration-python`
-
-    :jenkinsjob:`OMERO-DEV-breaking-integration-broken`
-
-        This job collects the OMERO.java broken test results
-
-        #. Receives TestNG results under
-           :file:`components/tools/OmeroJava/target/reports/broken` from
-           :term:`OMERO-DEV-breaking-integration`,
-        #. Generates TestNG report
-
-    :jenkinsjob:`OMERO-DEV-breaking-integration-java`
-
-        This job collects the OMERO.java integration test results
-
-        #. Receives TestNG results under
-           :file:`components/tools/OmeroJava/target/reports/integration` from
-           :term:`OMERO-DEV-breaking-integration`,
-        #. Generates TestNG report
-
-    :jenkinsjob:`OMERO-DEV-breaking-integration-python`
-
-        This job collects the OMERO.py integration test results
-
-        #. Receives pytest results under
-           :file:`components/tools/OmeroPy/target/reports` from
-           :term:`OMERO-DEV-breaking-integration`,
-        #. Generates pytest report

--- a/contributing/schema-changes.rst
+++ b/contributing/schema-changes.rst
@@ -142,14 +142,3 @@ diff` reports should help you to create a new
 When you commit your code and issue a pull request, include the
 changes to :omero_source:`omero.properties <etc/omero.properties>` and
 :omero_sourcedir:`sql/psql` among the commits in the pull request.
-
-Review workflow
----------------
-
-Any pull request introducing a schema change will be initially marked and
-reviewed with a `breaking` label (see :doc:`ci-introduction`) so after
-opening your pull request please have it labeled as being breaking. This
-implies the pull request will first be included in the
-:ref:`omero_breaking` and Bio-Formats Breaking jobs exclusively. Once
-positively reviewed, the `breaking` label will be removed so that the pull
-request is included in the daily merge builds before final merging.


### PR DESCRIPTION
This removes all mention of the OMERO breaking jobs and the breaking queue workflow for schema changes.

Remaining mentions of breaking are on the ome-files-ci page and the scc page - both likely require some proper re-writing outside the scope of this PR.