### PR TITLE
Make Java 11 "upcoming" instead of "supported" for OMERO 5.5

### DIFF
--- a/omero/sysadmins/version-requirements.rst
+++ b/omero/sysadmins/version-requirements.rst
@@ -230,7 +230,7 @@ Components
          - |Supported|
        * - 11
          - |Unsupported|
-         - |Supported|
+         - |Upcoming|
          - |Recommended|
 
   * Rationale: For OMERO 5.4 deprecate Java 7 because security support ended
@@ -807,7 +807,7 @@ OMERO support policies
       - from Sep 2018
       - to Oct 2024
       - |Unsupported|
-      - |Supported|
+      - |Upcoming|
       - |Recommended|
       - `Reference <https://access.redhat.com/articles/1299013>`__
 


### PR DESCRIPTION
@jburel mentioned issues with starting OMERO.server 5.5 with Java 11. Locally with OpenJDK 11.0.2+9-Debian-3bpo91 I observe,

```
...
Caused by: bitronix.tm.internal.BitronixRuntimeException: error initializing JdbcProxyFactory
	at bitronix.tm.resource.jdbc.proxy.JdbcProxyFactory$Initializer.initialize(JdbcProxyFactory.java:82) ~[btm.jar:3.0.0-mk1]
	at bitronix.tm.resource.jdbc.proxy.JdbcProxyFactory$Initializer.access$000(JdbcProxyFactory.java:60) ~[btm.jar:3.0.0-mk1]
	at bitronix.tm.resource.jdbc.proxy.JdbcProxyFactory.<clinit>(JdbcProxyFactory.java:39) ~[btm.jar:3.0.0-mk1]
	... 97 common frames omitted
Caused by: java.lang.RuntimeException: java.lang.NullPointerException
	at bitronix.tm.resource.jdbc.proxy.JdbcJavassistProxyFactory.createProxyConnectionClass(JdbcJavassistProxyFactory.java:159) ~[btm.jar:3.0.0-mk1]
	at bitronix.tm.resource.jdbc.proxy.JdbcJavassistProxyFactory.<init>(JdbcJavassistProxyFactory.java:72) ~[btm.jar:3.0.0-mk1]
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[na:na]
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62) ~[na:na]
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[na:na]
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490) ~[na:na]
	at java.base/java.lang.Class.newInstance(Class.java:584) ~[na:na]
	at bitronix.tm.resource.jdbc.proxy.JdbcProxyFactory$Initializer.initialize(JdbcProxyFactory.java:80) ~[btm.jar:3.0.0-mk1]
	... 99 common frames omitted
Caused by: java.lang.NullPointerException: null
	at javassist.util.proxy.SecurityActions.setAccessible(SecurityActions.java:103) ~[javassist.jar:na]
	at javassist.util.proxy.DefineClassHelper.toClass3(DefineClassHelper.java:151) ~[javassist.jar:na]
	at javassist.util.proxy.DefineClassHelper.toClass2(DefineClassHelper.java:134) ~[javassist.jar:na]
	at javassist.util.proxy.DefineClassHelper.toClass(DefineClassHelper.java:95) ~[javassist.jar:na]
	at javassist.ClassPool.toClass(ClassPool.java:1143) ~[javassist.jar:na]
	at javassist.CtClass.toClass(CtClass.java:1316) ~[javassist.jar:na]
	at bitronix.tm.resource.jdbc.proxy.JdbcJavassistProxyFactory.generateProxyClass(JdbcJavassistProxyFactory.java:265) ~[btm.jar:3.0.0-mk1]
	at bitronix.tm.resource.jdbc.proxy.JdbcJavassistProxyFactory.createProxyConnectionClass(JdbcJavassistProxyFactory.java:156) ~[btm.jar:3.0.0-mk1]
	... 106 common frames omitted
```