### PR TITLE
OmeroJava_link_to_examples

### DIFF
--- a/omero/developers/Java.rst
+++ b/omero/developers/Java.rst
@@ -60,6 +60,9 @@ to access Projects, Datasets, etc. see :ref:`gatewaybrowse`.
 As the plain Ice objects can be a bit 'bulky' to handle, they are usually wrapped
 into Java  :javadoc:`DataObjects <omero/gateway/model/DataObject.html>`.
 
+All the code examples below can be found at
+:sourcedir:`examples/Training/java/src/training`.
+
 .. _gatewayconnect:
 
 Connect to OMERO


### PR DESCRIPTION
This adds a link from the OMERO Java docs page to the Training/java source files used in the page.
This was painfully missing from the Cambridge training sessions and will be needed for TOPIM workshop soon.