### PR TITLE
Point to merge-ci's OMERO-docs

### DIFF
--- a/common/conf.py
+++ b/common/conf.py
@@ -129,8 +129,8 @@ jenkins_view_root = jenkins_root + '/view'
 
 # Variables used to define Jenkins extlinks (merge-ci)
 mergeci_root = 'https://merge-ci.openmicroscopy.org/jenkins'
-mergeci_job_root = jenkins_root + '/job'
-mergeci_view_root = jenkins_root + '/view'
+mergeci_job_root = mergeci_root + '/job'
+mergeci_view_root = mergeci_root + '/view'
 
 # Variables used to define other extlinks
 cvs_root = 'http://cvs.openmicroscopy.org.uk'
@@ -153,7 +153,7 @@ extlinks = {
     'jenkinsview' : (jenkins_view_root + '/%s', ''),
     # Jenkins links (merge-ci)
     'mergeci' : (mergeci_root + '/%s', ''),
-    'mergeci_job' : (mergeci_job_root + '/%s', ''),
+    'mergecijob' : (mergeci_job_root + '/%s', ''),
     # Mailing list/forum links
     'mailinglist' : (lists_root + '/mailman/listinfo/%s', ''),
     'ome-users' : (lists_root + '/pipermail/ome-users/%s' ,''),

--- a/common/conf.py
+++ b/common/conf.py
@@ -122,10 +122,15 @@ omero_github_root = github_root + user + '/openmicroscopy/'
 bf_github_root = github_root + user + '/bioformats/'
 doc_github_root = github_root + user + '/ome-documentation/'
 
-# Variables used to define Jenkins extlinks
+# Variables used to define Jenkins extlinks (ci-master)
 jenkins_root = 'https://ci.openmicroscopy.org'
 jenkins_job_root = jenkins_root + '/job'
 jenkins_view_root = jenkins_root + '/view'
+
+# Variables used to define Jenkins extlinks (merge-ci)
+mergeci_root = 'https://merge-ci.openmicroscopy.org/jenkins'
+mergeci_job_root = jenkins_root + '/job'
+mergeci_view_root = jenkins_root + '/view'
 
 # Variables used to define other extlinks
 cvs_root = 'http://cvs.openmicroscopy.org.uk'
@@ -142,10 +147,13 @@ extlinks = {
     'ticket' : (trac_root + '/ticket/%s', '#'),
     'milestone' : (trac_root + '/milestone/%s', ''),
     'report' : (trac_root + '/report/%s', ''),
-    # Jenkins links
+    # Jenkins links (ci-master)
     'jenkins' : (jenkins_root + '/%s', ''),
     'jenkinsjob' : (jenkins_job_root + '/%s', ''),
     'jenkinsview' : (jenkins_view_root + '/%s', ''),
+    # Jenkins links (merge-ci)
+    'mergeci' : (mergeci_root + '/%s', ''),
+    'mergeci_job' : (mergeci_job_root + '/%s', ''),
     # Mailing list/forum links
     'mailinglist' : (lists_root + '/mailman/listinfo/%s', ''),
     'ome-users' : (lists_root + '/pipermail/ome-users/%s' ,''),

--- a/contributing/ci-docs.rst
+++ b/contributing/ci-docs.rst
@@ -148,7 +148,7 @@ The branch for the 5.x series of the OMERO documentation is develop.
 		#. |sphinxbuild|
 		#. |linkcheck|
 
-	:jenkinsjob:`OMERO-docs`
+	:mergecijob:`OMERO-docs`
 
 		This job is used to review the PRs opened against the develop branch
 		of the OMERO 5.x documentation

--- a/contributing/ci-docs.rst
+++ b/contributing/ci-docs.rst
@@ -20,7 +20,7 @@ More detail on how and where to edit OME documentation is available on the
 		* :term:`OMERO-DEV-latest-docs`
 
 	-	* Builds the OMERO documentation for review
-		* :term:`OMERO-DEV-merge-docs`
+		* :term:`OMERO-docs`
 
 	-	* Builds the auto-generated OMERO documentation
 		* :term:`OMERO-DEV-latest-docs-autogen`
@@ -148,7 +148,7 @@ The branch for the 5.x series of the OMERO documentation is develop.
 		#. |sphinxbuild|
 		#. |linkcheck|
 
-	:jenkinsjob:`OMERO-DEV-merge-docs`
+	:jenkinsjob:`OMERO-docs`
 
 		This job is used to review the PRs opened against the develop branch
 		of the OMERO 5.x documentation

--- a/contributing/editing-docs.rst
+++ b/contributing/editing-docs.rst
@@ -340,7 +340,7 @@ Building/reviewing PRs via the CI
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Once a PR is open, you can build it for review using the
-:jenkinsjob:`OMERO-DEV-merge-docs` job on the Jenkins CI. Staging
+:mergecijob:`OMERO-docs` job on the Jenkins CI. Staging
 documentation are no longer deployed at a URL but you can download it as a zip
 for review with the correct styling from the top centre panel in the job,
 under ‘Last Successful Artifacts’.


### PR DESCRIPTION
This is a temporary fix and won't scale to the introduction
of latest-ci, etc. A review of the term naming strategy is
likely needed.

cc: @sbesson