### PR TITLE
update import template path docs for current behavior of special terms

### DIFF
--- a/omero/sysadmins/fs-upload-configuration.rst
+++ b/omero/sysadmins/fs-upload-configuration.rst
@@ -191,8 +191,8 @@ path.
 No more than one of :literal:`%time%`, :literal:`%subdirs%` or
 :literal:`%increment%` may be used in any one path component, although
 they may each be used many times in the whole path. If
-:literal:`%subdirs%` expands to nothing then its path component is
-wholly omitted.
+:literal:`%subdirs%` expands to nothing then its entire path component
+is omitted: no other expansion terms in that component are used.
 
 Legal file names
 ----------------

--- a/omero/sysadmins/fs-upload-configuration.rst
+++ b/omero/sysadmins/fs-upload-configuration.rst
@@ -135,6 +135,9 @@ For any directory in the template path
   expands to the session key (UUID) of the session, for example
   :literal:`6c2dae43-cfad-48ce-af6f-025569f9e6df`
 
+:literal:`%thread%`
+  expands to the name of the server thread that is performing the import
+
 For user-owned directories only
 """""""""""""""""""""""""""""""
 

--- a/omero/sysadmins/fs-upload-configuration.rst
+++ b/omero/sysadmins/fs-upload-configuration.rst
@@ -185,7 +185,7 @@ path.
   :literal:`example/1234-below` and, much later,
   :literal:`example/1234-below/5678`
 
-No more than one of either :literal:`%subdirs%` or
+No more than one of :literal:`%time%`, :literal:`%subdirs%` or
 :literal:`%increment%` may be used in any one path component, although
 they may each be used many times in the whole path.
 

--- a/omero/sysadmins/fs-upload-configuration.rst
+++ b/omero/sysadmins/fs-upload-configuration.rst
@@ -190,7 +190,9 @@ path.
 
 No more than one of :literal:`%time%`, :literal:`%subdirs%` or
 :literal:`%increment%` may be used in any one path component, although
-they may each be used many times in the whole path.
+they may each be used many times in the whole path. If
+:literal:`%subdirs%` expands to nothing then its path component is
+wholly omitted.
 
 Legal file names
 ----------------


### PR DESCRIPTION
Updates import prefix template path documentation to reflect https://github.com/openmicroscopy/openmicroscopy/pull/2773, https://github.com/openmicroscopy/openmicroscopy/pull/5833 and https://github.com/openmicroscopy/openmicroscopy/pull/5835#issuecomment-416536414. Staged at https://ci.openmicroscopy.org/job/OMERO-DEV-merge-docs/ws/src/omero/_build/html/sysadmins/fs-upload-configuration.html#template-path. Motivation for `%thread%` will be documented once https://github.com/openmicroscopy/openmicroscopy/pull/5828 is approved.