### PR TITLE
Contributing: add Ansible page

### DIFF
--- a/contributing/ansible-development.rst
+++ b/contributing/ansible-development.rst
@@ -15,13 +15,9 @@ Source code
 The source code of an Ansible role should be maintained under version control
 using Git_ and hosted on GitHub_ under the
 `openmicroscopy <http://github.com/openmicroscopy/>`__ organization.
-The Git repositories should be named as `ansible-role-<ROLENAME>`. Note that
-for role name composed of multiple words, setting the `role_name` in
-:file:`meta/main.yml` will update hyphens as underscores during import into
-Galaxy.
+The Git repositories should be named as `ansible-role-<ROLENAME>`.
 
-Each directory
-layout should minimally follow the standard
+Each directory layout should minimally follow the standard
 `Ansible role layout <https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html#role-directory-structure>`_ including other files and folders for testing and
 deployment. A typical role structure is shown below::
 
@@ -82,6 +78,11 @@ All core OME Ansible roles should be deployed to
 `openmicroscopy <https://galaxy.ansible.com/openmicroscopy/>`__ organization.
 All roles must support RHEL/CentOS 7 as a primary platform. New roles should
 also include Ubuntu 18.04 as a supported platform whenever possible.
+
+The Galaxy role name should be `openmicroscopy.<ROLENAME>`. For overriding the
+default name derived from the GitHub repository name, the `role_name` variable
+should be set in :file:`meta/main.yml`. For role names composed of multiple
+words, note that the Galaxy import process will convert hyphens as underscores.
 
 Ansible playbooks can consume these roles using a :file:`requirements.yml`
 file - see

--- a/contributing/ansible-development.rst
+++ b/contributing/ansible-development.rst
@@ -82,7 +82,7 @@ also include Ubuntu 18.04 as a supported platform whenever possible.
 The Galaxy role name should be `openmicroscopy.<ROLENAME>`. For overriding the
 default name derived from the GitHub repository name, the `role_name` variable
 should be set in :file:`meta/main.yml`. For role names composed of multiple
-words, note that the Galaxy import process will convert hyphens as underscores.
+words, note that the Galaxy import process will convert hyphens to underscores.
 
 Ansible playbooks can consume these roles using a :file:`requirements.yml`
 file - see

--- a/contributing/ansible-development.rst
+++ b/contributing/ansible-development.rst
@@ -13,9 +13,9 @@ Source code
 -----------
 
 The source code of a Java library should be maintained under version control
-using Git_ and hosted on GitHub_. Each directory layout should follow the 
-standard
-`Ansible role layout <https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html#role-directory-structure>`_::
+using Git_ and hosted on GitHub_. Each directory layout should minimally follow the  standard
+`Ansible role layout <https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html#role-directory-structure>`_ including other files and folders for testing and
+deployment. A typical role structure is shown below::
 
     defaults/           # Default variables
     handlers/           # Handlers
@@ -33,19 +33,20 @@ Versioning
 
 .. _PEP440: https://www.python.org/dev/peps/pep-0440/#semantic-versioning
 
-Ansible roles must follow PEP440_ rules for versioning. Additionally final
-releases must be compliant with `Semantic Versioning`_ i.e. the version must
-be expressed as `MAJOR.MINOR.PATCH` and:
+Ansible roles must follow the PEP440_ scheme for versioning. Final releases
+must also be compliant with `Semantic Versioning`_ i.e. a final version must
+be expressed as `MAJOR.MINOR.PATCH` where:
 
-- the MAJOR version must be incremented when you make incompatible API changes,
-- the MINOR version must be incremented when you add functionality in a
+- the MAJOR version must be incremented when incompatible API changes are made,
+- the MINOR version must be incremented when functionality is added in a
   backwards-compatible manner, and
-- the PATCH version must be incremented when you make backwards-compatible bug
-  fixes.
+- the PATCH version must be incremented when you backwards-compatible bug
+  fixes are made.
 
-Release tags must be expressed as `MAJOR.MINOR.PATCH` with no prefix.
+Final releases must be tagged with a tag matching the version i.e. 
+`MAJOR.MINOR.PATCH` with no prefix for integration with Galaxy.
 
-Development releases or pre-releases must follow the PEP440_ standard e.g.
+Development releases or pre-releases must follow the PEP440_ scheme e.g.
 `MAJOR.MINOR.PATCH.dev1`, `MAJOR.MINOR.PATCHa1` `MAJOR.MINOR.PATHrc1`.
 
 Testing and Continuous Integration
