### PR TITLE
Link to Hibernate 3.6 documentation.

### DIFF
--- a/omero/developers/GettingStarted.rst
+++ b/omero/developers/GettingStarted.rst
@@ -246,7 +246,7 @@ HQL examples
 HQL is used for Query Service queries (see above). Some examples,
 coupled with the references for the :doc:`OMERO model
 <Model/EveryObject>` and `HQL syntax
-<https://docs.jboss.org/hibernate/orm/3.5/reference/en/html/queryhql.html>`_
+<https://docs.jboss.org/hibernate/orm/3.6/reference/en-US/html/queryhql.html>`_
 should get you going, along with notes about object loading on the
 |OmeroModel| page.
 


### PR DESCRIPTION
Bumps Hibernate documentation link from 3.5 to 3.6. Staged at https://ci.openmicroscopy.org/job/OMERO-DEV-merge-docs/ws/src/omero/_build/html/developers/GettingStarted.html#hql-examples.