### PR TITLE
contributing: Fix broken pypi packaging link

### DIFF
--- a/contributing/tools-maintenance.rst
+++ b/contributing/tools-maintenance.rst
@@ -41,5 +41,5 @@ Finally, the signed tag needs to be pushed to the source code repository::
 
 .. seealso::
 
-  https://packaging.python.org/distributing/#uploading-your-project-to-pypi
+  https://packaging.python.org/tutorials/packaging-projects/#uploading-the-distribution-archives
      Instructions about uploading a project to PyPi


### PR DESCRIPTION
This appears to be permanently moved; the original page is gone entirely.  The new link looks like an appropriate substitute.

Check build is green.