### PR TITLE
where to get client JAR for CLASSPATH

### DIFF
--- a/omero/developers/Java.rst
+++ b/omero/developers/Java.rst
@@ -33,11 +33,13 @@ The required :file:`.jar` files can be obtained in a number of ways:
 Extended classpath
 ------------------
 
-To access all the functionality available in omero\_client.jar or to use the
-importer, you will need more jar files. To see all the current requirements,
-take a look at the builds on :jenkins:`jenkins <>`, or alternatively examine
-the dependencies in the ivy.xml files (e.g.
-:source:`components/insight/ivy.xml`)
+To access all the functionality available in :file:`omero_client.jar` or
+to use the importer, you will need more jar files. To see all the
+current requirements, take a look at the builds on :jenkins:`Jenkins
+<>`, or alternatively examine the dependencies in the :file:`ivy.xml`
+files (e.g. :source:`components/insight/ivy.xml`). The
+:file:`omero_client.jar` file can be found within the OMERO.matlab
+toolbox available from the :downloads:`download page <>`.
 
 .. _javagateway:
 


### PR DESCRIPTION
Until we fix https://trello.com/c/RbxNUNHD/17-omeroclientsjar we should warn people how to find `omero_client.jar` as it was far from clear to me. Staged at https://ci.openmicroscopy.org/job/OMERO-DEV-merge-docs/ws/src/omero/_build/html/developers/Java.html#extended-classpath.