### PR TITLE
web apps install

### DIFF
--- a/omero/sysadmins/unix/install-web/walkthrough/omeroweb-install-centos7-ice3.6.rst
+++ b/omero/sysadmins/unix/install-web/walkthrough/omeroweb-install-centos7-ice3.6.rst
@@ -95,7 +95,13 @@ Install the OMERO.web requirements. Select one of the commands corresponding to 
     # option 2: in a virtual environment with --system-site-packages off
     /home/omero/omerowebvenv/bin/pip install --upgrade -r /home/omero/OMERO.py/share/web/requirements-py27-all.txt
     
-    
+
+Installing OMERO.web apps
+-------------------------
+
+A number of apps are available to add functionality to OMERO.web, such as OMERO.figure and OMERO.iviewer.
+See the main website for a `list of released apps <https://www.openmicroscopy.org/omero/apps/>`_.
+These apps are optional and can be installed via pip to your OMERO.web virtual environment at any time.
 
 Configuring OMERO.web
 ---------------------


### PR DESCRIPTION
See https://github.com/openmicroscopy/www.openmicroscopy.org/pull/249 points raised by @joshmoore and discussion with @rgozim about poor visibility of OMERO.web app installs on our docs pages.

This adds a section to the OMERO.web install pages (just did one for now - will duplicate to the others once this one is good) to link to the new www.openmicroscopy.org/omero/apps page and make sure sysadmins know about existence of web apps.