### PR TITLE
Update auto-generated documentation

### DIFF
--- a/omero/conf_autogen.py
+++ b/omero/conf_autogen.py
@@ -1,5 +1,5 @@
 omero_db_version = "OMERO5.4"
 omero_db_patch = "0"
-versions_bioformats = "5.8.2"
+versions_bioformats = "5.9.2"
 current_dbver = "OMERO5.4__0"
 previous_dbver = "OMERO5.3__1"

--- a/omero/downloads/inplace/advanced-help.txt
+++ b/omero/downloads/inplace/advanced-help.txt
@@ -21,7 +21,7 @@ ADVANCED OPTIONS:
           cp_rm           	# Caution! Copy followed by source deletion.
 
 
-  e.g. $ bin/omero import -- --transfer=ln_s foo.tiff
+  e.g. $ bin/omero import --transfer=ln_s foo.tiff
        $ ./importer-cli --transfer=ln bar.tiff
        $ CLASSPATH=mycode.jar ./importer-cli --transfer=com.example.MyTransfer baz.tiff
 
@@ -52,8 +52,8 @@ ADVANCED OPTIONS:
     --exclude=clientpath    	Exclude files based on the original path.
 
 
-  e.g. $ bin/omero import -- --exclude=filename foo.tiff # First-time imports
-       $ bin/omero import -- --exclude=filename foo.tiff # Second-time skips
+  e.g. $ bin/omero import --exclude=filename foo.tiff # First-time imports
+       $ bin/omero import --exclude=filename foo.tiff # Second-time skips
 
   Import speed:
   -------------
@@ -63,7 +63,7 @@ ADVANCED OPTIONS:
                             	     MD5-128, Murmur3-32, Murmur3-128,
                             	     SHA1-160 (slow, default)
 
-  e.g. $ bin/omero import -- --checksum-algorithm=CRC-32 foo.tiff
+  e.g. $ bin/omero import --checksum-algorithm=CRC-32 foo.tiff
        $ ./importer-cli --checksum-algorithm=Murmur3-128 bar.tiff
 
     --no-stats-info		Disable calculation of minima and maxima when as part of the Bio-Formats reader metadata
@@ -85,7 +85,7 @@ ADVANCED OPTIONS:
   ---------
 
     --qa-baseurl=ARG	Specify the base URL for reporting feedback
-  e.g. $ bin/omero import broken_image.tif -- --email EMAIL --report --upload --logs --qa-baseurl=https://qa.staging.openmicroscopy.org/qa
-       $ ./importer-cli broken_image.tif --email EMAIL --report --upload --logs --qa-baseurl=https://qa.staging.openmicroscopy.org/qa
+  e.g. $ bin/omero import broken_image.tif -- --email EMAIL --report --upload --logs --qa-baseurl=http://qa.example.com
+       $ ./importer-cli broken_image.tif --email EMAIL --report --upload --logs --qa-baseurl=http://qa.openmicroscopy.org.uk/qa
 
 Report bugs to <ome-users@lists.openmicroscopy.org.uk>

--- a/omero/sysadmins/config.rst
+++ b/omero/sysadmins/config.rst
@@ -136,6 +136,7 @@ Allowable elements are:
    %session%      c3fdd5d8-831a-40ff-80f2-0ba5baef448a
    %sessionId%    592
    %perms%        rw----
+   %thread%       Blitz-0-Ice.ThreadPool.Server-3
    /              path separator
    //             end of root-owned directories
 
@@ -422,9 +423,19 @@ Default: `0`
 omero.db.poolsize
 ^^^^^^^^^^^^^^^^^
 Sets the number of database server connections which
-will be used by OMERO. Your database installation
-will need to be configured to accept *at least* as
-many, preferably more, connections as this value.
+will be used by OMERO.
+
+A sizeable increase in this value, e.g. to 100, will
+significantly increase the performance of your server,
+but your database installation will need to be configured
+to accept *at least* as many, preferably more, connections
+as this value.
+
+The related values omero.threads.max_threads and
+omero.threads.background_threads do *not* need to be
+increased by the same amount. A system will be more stable
+if background_threads is less than max_threads and
+max_threads is less than poolsize.
 
 Default: `10`
 
@@ -1040,6 +1051,26 @@ a login is required.
 
 Default: `600000`
 
