### PR TITLE
Correct GH URL typo

### DIFF
--- a/omero/users/history.rst
+++ b/omero/users/history.rst
@@ -32,7 +32,7 @@ separate repositories:
 - https://github.com/ome/omero-model
 - https://github.com/ome/omero-common
 - https://github.com/ome/omero-romio
-- https://github.com/ome/omero-rendering
+- https://github.com/ome/omero-renderer
 - https://github.com/ome/omero-server
 - https://github.com/ome/omero-blitz
 - https://github.com/ome/omero-insight


### PR DESCRIPTION
fix for:

 * https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-latest-docs/502/console
 * https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-merge-docs/1411/console