### PR TITLE
Remove reference to OMERO Homebrew job

### DIFF
--- a/contributing/ci-omero.rst
+++ b/contributing/ci-omero.rst
@@ -249,11 +249,3 @@ under the :jenkinsview:`DEV` view tab of Jenkins.
         #. Checks out :omero_scc_branch:`develop/merge/daily` 
         #. Builds OMERO.server and starts it
         #. Runs the robot framework tests and collect the results
-
-    :jenkinsjob:`OMERO-DEV-merge-homebrew`
-
-        This job tests the installation of OMERO using Homebrew
-
-        #. Cleans :file:`/usr/local`
-        #. Installs Homebrew from https://github.com/ome/omero-install
-        #. Installs OMERO via :file:`osx/install_homebrew.sh`


### PR DESCRIPTION
The Homebrew formulas have been unmaintained are removed from the OME tap for a year and the CI job is now shelved.

See https://github.com/ome/homebrew-alt/pull/144 for the official deprecation of the HOmebrew support.