### PR TITLE
LDAP ignore case thorough documentation

### DIFF
--- a/omero/sysadmins/server-ldap.rst
+++ b/omero/sysadmins/server-ldap.rst
@@ -216,10 +216,16 @@ using::
 
    bin/omero config set omero.security.ignore_case true
 
-.. warning:: Enabling this option will affect all usernames in your OMERO
-   system. It is the system administrator's responsibility to handle any
-   username clashes which may result. Making all usernames lowercase is
-   recommended.
+.. warning:: Enabling this option will affect **all**, even non-LDAP,
+   usernames in your OMERO system. It is the system administrator's
+   responsibility to handle any username clashes which may result.
+   Making non-LDAP usernames lowercase is required. Users with uppercase
+   characters in their username will not be able to log in and will
+   not appear in some administrative tools.
+
+   ``UPDATE experimenter SET omename = lowercase(omename);`` can be used on
+   your database to make this change to all users if desired. This operation
+   is irreversible.
 
 LDAP over |SSL|
 ---------------

--- a/omero/sysadmins/server-ldap.rst
+++ b/omero/sysadmins/server-ldap.rst
@@ -219,9 +219,9 @@ using::
 .. warning:: Enabling this option will affect **all**, even non-LDAP,
    usernames in your OMERO system. It is the system administrator's
    responsibility to handle any username clashes which may result.
-   Making non-LDAP usernames lowercase is required. Users with uppercase
-   characters in their username will not be able to log in and will
-   not appear in some administrative tools.
+   Making non-LDAP usernames lowercase is required. Non-LDAP users with
+   uppercase characters in their username will not be able to log in and
+   will not appear in some administrative tools.
 
    ``UPDATE experimenter SET omename = lowercase(omename);`` can be used on
    your database to make this change to all users if desired. This operation

--- a/omero/sysadmins/server-ldap.rst
+++ b/omero/sysadmins/server-ldap.rst
@@ -223,7 +223,7 @@ using::
    uppercase characters in their username will not be able to log in and
    will not appear in some administrative tools.
 
-   ``UPDATE experimenter SET omename = lowercase(omename);`` can be used on
+   ``UPDATE experimenter SET omename = lower(omename);`` can be used on
    your database to make this change to all users if desired. This operation
    is irreversible.
 


### PR DESCRIPTION
The impact of `omero.security.ignore_case` on non-LDAP users is currently downplayed.

This makes the documentation of a change of this property more thorough and gives an example how to make all usernames to lower case.