### PR TITLE
Update PyPI URLs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -420,7 +420,7 @@ Jenkins                     http://jenkins-ci.org
 roadmap                     https://trac.openmicroscopy.org/ome/roadmap
 Open Microscopy Environment https://www.openmicroscopy.org
 Glencoe Software, Inc.      https://www.glencoesoftware.com/
-PyPI                        https://pypi.python.org
+PyPI                        https://pypi.org
 =========================== ==============================================
 
 Abbreviations

--- a/common/conf.py
+++ b/common/conf.py
@@ -170,7 +170,7 @@ extlinks = {
     'zerocdoc' : ('https://doc.zeroc.com/%s', ''),
     'djangodoc' : ('https://docs.djangoproject.com/en/1.8/%s', ''),
     'doi' : ('http://dx.doi.org/%s', ''),
-    'pypi': ('https://pypi.org/%s', ''),
+    'pypi': ('https://pypi.org/project/%s', ''),
     }
 
 rst_epilog = """

--- a/common/conf.py
+++ b/common/conf.py
@@ -170,7 +170,7 @@ extlinks = {
     'zerocdoc' : ('https://doc.zeroc.com/%s', ''),
     'djangodoc' : ('https://docs.djangoproject.com/en/1.8/%s', ''),
     'doi' : ('http://dx.doi.org/%s', ''),
-    'pypi': ('https://pypi.python.org/pypi/%s', ''),
+    'pypi': ('https://pypi.org/%s', ''),
     }
 
 rst_epilog = """

--- a/common/conf.py
+++ b/common/conf.py
@@ -189,7 +189,7 @@ rst_epilog = """
 .. _Python: https://www.python.org
 .. _Libjpeg: http://libjpeg.sourceforge.net/
 .. _Django: https://www.djangoproject.com/
-.. _PyPI: https://pypi.python.org/pypi
+.. _PyPI: https://pypi.org
 
 .. |SSH| replace:: :abbr:`SSH (Secure Shell)`
 .. |VM| replace:: :abbr:`VM (Virtual Machine)`

--- a/omero/developers/cli/extending.rst
+++ b/omero/developers/cli/extending.rst
@@ -14,7 +14,7 @@ Alternatively, plugins can be added to any directory ending with
 `omero-cli-render <https://github.com/ome/omero-cli-render/>`_.
 
 Team-supported |CLI| plugins will be pip-installable. Search for
-"`omero cli <https://pypi.python.org/pypi?%3Aaction=search&term=OMERO.CLI&submit=search>`_"
+"`omero cli <https://pypi.org/search/?q=omero+cli>`_"
 on PyPI_.
 
 Thread-safety


### PR DESCRIPTION
PyPI have migrated entirely to https://pypi.org - this updates the URLs in the docs