@@ -54,19 +55,19 @@ Testing and Continuous Integration
 .. _Molecule: https://molecule.readthedocs.io/
 
 For each Ansible role, a :file:`molecule` folder should be configured allowing
-the testing of the role using  Molecule_. One or multiple scenarios should be
+the testing to be tested using  Molecule_. One or multiple scenarios should be
 configured using at least a Docker driver if possible.
 
 Continuous Integration of Ansible roles is performed using Travis CI.
 
 .. note::
-   OME Ansible roles are getting progressively upgraded to Molecule 2.x. New
-   roles should be configured using Molecule 2.x.
+   OME Ansible roles are getting progressively upgraded from Molecule 1.x to 
+   Molecule 2.x. New roles should be configured using Molecule 2.x.
 
 Distribution
 ------------
 
-All OME Ansible roles should be deployed to
+All core OME Ansible roles should be deployed to
 `Ansible Galaxy <https://galaxy.ansible.com>`_ under the
 `openmicroscopy <https://galaxy.ansible.com/openmicroscopy/>`_  organization.
 

--- a/contributing/ansible-development.rst
+++ b/contributing/ansible-development.rst
@@ -77,13 +77,11 @@ https://github.com/openmicroscopy/prod-playbooks/blob/master/requirements.yml
 and https://github.com/IDR/deployment/blob/master/ansible/requirements.yml
 for examples of such files.
 
-Release process
----------------
+The release of an Ansible role and its deployment to Galaxy release happens
+by using the
+`Travis integration <https://docs.ansible.com/ansible/latest/reference_appendices/galaxy.html#travis-integrations>`_ on release tag.
 
-Deployment of a role release happens using the
-`Travis integration <https://docs.ansible.com/ansible/latest/reference_appendices/galaxy.html#travis-integrations>`_.
-
-A PGP-signed tag should be created for the released version e.g.
+A PGP-signed tag of form `x.y.z` should be created for the released version
 using :command:`scc tag-release` or :command:`git tag -s` and pushed to the
 upstream repository::
 

--- a/contributing/ansible-development.rst
+++ b/contributing/ansible-development.rst
@@ -22,7 +22,7 @@ deployment. A typical role structure is shown below::
 
     defaults/           # Default variables
     handlers/           # Handlers
-    meta/               # Role metadaa
+    meta/               # Role metadata
         main.yml        # Dependencies and Galaxy metadata
     molecule/           # Test
     tasks/              # Main list of tasks to be executed
@@ -43,14 +43,14 @@ be expressed as `MAJOR.MINOR.PATCH` where:
 - the MAJOR version must be incremented when incompatible API changes are made,
 - the MINOR version must be incremented when functionality is added in a
   backwards-compatible manner, and
-- the PATCH version must be incremented when you backwards-compatible bug
+- the PATCH version must be incremented when backwards-compatible bug
   fixes are made.
 
 Final releases must be tagged with a tag matching the version i.e. 
-`MAJOR.MINOR.PATCH` with no prefix for integration with Galaxy.
+`MAJOR.MINOR.PATCH` with no prefix.
 
 Development releases or pre-releases must follow the PEP440_ scheme e.g.
-`MAJOR.MINOR.PATCH.dev1`, `MAJOR.MINOR.PATCHa1` `MAJOR.MINOR.PATHrc1`.
+`MAJOR.MINOR.PATCH.dev1`, `MAJOR.MINOR.PATCHa1` `MAJOR.MINOR.PATCHrc1`.
 
 Testing and Continuous Integration
 ----------------------------------
@@ -58,7 +58,7 @@ Testing and Continuous Integration
 .. _Molecule: https://molecule.readthedocs.io/
 
 For each Ansible role, a :file:`molecule` folder should be configured allowing
-the testing to be tested using  Molecule_. One or multiple scenarios should be
+the testing to be tested using  Molecule_. One or more scenarios should be
 configured using at least a Docker driver if possible. A generic
 :file:`molecule` folder can be initialized using the following command::
 

--- a/contributing/ansible-development.rst
+++ b/contributing/ansible-development.rst
@@ -77,8 +77,8 @@ Distribution and support
 All core OME Ansible roles should be deployed to
 `Ansible Galaxy <https://galaxy.ansible.com>`_ under the
 `openmicroscopy <https://galaxy.ansible.com/openmicroscopy/>`__ organization.
-All roles must support EL 7 as a primary platform. New roles should also
-include Ubuntu as a supported platform whenever possible.
+All roles must support RHEL/CentOS 7 as a primary platform. New roles should
+also include Ubuntu as a supported platform whenever possible.
 
 Ansible playbooks can consume these roles using a :file:`requirements.yml`
 file - see
