### PR TITLE
app example

### DIFF
--- a/omero/developers/Web/CreateApp.rst
+++ b/omero/developers/Web/CreateApp.rst
@@ -219,7 +219,7 @@ The following example can be found in the
 
 
        @login_required()
-       def stack_preview(request, imageId, conn=None, **kwargs):
+       def stack_preview(request, image_id, conn=None, **kwargs):
             """ Shows a subset of Z-planes for an image """
             image = conn.getObject("Image", image_id)
             image_name = image.getName()


### PR DESCRIPTION
Fix example coming from webtest
The code is correct in omero-webtest but it was not correctly copied across (not included)
https://trello.com/c/toYDGCS4/355-bug-createapp-in-web-doc-bug

cc @pwalczysko 