### PR TITLE
For public user URL filter add helpful clarification.

### DIFF
--- a/omero/sysadmins/public.rst
+++ b/omero/sysadmins/public.rst
@@ -75,7 +75,8 @@ To set this up on your OMERO.web installation:
 
 - Set the :property:`omero.web.public.url_filter`. This filter is a
   regular expression that will allow only matching URLs to be accessed
-  by the public user.
+  by the public user. If this is not set, no URLs will be publicly
+  available.
 
   There are three common use cases for the URL filter:
 


### PR DESCRIPTION
Adds to https://ci.openmicroscopy.org/job/OMERO-DEV-merge-docs/ws/src/omero/_build/html/sysadmins/public.html#configuring-public-user a helpful note that I found in `omeroweb/settings.py`.