+.. property:: omero.threads.background_threads
+
+omero.threads.background_threads
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Number of threads from the max_threads pool that can
+be used at any given time for background tasks like
+import.
+
+Default: `10`
+
+.. property:: omero.threads.background_timeout
+
+omero.threads.background_timeout
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Number of milliseconds to wait for a slot in the
+background queue before a rejection error will be
+raised.
+
+Default: `3600000`
+
 .. property:: omero.threads.cancel_timeout
 
 omero.threads.cancel_timeout
@@ -1058,6 +1089,9 @@ Default: `5000`
 
 omero.threads.max_threads
 ^^^^^^^^^^^^^^^^^^^^^^^^^
+Maximum number of threads that can simultaneously
+run at the "USER" priority level. Internal system
+threads may still run.
 
 Default: `50`
 
@@ -1065,6 +1099,8 @@ Default: `50`
 
 omero.threads.min_threads
 ^^^^^^^^^^^^^^^^^^^^^^^^^
+Number of threads that will be kept waiting
+at all times.
 
 Default: `5`
 
@@ -1924,7 +1960,7 @@ Default: `{}`
 
 omero.web.debug
 ^^^^^^^^^^^^^^^
-A boolean that turns on/off debug mode.
+A boolean that turns on/off debug mode. Use debug mode only in development, not in production, as it logs sensitive and confidential information in plaintext.
 
 Default: `false`
 
@@ -2176,6 +2212,22 @@ A boolean that determines whether to expire the session when the user closes the
 
 Default: `true`
 
+.. property:: omero.web.sharing.opengraph
+
+omero.web.sharing.opengraph
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Dictionary of `server-name: site-name`, where server-name matches a name from `omero.web.server_list`. For example: ``'{"omero": "Open Microscopy"}'``
+
+Default: `{}`
+
+.. property:: omero.web.sharing.twitter
+
+omero.web.sharing.twitter
+^^^^^^^^^^^^^^^^^^^^^^^^^
+Dictionary of `server-name: @twitter-site-username`, where server-name matches a name from `omero.web.server_list`. For example: ``'{"omero": "@openmicroscopy"}'``
+
+Default: `{}`
+
 .. property:: omero.web.static_root
 
 omero.web.static_root
@@ -2246,7 +2298,7 @@ omero.web.ui.top_links
 ^^^^^^^^^^^^^^^^^^^^^^
 Add links to the top header: links are ``['Link Text', 'link|lookup_view', options]``, where the url is reverse('link'), simply 'link' (for external urls) or lookup_view is a detailed dictionary {"viewname": "str", "args": [], "query_string": {"param": "value" }], E.g. ``'["Webtest", "webtest_index"] or ["Homepage", "http://...", {"title": "Homepage", "target": "new"} ] or ["Repository", {"viewname": "webindex", "query_string": {"experimenter": -1}}, {"title": "Repo"}]'``
 
-Default: `[["Data", "webindex", {"title": "Browse Data via Projects, Tags etc"}],["History", "history", {"title": "History"}],["Help", "http://help.openmicroscopy.org/",{"title":"Open OMERO user guide in a new tab", "target":"new"}]]`
+Default: `[["Data", "webindex", {"title": "Browse Data via Projects, Tags etc"}],["History", "history", {"title": "History"}],["Help", "https://help.openmicroscopy.org/",{"title":"Open OMERO user guide in a new tab", "target":"new"}]]`
 
 .. property:: omero.web.use_x_forwarded_host
 

--- a/omero/sysadmins/unix/walkthrough/walkthrough_centos6_py27_ius.sh
+++ b/omero/sysadmins/unix/walkthrough/walkthrough_centos6_py27_ius.sh
@@ -28,7 +28,7 @@ yum -y install libjpeg-devel zlib-devel
 # install pip and virtualenv using Python 2.6 
 yum -y install python-pip
 
-pip install --upgrade virtualenv
+pip install --upgrade virtualenv==14.0.6
 
 #if virtualenv is not installed (unlikely)
 #yum -y install python27-pip

--- a/omero/sysadmins/unix/walkthrough/walkthrough_centos7.sh
+++ b/omero/sysadmins/unix/walkthrough/walkthrough_centos7.sh
@@ -16,7 +16,7 @@ yum -y install java-1.8.0-openjdk
 # install dependencies
 
 yum -y install python-{pip,devel,virtualenv,yaml,jinja2,tables}
