### PR TITLE
Remove Windows support mention & nitpick

### DIFF
--- a/omero/developers/cli/index.rst
+++ b/omero/developers/cli/index.rst
@@ -9,15 +9,6 @@ Command Line Interface as an OMERO development tool
     obj
     extending
 
-
-.. seealso::
-
-    :doc:`/users/cli/index`
-        User documentation on the Command Line Interface
-
-    :doc:`/sysadmins/cli/index`
-        System Administrator documentation for the Command Line Interface
-
 Help for any specific CLI command can be displayed using the ``-h``
 argument. See :ref:`cli_help` for more information.
 
@@ -32,3 +23,10 @@ General notes
    to have a startup script.
 -  All commands respond to :program:`omero help`.
 
+.. seealso::
+
+    :doc:`/users/cli/index`
+        User documentation on the Command Line Interface
+
+    :doc:`/sysadmins/cli/index`
+        System Administrator documentation for the Command Line Interface

--- a/omero/users/cli/index.rst
+++ b/omero/users/cli/index.rst
@@ -6,9 +6,7 @@ advanced user tools. Most of commands work remotely so that the |CLI| can be
 used as a client against an OMERO server.
 
 .. note:: The end of Windows support for OMERO.server means that the CLI is
-    currently unsupported on this platform too. However, we intend to make
-    OMERO.python installable via pip for future releases which would restore
-    Windows support for the CLI.
+    unsupported on this platform too.
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
While reviewing the docs for the 5.4.4 release, I realized I'd removed the sentence about supporting CLI on Windows via OMERO.py from the CLI user installation page but not the CLI user index page. Also, a minor rearrangement to the dev CLI index to improve readability.

Can go in 5.4.5 as not urgent.