### PR TITLE
Ignore broken Eclipse AspectJ link while server is fixed.

### DIFF
--- a/omero/conf.py
+++ b/omero/conf.py
@@ -174,7 +174,8 @@ linkcheck_ignore += [r'http://localhost:\d+/?', 'http://localhost/',
     r'https?://www\.openmicroscopy\.org/site/team/.*',
     r'.*[.]?example\.com/.*',
     r'https://spreadsheets.google.com/.*',
-    'https://msdn.microsoft.com/en-us/library/aa362244\(v=vs.85\).aspx'
+    'https://msdn.microsoft.com/en-us/library/aa362244\(v=vs.85\).aspx',
+    'https://eclipse.org/aspectj/'
 ]
 
 exclude_patterns = ['sysadmins/unix/walkthrough/requirements*',


### PR DESCRIPTION
Yesterday I got the Eclipse Webmaster to alert the AspectJ project team to their internal server error. This PR might keep [OMERO-DEV-merge-docs](https://ci.openmicroscopy.org/job/OMERO-DEV-merge-docs/) green while we give them time to fix it.