### PR TITLE
adjust Ice anchor to match upstream changes

### DIFF
--- a/omero/sysadmins/grid.rst
+++ b/omero/sysadmins/grid.rst
@@ -308,7 +308,7 @@ permissions verifier, so that anyone with a proper OMERO account can
 access the server.
 
 See :zerocdoc:`Controlling Access to IceGrid Sessions
-<ice/3.6/ice-services/icegrid/resource-allocation-using-icegrid-sessions#ResourceAllocationusingIceGridSessions-ControllingAccesstoIceGridSessions>`
+<ice/3.6/ice-services/icegrid/resource-allocation-using-icegrid-sessions#id-.ResourceAllocationusingIceGridSessionsv3.6-ControllingAccesstoIceGridSessions>`
 of the Ice manual for more information.
 
 Unique node names


### PR DESCRIPTION
ZeroC appear to have adjusted their site back from what commit 52ea7c04e4e78961f162d1d2eed9a51bcdef0199 fixed. Staged at https://ci.openmicroscopy.org/job/OMERO-DEV-merge-docs/ws/src/omero/_build/html/sysadmins/grid.html#permissions-verifier. https://ci.openmicroscopy.org/job/OMERO-DEV-merge-docs/ should be green.