### PR TITLE
HDF5: Fix broken link

### DIFF
--- a/omero/sysadmins/server-tables.rst
+++ b/omero/sysadmins/server-tables.rst
@@ -11,7 +11,7 @@ Requirements
 
 If you would like to help test the Tables API, you will need the following installed:
 
--  `HDF5 <https://www.hdfgroup.org/HDF5/release/obtain5.html>`_
+-  `HDF5 <https://www.hdfgroup.org/downloads/hdf5/>`_
 -  `NumPy <http://numpy.sourceforge.net/numdoc/HTML/numdoc.htm>`_ points to downloads at
    http://sourceforge.net/projects/numpy/
 -  `PyTables <http://pytables.github.com/downloads.html>`_ (Some packages include HDF5)


### PR DESCRIPTION
This PR is to correct a link to obtain HDF5 which is now broken: https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-merge-docs/

The suggested replacements were:
https://support.hdfgroup.org/downloads/index.html (deprecated)
https://portal.hdfgroup.org/display/support …
https://portal.hdfgroup.org/display/support/Downloads
https://www.hdfgroup.org/downloads/hdf5/ (looks good, but “login to download”)

In this PR I have opted for the last of those options.