### PR TITLE
Update BF release jobs

### DIFF
--- a/contributing/ci-bio-formats.rst
+++ b/contributing/ci-bio-formats.rst
@@ -26,20 +26,8 @@ All jobs are listed under the :jenkinsview:`Bio-Formats` view tab of Jenkins.
                 * | :term:`BIOFORMATS-DEV-merge-build`
                     :term:`BIOFORMATS-DEV-merge-build-win`
 
-        -       * Builds the merge Bio-Formats artifacts using Maven
-                * :term:`BIOFORMATS-DEV-merge-maven`
-
         -       * Runs the MATLAB tests
                 * :term:`BIOFORMATS-DEV-merge-matlab`
-
-        -       * Runs automated tests against the full repository on squig
-                * :term:`BIOFORMATS-DEV-merge-full-repository`
-
-        -       * Runs automated tests against a subset of the data repository on squig
-                * :term:`BIOFORMATS-DEV-merge-repository-subset`
-
-        -       * Runs performance tests
-                * :term:`BIOFORMATS-DEV-merge-performance`
 
 5.x.x series
 ^^^^^^^^^^^^
@@ -75,7 +63,7 @@ The branch for the 5.x series of Bio-Formats is develop.
                 representative subset of the data repository
 
                 #. Triggers :term:`BIOFORMATS-DEV-merge-push`
-                #. Triggers :term:`BIOFORMATS-DEV-merge-build` and :term:`BIOFORMATS-DEV-merge-maven`
+                #. Triggers :term:`BIOFORMATS-DEV-merge-build`
                 #. Triggers downstream merge projects
 
                 See :jenkinsjob:`the build graph <BIOFORMATS-DEV-merge-daily/lastSuccessfulBuild/BuildGraph>`
@@ -100,10 +88,6 @@ The branch for the 5.x series of Bio-Formats is develop.
                 This job builds the merge Bio-Formats artifacts using Ant
                 on Windows
 
-        :jenkinsjob:`BIOFORMATS-DEV-merge-maven`
-
-            This job builds the merge Bio-Formats artifacts using Maven
-
         :jenkinsjob:`BIOFORMATS-DEV-merge-matlab`
 
                 This job runs the MATLAB tests of Bio-Formats
@@ -112,14 +96,6 @@ The branch for the 5.x series of Bio-Formats is develop.
                    :term:`BIOFORMATS-DEV-merge-build`
                 #. Runs the MATLAB unit tests under
                    :file:`components/bio-formats/test/matlab` and collect the results
-
-        :jenkinsjob:`BIOFORMATS-DEV-merge-full-repository`
-
-                This job runs the automated tests against the curated data
-                repository on Linux
-
-                #. Checks out :bf_scc_branch:`develop/merge/daily`
-                #. Runs automated tests against :file:`/ome/data_repo/curated/`
 
         :jenkinsjob:`BIOFORMATS-DEV-merge-repository-subset`
 
@@ -131,11 +107,3 @@ The branch for the 5.x series of Bio-Formats is develop.
                    under :file:`/ome/data_repo/curated/`. The list of
                    directories to test by setting a space-separated list of
                    formats for the ``DEFAULT_FORMAT_LIST`` variable.
-
-        :jenkinsjob:`BIOFORMATS-DEV-merge-performance`
-
-                This job runs performance tests against directories on squig
-
-                #. Checks out the :bf_scc_branch:`develop/merge/daily`
-                #. Runs file-handles and openbytes-performance tests against
-                   files specified by :file:`performance_files.txt`

--- a/contributing/ci-release.rst
+++ b/contributing/ci-release.rst
@@ -24,14 +24,8 @@ view.
 
     -   * Job task
         * Bio-Formats   
-    -   * Trigger the Bio-Formats release jobs
-        * :jenkinsjob:`BIOFORMATS-DEV-release-trigger`
-    -   * Tags the Bio-Formats source code repository
-        * :jenkinsjob:`BIOFORMATS-DEV-release-push`
     -   * Build the Bio-Formats download artifacts
         * :jenkinsjob:`BIOFORMATS-DEV-release`
-    -   * Generate the Bio-Formats downloads page
-        * :jenkinsjob:`BIOFORMATS-DEV-release-downloads`
 
 
 Bio-Formats
@@ -39,40 +33,15 @@ Bio-Formats
 
 .. glossary::
 
-    :jenkinsjob:`BIOFORMATS-DEV-release-trigger`
-
-        This job triggers the Bio-Formats release jobs. Prior
-        to running it, its variables need to be properly configured:
-
-        - :envvar:`RELEASE` is the Bio-Formats release number.
-
-        #. Triggers :term:`BIOFORMATS-DEV-release-push`
-        #. Triggers :term:`BIOFORMATS-DEV-release`
-
-    :jenkinsjob:`BIOFORMATS-DEV-release-push`
-
-        This job creates a tag on the `develop` branch
-
-        #. Runs `scc tag-release $RELEASE` and pushes the tag to the
-           snoopycrimecop fork of bioformats.git_
-
     :jenkinsjob:`BIOFORMATS-DEV-release`
 
         This job builds the Java downloads artifacts of Bio-Formats
 
-        #. Checks out the :envvar:`RELEASE` tag of the
-           snoopycrimecop fork of bioformats.git_
+        #. Checks out the v:envvar:`RELEASE` tag of
+           https://github.com/openmicroscopy/bioformats
         #. |buildBF|
+        #. Downloads the documentation artifacts from OME artifactory
         #. |copyreleaseartifacts|
-        #. Triggers :term:`BIOFORMATS-DEV-release-downloads`
-
-    :jenkinsjob:`BIOFORMATS-DEV-release-downloads`
-
-        This job builds the Bio-Formats Java downloads page
-
-        #. Checks out the `develop` branch of
-           https://github.com/openmicroscopy/ome-release.git
-        #. Runs `make clean bf`
 
 OMERO
 ^^^^^


### PR DESCRIPTION
This PR propagates recent changes applied to the CI jobs to the contributing page and should turn https://ci.openmicroscopy.org/view/Failing/job/CONTRIBUTING-merge-docs/ green.

- following the bio-formats-documentation decoupling, the release jobs are simplified to one job which checks out the tag and the artifacts and builds the component
- many of the CI jobs have been migrated towards containerized Jenkins instances and disabled/shelved from https://ci.openmicroscopy.org/ and are removed from the list.

As an addition, we could potentially expose the current https://web-proxy.openmicroscopy.org/west-ci/ and https://web-proxy.openmicroscopy.org/east-ci/ URLs in these pages as most of the Bio-Formats development happens in these devspaces.