### PR TITLE
Matlab: link to nice downloads page instead of listing

### DIFF
--- a/omero/developers/Matlab.rst
+++ b/omero/developers/Matlab.rst
@@ -9,7 +9,8 @@ See |DevelopingOmeroClients| and |OmeroModel|, for an introduction to
 Installing the OMERO.matlab toolbox
 -----------------------------------
 
--  Download the latest released version from the :downloads:`download page <>`.
+-  Download the latest released version from the
+   `Downloads page <https://www.openmicroscopy.org/omero/downloads/>`_.
 -  Unzip the directory anywhere on your system.
 -  In MATLAB, move to the newly unzipped directory and run ``loadOmero;``.
 -  The MATLAB files are now on your path, and the necessary jars are on


### PR DESCRIPTION
https://docs.openmicroscopy.org/omero/5.4.10/developers/Matlab.html suggests downloading the Matlab client package from https://downloads.openmicroscopy.org/omero/5.4.10/ which is an unhelpful file listing. This changes the link to https://www.openmicroscopy.org/omero/downloads/.