### PR TITLE
Remove dojofoundation links

### DIFF
--- a/contributing/code-contributions.rst
+++ b/contributing/code-contributions.rst
@@ -99,8 +99,6 @@ There are any number of other projects which have set up similar
 practices for code contributions. If you would like to read more on
 the rationale, please see:
 
-* http://dojofoundation.org/about/get-involved
-* http://dojofoundation.org/about/cla
 * http://incubator.apache.org/
 * http://www.apache.org/foundation/how-it-works.html
 


### PR DESCRIPTION
The below 2 links from https://docs.openmicroscopy.org/contributing/code-contributions.html no longer exist:
http://dojofoundation.org/about/get-involved	
http://dojofoundation.org/about/cla

The closest matches I could find to a replacement are the below options but neither seemed like an exact match for code contribution guidelines:
https://github.com/JSFoundation/TAC/blob/master/Project-Lifecycle.md
https://js.foundation/community/code-of-conduct