### PR TITLE
Make homebrew install python2

### DIFF
--- a/omero/sysadmins/unix/server-install-homebrew.rst
+++ b/omero/sysadmins/unix/server-install-homebrew.rst
@@ -100,7 +100,7 @@ Requirements
 
 4. Install Python provided by Homebrew::
 
-    $ brew install python
+    $ brew install python2
 
    Homebrew installs Python in the following location::
 

--- a/omero/sysadmins/unix/server-installation.rst
+++ b/omero/sysadmins/unix/server-installation.rst
@@ -192,7 +192,7 @@ If possible, install the following packages:
       - python2.7 python-numpy python-tables
 
     * - Homebrew
-      - python numpy
+      - python2 numpy
 
     * - RedHat
       - python


### PR DESCRIPTION
@rleigh-codelibre mentioned that Homebrew now installs Python 3 by default so this PR makes it explicit that you need python2 on both the Homebrew walkthrough and the main installation page.

I assume no other changes needed.