### PR TITLE
mention Hibernate training

### DIFF
--- a/common/conf.py
+++ b/common/conf.py
@@ -157,6 +157,7 @@ extlinks = {
     'bf' : (oo_root + '/bio-formats/%s', ''),
     'secvuln' : (oo_root + '/security/advisories/%s', ''),
     'security' : (oo_root + '/security/%s', ''),
+    'presentations' : (downloads_root + '/presentations/%s', ''),
     # Doc links
     'model_doc' : (docs_root + '/latest/ome-model/%s', ''),
     'devs_doc' : (docs_root + '/contributing/%s', ''),

--- a/omero/developers/Server/Queries.rst
+++ b/omero/developers/Server/Queries.rst
@@ -80,7 +80,7 @@ has one named parameter "name", which can be specified by the call:
 
 ::
 
-            parameters.addString("name","<myNamHere>");
+            parameters.addString("name","<myNameHere>");
 
 Positional parameters of the form
 

--- a/omero/developers/Server/Queries.rst
+++ b/omero/developers/Server/Queries.rst
@@ -7,6 +7,9 @@ Using server queries internally
     contain information for how to perform API queries. If that is the kind of
     information you are looking for, you may find
     :doc:`/developers/Modules/Api` more useful as a starting point.
+    OME's :presentations:`Hibernate 3.5 Training
+    <2017/Team-Training/Hibernate/>` additionally provides information
+    on both API queries and server internals.
 
 .. figure:: /images/omero-queries-queryfactory-collaboration.png
   :align: center


### PR DESCRIPTION
Given the work that went into creating our Hibernate training it seems sensible to mention it on the most in-depth server-side queries page that we have among our developer documentation. Staged at https://ci.openmicroscopy.org/job/OMERO-DEV-merge-docs/ws/src/omero/_build/html/developers/Server/Queries.html.