### PR TITLE
Fix script examples

### DIFF
--- a/omero/developers/scripts/matlab-scripts.rst
+++ b/omero/developers/scripts/matlab-scripts.rst
@@ -33,7 +33,6 @@ Calling a simple MATLAB function
     from mlabwrap import matlab;  
     client = script.client("rand.py", "Get matrix of random numbers drawn from a uniform distribution",  
                             script.Long("x").inout(), script.Long("y").inout())
-    client.createSession()
 
     x = client.getInput("x").val
     y  = client.getInput("y").val
@@ -59,7 +58,6 @@ object and accessing the same client instance as the script.
                             script.String("password"),
                             script.Long("pixelsId").inout(), script.String("method").inout()
                             script.Long("stack").inout())
-    client.createSession()
 
     iceConfig = client.getInput("pixelsId").val
     user = client.getInput("pixelsId").val

--- a/omero/developers/scripts/matlab-scripts.rst
+++ b/omero/developers/scripts/matlab-scripts.rst
@@ -28,11 +28,11 @@ Calling a simple MATLAB function
 
 ::
 
-    import omero, omero.scripts as script
+    import omero, omero.scripts as scripts
     # import mlabwrap to launch matlab.
     from mlabwrap import matlab;  
-    client = script.client("rand.py", "Get matrix of random numbers drawn from a uniform distribution",  
-                            script.Long("x").inout(), script.Long("y").inout())
+    client = scripts.client("rand.py", "Get matrix of random numbers drawn from a uniform distribution",
+                            scripts.Long("x").inout(), scripts.Long("y").inout())
 
     x = client.getInput("x").val
     y  = client.getInput("y").val
@@ -50,14 +50,14 @@ object and accessing the same client instance as the script.
 
 ::
 
-    import omero, omero.scripts as script
+    import omero, omero.scripts as scripts
     # import mlabwrap to launch matlab.
     from mlabwrap import matlab;  
-    client = script.client("projection.py", "Call the matlab projection code",  
-                            script.String("iceConfig").in(), script.String("user").in(),
-                            script.String("password"),
-                            script.Long("pixelsId").inout(), script.String("method").inout()
-                            script.Long("stack").inout())
+    client = scripts.client("projection.py", "Call the matlab projection code",
+                            scripts.String("iceConfig").in(), scripts.String("user").in(),
+                            scripts.String("password"),
+                            scripts.Long("pixelsId").inout(), scripts.String("method").inout()
+                            scripts.Long("stack").inout())
 
     iceConfig = client.getInput("pixelsId").val
     user = client.getInput("pixelsId").val

--- a/omero/developers/scripts/user-guide.rst
+++ b/omero/developers/scripts/user-guide.rst
@@ -10,7 +10,7 @@ form:
 ::
 
     # import the omero package and the omero.scripts package.
-    import omero, omero.scripts as script
+    import omero, omero.scripts as scripts
 
     '''
     This method creates the client script object, with name SCRIPTNAME and SCRIPTDESCRIPTION.
@@ -19,8 +19,8 @@ form:
     variable of in, out or inout depending on whether the variable if for input, output or input
     and output.
     '''
-    client = script.client("SCRIPTNAME", "SCRIPTDESCRIPTION",
-             script.TYPE("VARIABLENAME").[in()|out()|inout()], …)
+    client = scripts.client("SCRIPTNAME", "SCRIPTDESCRIPTION",
+             scripts.TYPE("VARIABLENAME").[in()|out()|inout()], …)
 
     # All variables are stored in a map accessed by getInput and setOutput via the client object.
     VARIABLENAME = client.getInput("VARIABLENAME");
@@ -49,9 +49,9 @@ This script echoes the input parameters as outputs.
 
 ::
 
-    import omero, omero.scripts as script
-    client = script.client("ping.py", "simple ping script",
-             script.Long("a"), script.String("b"))
+    import omero, omero.scripts as scripts
+    client = scripts.client("ping.py", "simple ping script",
+             scripts.Long("a"), scripts.String("b"))
 
     keys = client.getInputKeys()
     print "Keys found:"

--- a/omero/developers/scripts/user-guide.rst
+++ b/omero/developers/scripts/user-guide.rst
@@ -21,8 +21,6 @@ form:
     '''
     client = script.client("SCRIPTNAME", "SCRIPTDESCRIPTION",
              script.TYPE("VARIABLENAME").[in()|out()|inout()], …)
-    # create a session on the server.
-    client.createSession()
 
     # All variables are stored in a map accessed by getInput and setOutput via the client object.
     VARIABLENAME = client.getInput("VARIABLENAME");
@@ -54,7 +52,6 @@ This script echoes the input parameters as outputs.
     import omero, omero.scripts as script
     client = script.client("ping.py", "simple ping script",
              script.Long("a"), script.String("b"))
-    client.createSession()
 
     keys = client.getInputKeys()
     print "Keys found:"


### PR DESCRIPTION
The `client.createSession()` call is no longer needed an in fact raises an error.

Also renamed the import of `omero.scripts` in a few places to make it more consistent across the examples.