### PR TITLE
Note that "fs rename" is not available.

### DIFF
--- a/omero/sysadmins/cli/fs.rst
+++ b/omero/sysadmins/cli/fs.rst
@@ -251,6 +251,11 @@ For example
     mv /OMERO/ManagedRepository/user-0_2/2014-07/23/16-29-14.809/ /OMERO/ManagedRepository/pg-0_3/user-0_2/2014-07-23/16-49-23.543/
     mv /OMERO/ManagedRepository/user-0_2/2014-07/23/16-29-14.809.log /OMERO/ManagedRepository/pg-0_3/user-0_2/2014-07-23/16-49-23.543.log
 
+.. note::
+
+  The :program:`omero fs rename` subcommand is currently disabled
+  pending a bug-fix.
+
 Detailing disk usage
 ^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Alerts users to the effect of https://github.com/openmicroscopy/openmicroscopy/pull/5800. Staged at https://ci.openmicroscopy.org/job/OMERO-DEV-merge-docs/ws/src/omero/_build/html/sysadmins/cli/fs.html#renaming-filesets.