@@ -87,8 +87,9 @@ and https://github.com/IDR/deployment/blob/master/ansible/requirements.yml
 for examples of such files.
 
 The release of an Ansible role and its deployment to Galaxy release happens
-by using the
-`Travis integration <https://docs.ansible.com/ansible/latest/reference_appendices/galaxy.html#travis-integrations>`_ on release tag.
+by triggering a role import in Galaxy using the
+`Travis integration <https://docs.ansible.com/ansible/latest/reference_appendices/galaxy.html#travis-integrations>`_
+on each release tag.
 
 A PGP-signed tag of form `x.y.z` should be created for the released version
 using :command:`scc tag-release` or :command:`git tag -s` and pushed to the

--- a/contributing/ansible-development.rst
+++ b/contributing/ansible-development.rst
@@ -12,10 +12,15 @@ OME roles registered in https://github.com/ome/ansible-roles.
 Source code
 -----------
 
-The source code of a Java library should be maintained under version control
+The source code of an Ansible role should be maintained under version control
 using Git_ and hosted on GitHub_ under the
 `openmicroscopy <http://github.com/openmicroscopy/>`__ organization.
-Git repositories should be named as `ansible-role-<ROLE_NAME>`. Each directory
+The Git repositories should be named as `ansible-role-<ROLENAME>`. Note that
+for role name composed of multiple words, setting the `role_name` in
+:file:`meta/main.yml` will update hyphens as underscores during import into
+Galaxy.
+
+Each directory
 layout should minimally follow the standard
 `Ansible role layout <https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html#role-directory-structure>`_ including other files and folders for testing and
 deployment. A typical role structure is shown below::
@@ -49,9 +54,6 @@ be expressed as `MAJOR.MINOR.PATCH` where:
 Final releases must be tagged with a tag matching the version i.e. 
 `MAJOR.MINOR.PATCH` with no prefix.
 
-Development releases or pre-releases must follow the PEP440_ scheme e.g.
-`MAJOR.MINOR.PATCH.dev1`, `MAJOR.MINOR.PATCHa1` `MAJOR.MINOR.PATCHrc1`.
-
 Testing and Continuous Integration
 ----------------------------------
 
@@ -68,8 +70,9 @@ configured using at least a Docker driver if possible. A generic
 Continuous Integration of Ansible roles is performed using Travis CI.
 
 .. note::
+
    OME Ansible roles are getting progressively upgraded from Molecule 1.x to 
-   Molecule 2.x. New roles should be configured using Molecule 2.x.
+   Molecule 2.x. New roles must be configured using Molecule 2.x.
 
 Distribution and support
 ------------------------
@@ -78,7 +81,7 @@ All core OME Ansible roles should be deployed to
 `Ansible Galaxy <https://galaxy.ansible.com>`_ under the
 `openmicroscopy <https://galaxy.ansible.com/openmicroscopy/>`__ organization.
 All roles must support RHEL/CentOS 7 as a primary platform. New roles should
-also include Ubuntu as a supported platform whenever possible.
+also include Ubuntu 18.04 as a supported platform whenever possible.
 
 Ansible playbooks can consume these roles using a :file:`requirements.yml`
 file - see

