### PR TITLE
fix documentation links broken by OMERO decoupling

### DIFF
--- a/contributing/conf.py
+++ b/contributing/conf.py
@@ -32,6 +32,8 @@ scc_github_root = github_root + 'snoopycrimecop'
 omero_main_github_root = main_github_root + '/openmicroscopy/'
 bf_main_github_root = main_github_root + '/bioformats/'
 
+omero_subs_github_root = github_root + 'ome/omero-{}/{}/{}/%s'
+
 # OME contributing-specific extlinks
 contributing_extlinks = {
     # Github links
@@ -40,6 +42,12 @@ contributing_extlinks = {
     'omero_commit' : (omero_github_root + 'commit/%s', ''),
     'omero_pr' : (omero_main_github_root + 'pull/%s', ''),
     'omero_scc_branch' : (scc_github_root + '/openmicroscopy/tree/%s', ''),
+    'omero_model_source' : (omero_subs_github_root.format('model', 'blob', 'master'), ''),
+    'omero_common_source' : (omero_subs_github_root.format('common', 'blob', 'master'), ''),
+    'omero_romio_source' : (omero_subs_github_root.format('romio', 'blob', 'master'), ''),
+    'omero_renderer_source' : (omero_subs_github_root.format('renderer', 'blob', 'master'), ''),
+    'omero_server_source' : (omero_subs_github_root.format('server', 'blob', 'master'), ''),
+    'omero_blitz_source' : (omero_subs_github_root.format('blitz', 'blob', 'master'), ''),
     'bf_source' : (bf_github_root + 'blob/'+ branch + '/%s', ''),
     'bf_sourcedir' : (bf_github_root + 'tree/'+ branch + '/%s', ''),
     'bf_commit' : (bf_github_root + 'commit/%s', ''),

--- a/contributing/editing-docs.rst
+++ b/contributing/editing-docs.rst
@@ -439,12 +439,12 @@ Model glossary
 """"""""""""""
 
 Content for :omero_doc:`Glossary of all OMERO Model Objects <developers/Model/EveryObject.html>`
-is generated using :omero_source:`GraphPathReport <components/server/src/ome/services/graphs/GraphPathReport.java>`.
+is generated using :omero_server_source:`GraphPathReport <src/main/java/ome/services/graphs/GraphPathReport.java>`.
 
 To update the content:
 
--  Run the command indicated in :omero_source:`GraphPathReport <components/server/src/ome/services/graphs/GraphPathReport.java>`
-   to generate EveryObject.rst
+-  Run the command indicated in :omero_server_source:`GraphPathReport <src/main/java/ome/services/graphs/GraphPathReport.java>`
+   to generate :file:`EveryObject.rst`
 -  Replace `EveryObject.rst <https://github.com/openmicroscopy/ome-documentation/blob/develop/omero/developers/Model/EveryObject.rst>`_
    with the generated one
 -  Open a PR with any changes

--- a/contributing/schema-changes.rst
+++ b/contributing/schema-changes.rst
@@ -22,8 +22,8 @@ described below.
 
 Changes to the :model_doc:`OME-XML model <developers/model-overview.html>`
 typically require corresponding changes in the OMERO data schema as
-defined in its :omero_source:`XML mappings files
-<components/model/resources/mappings/>`. These feed into OMERO's database
+defined in its :omero_model_source:`XML mappings files
+<src/main/resources/mappings/>`. These feed into OMERO's database
 schema so this process is then required.
 
 Patch number conflicts
@@ -43,16 +43,16 @@ Model object proxies
 --------------------
 
 Changes to model objects that are passed from the server to clients may
-require corresponding changes to be made to the :omero_source:`IceMapper
-<components/blitz/src/omero/util/IceMapper.java>` class so that the
+require corresponding changes to be made to the :omero_blitz_source:`IceMapper
+<src/main/java/omero/util/IceMapper.java>` class so that the
 client-side proxy objects are properly populated.
 
 For example, :omero_commit:`commit 8815a409
 <8815a409e24b41ff4c68829657ad98a278594ade>` adds fields to the `Roles` class
-in the server's :omero_source:`System.ice
-<components/blitz/resources/omero/System.ice>` whose instances can be passed
-to clients via the :omero_source:`admin service API
-<components/blitz/resources/omero/api/IAdmin.ice>` so a further
+in the server's :omero_blitz_source:`System.ice
+<src/main/slice/omero/System.ice>` whose instances can be passed
+to clients via the :omero_blitz_source:`admin service API
+<src/main/slice/omero/api/IAdmin.ice>` so a further
 :omero_commit:`commit 2426042a <2426042a4f0b5e31a6e9743844da168a9e550375>` was
 needed to populate those fields in the proxy object.
 


### PR DESCRIPTION
See https://github.com/openmicroscopy/openmicroscopy/pull/5934. Trying to get [CONTRIBUTING-merge-docs](https://ci.openmicroscopy.org/job/CONTRIBUTING-merge-docs/) passing.

([OMERO-DEV-merge-docs](https://ci.openmicroscopy.org/job/OMERO-DEV-merge-docs/) will be addressed separately.)