-pip install --upgrade pip
+
 
 #start-web-dependencies
 yum -y install python-pillow numpy

--- a/omero/sysadmins/unix/walkthrough/walkthrough_debian9.sh
+++ b/omero/sysadmins/unix/walkthrough/walkthrough_debian9.sh
@@ -23,11 +23,10 @@ apt-get -y install python-{pip,virtualenv,yaml,jinja2}
 # to be installed if recommended/suggested is false
 apt-get -y install python-setuptools python-wheel virtualenv
 
-pip install --upgrade pip
 
 # python-tables will install tables version 3.3
 # but it does not work. install pytables from pypi.
-pip install tables
+pip install tables==3.4.4
 
 #start-web-dependencies
 apt-get -y install zlib1g-dev libjpeg-dev

--- a/omero/sysadmins/unix/walkthrough/walkthrough_ubuntu1404.sh
+++ b/omero/sysadmins/unix/walkthrough/walkthrough_ubuntu1404.sh
@@ -24,7 +24,6 @@ apt-get -y install openjdk-8-jre
 apt-get update
 apt-get -y install python-{pip,tables,virtualenv,yaml,jinja2}
 
-pip install --upgrade pip
 
 #start-web-dependencies
 apt-get -y install zlib1g-dev

--- a/omero/sysadmins/unix/walkthrough/walkthrough_ubuntu1604.sh
+++ b/omero/sysadmins/unix/walkthrough/walkthrough_ubuntu1604.sh
@@ -30,8 +30,6 @@ apt-get -y install \
 # to be installed if recommended/suggested is false
 apt-get -y install python-setuptools python-wheel virtualenv
 
-pip install --upgrade pip
-
 #start-web-dependencies
 apt-get -y install zlib1g-dev
 apt-get -y install python-{pillow,numpy}

--- a/omero/users/history.rst
+++ b/omero/users/history.rst
@@ -5,6 +5,51 @@
 OMERO version history
 =====================
 
+5.4.8-rc1 (August 2018)
+-----------------------
+
+This release focuses on a number of import performance
+improvements while including several other fixes as
+well as an upgrade of Bio-Formats.
+
+Import improvements include:
+
+- cli: new experimental `--parallel-upload` and
+  `--parallel-fileset` flags to the `import` command
+- cli: new `fs importtime` cli command
+- insight: new options for skipping various import steps
+  to speed up the process (match cli's `--skip` option)
+- insight: supporting imports with thousands of files
+  by providing a lightweight UI
+- insight: new loading placeholder when browsing data to
+  to show when an image is busy being processed and not
+  ready to generate a thumbnail
+- insight: added error placeholder when browsing data to
+  indicate a failed import
+- server: preventing recalculation of checksums for upload
+- server: providing better performance logging,
+  accessible to users via `fs logfile`
+- as well as preservation of Bio-Formats' knowledge of
+  channel colors where provided.
+
+Other client changes include:
+
+- web: better handling of large numbers of channels
+- web: fixed socket leakage on unclosed web sessions
+- web: fixed issue with bulk annotation table handling
+- cli: deprecating `admin sessionlist` and `config list`
+
+Sysadmin improvements include:
+
+- new `%thread%` option for omero.fs.repo.path
+  as well as fix a few bugs for dealing with
+  parallel imports
+- new omero.threads.background_threads property
+  to limit the number of simultaneous imports
+
+This release also upgrades the version of Bio-Formats which OMERO
+uses to 5.9.2.
+
 5.4.7 (July 2018)
 -----------------
 
@@ -76,6 +121,7 @@ Further improvements include:
 -  enabled big image support in ImageJ/Fiji
 -  reduced the number of threads used by OMERO.web
 -  fixed other bugs in OMERO.web including:
+
    - broken History tab
    - handling of script params
    - pagination calculations


### PR DESCRIPTION
Repository: openmicroscopy/ome-documentation
Already up-to-date.



Generated by build [OMERO-DEV-latest-docs-autogen#1322](https://ci.openmicroscopy.org/job/OMERO-DEV-latest-docs-autogen/1322/).

----
--no-rebase