--- a/contributing/ansible-development.rst
+++ b/contributing/ansible-development.rst
@@ -1,0 +1,90 @@
+Ansible roles development
+=========================
+
+.. _Ansible: https://www.ansible.com/
+
+This document describes the conventions and process used by the OME team for
+developing, maintaining and releasing its Ansible_ roles.
+
+The set of rules and procedures described below applies to the official
+OME roles registered in https://github.com/ome/ansible-roles.
+
+Source code
+-----------
+
+The source code of a Java library should be maintained under version control
+using Git_ and hosted on GitHub_. Each directory layout should follow the 
+standard
+`Ansible role layout <https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html#role-directory-structure>`_::
+
+    defaults/           # Default variables
+    handlers/           # Handlers
+    meta/               # Role metadaa
+        main.yml        # Dependencies and Galaxy metadata
+    molecule/           # Test
+    tasks/              # Main list of tasks to be executed
+        main.yml
+    templates/          # Role templates
+    .travis.yml         # CI/deployment configuration file
+    README.md
+
+Versioning
+----------
+
+.. _PEP440: https://www.python.org/dev/peps/pep-0440/#semantic-versioning
+
+Ansible roles must follow PEP440_ rules for versioning. Additionally final
+releases must be compliant with `Semantic Versioning`_ i.e. the version must
+be expressed as `MAJOR.MINOR.PATCH` and:
+
+- the MAJOR version must be incremented when you make incompatible API changes,
+- the MINOR version must be incremented when you add functionality in a
+  backwards-compatible manner, and
+- the PATCH version must be incremented when you make backwards-compatible bug
+  fixes.
+
+Release tags must be expressed as `MAJOR.MINOR.PATCH` with no prefix.
+
+Development releases or pre-releases must follow the PEP440_ standard e.g.
+`MAJOR.MINOR.PATCH.dev1`, `MAJOR.MINOR.PATCHa1` `MAJOR.MINOR.PATHrc1`.
+
+Testing and Continuous Integration
+----------------------------------
+
+.. _Molecule: https://molecule.readthedocs.io/
+
+For each Ansible role, a :file:`molecule` folder should be configured allowing
+the testing of the role using  Molecule_. One or multiple scenarios should be
+configured using at least a Docker driver if possible.
+
+Continuous Integration of Ansible roles is performed using Travis CI.
+
+.. note::
+   OME Ansible roles are getting progressively upgraded to Molecule 2.x. New
+   roles should be configured using Molecule 2.x.
+
+Distribution
+------------
+
+All OME Ansible roles should be deployed to
+`Ansible Galaxy <https://galaxy.ansible.com>`_ under the
+`openmicroscopy <https://galaxy.ansible.com/openmicroscopy/>`_  organization.
+
+Ansible playbooks can consume these roles using a :file:`requirements.yml`
+file - see
+https://github.com/openmicroscopy/prod-playbooks/blob/master/requirements.yml 
+and https://github.com/IDR/deployment/blob/master/ansible/requirements.yml
+for examples of such files.
+
+Release process
+---------------
+
+Deployment of a role release happens using the
+`Travis integration <https://docs.ansible.com/ansible/latest/reference_appendices/galaxy.html#travis-integrations>`_.
+
+A PGP-signed tag should be created for the released version e.g.
+using :command:`scc tag-release` or :command:`git tag -s` and pushed to the
+upstream repository::
+
+    $ git tag -s x.y.z -m "<tag message>"
+    $ git push origin x.y.z

--- a/contributing/ansible-development.rst
+++ b/contributing/ansible-development.rst
@@ -13,7 +13,10 @@ Source code
 -----------
 
 The source code of a Java library should be maintained under version control
-using Git_ and hosted on GitHub_. Each directory layout should minimally follow the  standard
+using Git_ and hosted on GitHub_ under the
+`openmicroscopy <http://github.com/openmicroscopy/>`__ organization.
+Git repositories should be named as `ansible-role-<ROLE_NAME>`. Each directory
+layout should minimally follow the standard
 `Ansible role layout <https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html#role-directory-structure>`_ including other files and folders for testing and
 deployment. A typical role structure is shown below::
 
@@ -56,7 +59,11 @@ Testing and Continuous Integration
 
 For each Ansible role, a :file:`molecule` folder should be configured allowing
 the testing to be tested using  Molecule_. One or multiple scenarios should be
-configured using at least a Docker driver if possible.
+configured using at least a Docker driver if possible. A generic
+:file:`molecule` folder can be initialized using the following command::
+
+    molecule init scenario -r ansible-role-<NAME> -s default -d docker
+
 
 Continuous Integration of Ansible roles is performed using Travis CI.
 
@@ -64,12 +71,14 @@ Continuous Integration of Ansible roles is performed using Travis CI.
    OME Ansible roles are getting progressively upgraded from Molecule 1.x to 
    Molecule 2.x. New roles should be configured using Molecule 2.x.
 
-Distribution
-------------
+Distribution and support
+------------------------
 
 All core OME Ansible roles should be deployed to
 `Ansible Galaxy <https://galaxy.ansible.com>`_ under the
-`openmicroscopy <https://galaxy.ansible.com/openmicroscopy/>`_  organization.
+`openmicroscopy <https://galaxy.ansible.com/openmicroscopy/>`__ organization.
+All roles must support EL 7 as a primary platform. New roles should also
+include Ubuntu as a supported platform whenever possible.
 
 Ansible playbooks can consume these roles using a :file:`requirements.yml`
 file - see

--- a/contributing/index.rst
+++ b/contributing/index.rst
@@ -15,6 +15,7 @@ be valuable to a wider audience.
     code-contributions
     team-communication
     team-workflow
+    ansible-development
     java-development
     cpp-development
     development-tools


### PR DESCRIPTION
Add page describing the rule and policies for the OME Ansible roles including:

- source code and layout (Git + Ansible)
- versioning (PEP440 + semver for final releases)
- CI (Travis + Molecule)
- distribution and release (Galaxy)