### PR TITLE
Review contributing pages for OMERO CI jobs and deployments

### DIFF
--- a/contributing/ci-docs.rst
+++ b/contributing/ci-docs.rst
@@ -164,8 +164,7 @@ The branch for the 5.x series of the OMERO documentation is develop.
 		develop branch of the OMERO documentation
 
 		#. Checks out the develop branch of ome-documentation.git_
-		#. Downloads the OMERO.server and OMERO.clients from
-		   :term:`OMERO-DEV-latest`
+		#. Downloads the latest OMERO.server and OMERO.clients
 		#. Runs the :file:`omero/autogen_docs` autogeneration script
 		#. Pushes the auto-generated changes to
 		   :omedoc_scc_branch:`develop/latest/autogen`
@@ -176,8 +175,7 @@ The branch for the 5.x series of the OMERO documentation is develop.
 		develop branch of the OMERO documentation
 
 		#. Checks out :omedoc_scc_branch:`develop/merge/daily`
-		#. Downloads the OMERO.server and OMERO.clients from
-		   :term:`OMERO-DEV-merge-build`
+		#. Downloads the merge OMERO.server and OMERO.clients
 		#. Runs the :file:`omero/autogen_docs` autogeneration script
 		#. Pushes the auto-generated changes to
 		   :omedoc_scc_branch:`develop/merge/autogen`

--- a/contributing/ci-omero.rst
+++ b/contributing/ci-omero.rst
@@ -85,17 +85,17 @@ Jobs
         These jobs build the OMERO server components, the OMERO bundles and the
         OMERO clients from the integration branches created by the push jobs.
 
-    :jenkinsjob:`OMERO-server`
+    :mergecijob:`OMERO-server`
 
         This job deploys the server (see :ref:`deployment_servers`) created by
         :term:`OMERO-build`.
 
-    :jenkinsjob:`OMERO-web`
+    :mergecijob:`OMERO-web`
 
         This job deploys the Web application (see :ref:`deployment_servers`)
         created by :term:`OMERO-build`.
 
-    :jenkinsjob:`OMERO-test-integration`
+    :mergecijob:`OMERO-test-integration`
 
         This job deploys an OMERO.server and runs the OMERO.java, OMERO.py
         and OMERO.web integration tests.

--- a/contributing/ci-omero.rst
+++ b/contributing/ci-omero.rst
@@ -1,58 +1,10 @@
 OMERO jobs
 ----------
 
-.. list-table::
-    :header-rows: 1
-
-    -   * Job task
-        * DEV series
-
-    -   * Builds the latest OMERO artifacts
-        * :term:`OMERO-DEV-latest`
-
-    -   * Deploys the latest OMERO server
-        * :term:`OMERO-DEV-latest-deploy`
-
-    -   * Deploys the latest OMERO web
-        * :term:`WEB-DEV-latest-deploy`
-
-    -   * Updates submodules
-        * :term:`OMERO-DEV-latest-submods`
-
-    -   * Runs the daily OMERO merge builds
-        * :term:`OMERO-DEV-merge-daily`
-
-    -   * Merges the PRs
-        * :term:`OMERO-DEV-merge-push`
-
-    -   * Builds the merge OMERO artifacts
-        * :term:`OMERO-DEV-merge-build`
-
-    -   * Deploys the merge OMERO server
-        * :term:`OMERO-DEV-merge-deploy`
-
-    -   * Deploys the merge OMERO web
-        * :term:`WEB-DEV-merge-deploy`
-
-    -   * Runs the OMERO integration tests
-        * | :term:`OMERO-DEV-merge-integration`
-          | :term:`OMERO-DEV-merge-integration-broken`
-          | :term:`OMERO-DEV-merge-integration-java`
-          | :term:`OMERO-DEV-merge-integration-python`
-       
-    -   * Deploys the integration OMERO web and runs Robot tests using first server from the list
-        * :term:`WEB-DEV-integration-deploy`
-
-    -   * Runs the OMERO.matlab tests
-        * :term:`OMERO-DEV-merge-matlab`
-
-    -   * Runs the robot framework tests
-        * :term:`OMERO-DEV-merge-robotframework`
-
 .. _deployment_servers:
 
-Deployment servers and web
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+Deployments
+^^^^^^^^^^^
 
 The table below lists all the hostnames, ports and URLs of the OMERO.web
 clients of the deployment jobs described above:
@@ -62,175 +14,88 @@ clients of the deployment jobs described above:
     :widths: 10,20,20,10,20,40
 
     -   * Series
-        * Deployment job (server)
+        * OMERO.server deployment job
         * Hostname
         * Port
-        * Deployment job (web)
+        * OMERO.web deployment job
         * Webclient
 
-    -   * DEV
-        * :term:`OMERO-DEV-merge-deploy`
-        * eel.openmicroscopy.org
+    -   * Merge 
+        * :term:`OMERO-server`
+        * merge-ci.openmicroscopy.org
         * 4064
-        * :term:`WEB-DEV-merge-deploy`
-        * http://web-dev-merge.openmicroscopy.org/webclient/login/
-
-    -   * DEV
-        * :term:`OMERO-DEV-latest-deploy`
-        * eel.openmicroscopy.org
-        * 14064
-        * :term:`WEB-DEV-latest-deploy`
-        * http://web-dev-latest.openmicroscopy.org/webclient/login/
-
-    -   * DEV
-        * :term:`OMERO-DEV-merge-integration`
-        * eel.openmicroscopy.org
-        * 24064
-        * :term:`WEB-DEV-integration-deploy`
-        * http://web-dev-integration.openmicroscopy.org/webclient/login/
+        * :term:`OMERO-web`
+        * https://merge-ci.openmicroscopy.org/web/
 
 
-5.4.x series
-^^^^^^^^^^^^
+Jobs
+^^^^
 
-The branch for the 5.4.x series of OMERO is develop. All jobs are listed
-under the :jenkinsview:`DEV` view tab of Jenkins.
+.. list-table::
+    :header-rows: 1
+
+    -   * Job task
+        * Merge jobs
+
+    -   * Merges the PRs and couple versions
+        * | :term:`OMERO-gradle-plugins-push`
+          | :term:`OMERO-build-push`
+          | :term:`OMERO-push`
+          | :term:`OMERO-insight-push`
+          | :term:`OMERO-matlab-push`
+
+    -   * Builds the OMERO artifacts
+        * | :term:`OMERO-gradle-plugins-build`
+          | :term:`OMERO-build-build`
+          | :term:`OMERO-build`
+          | :term:`OMERO-insight-build`
+          | :term:`OMERO-matlab-build`
+
+    -   * Deploy OMERO
+        * | :term:`OMERO-server`
+          | :term:`OMERO-web`
+
+    -   * Runs the OMERO integration tests
+        * :term:`OMERO-test-integration`
 
 .. glossary::
 
-    :jenkinsjob:`OMERO-DEV-latest`
 
-        This job builds the develop branch of OMERO with Ice 3.5 or 3.6
+    :mergecijob:`OMERO-gradle-plugins-push`
+    :mergecijob:`OMERO-build-push`
+    :mergecijob:`OMERO-push`
+    :mergecijob:`OMERO-insight-push`
+    :mergecijob:`OMERO-matlab-push`
 
-        #. |buildOMERO|
-        #. |archiveOMEROartifacts|
+        These jobs merge all the PRs opened against the development branches
+        and couple the component versions for the following repositories:
 
-        See :jenkinsjob:`the build graph <OMERO-DEV-latest/lastSuccessfulBuild/BuildGraph>`
+        - https://github.com/ome/omero-gradle-plugins
+        - https://github.com/ome/omero-build
+        - https://github.com/openmicroscopy/openmicroscopy
+        - https://github.com/ome/omero-insight
+        - https://github.com/ome/omero-matlab
 
-    :jenkinsjob:`OMERO-DEV-latest-deploy`
+    :mergecijob:`OMERO-gradle-plugins-build`
+    :mergecijob:`OMERO-build-build`
+    :mergecijob:`OMERO-build`
+    :mergecijob:`OMERO-insight-build`
+    :mergecijob:`OMERO-matlab-build`
 
-        This job deploys the latest 5.4.x server (see
-        :ref:`deployment_servers`)
+        These jobs build the OMERO server components, the OMERO bundles and the
+        OMERO clients from the integration branches created by the push jobs.
 
-    :jenkinsjob:`WEB-DEV-latest-deploy`
+    :jenkinsjob:`OMERO-server`
 
-        This job deploys the latest 5.4.x webclient (see
-        :ref:`deployment_servers`)
+        This job deploys the server (see :ref:`deployment_servers`) created by
+        :term:`OMERO-build`.
 
-    :jenkinsjob:`OMERO-DEV-latest-submods`
+    :jenkinsjob:`OMERO-web`
 
-        This job updates the submodules on the develop branch
+        This job deploys the Web application (see :ref:`deployment_servers`)
+        created by :term:`OMERO-build`.
 
-        #. |updatesubmodules| and pushes the merge branch to
-           :omero_scc_branch:`develop_latest_submodules`
-        #. If the submodules are updated, opens a new PR or updates the
-           existing develop submodules PR
+    :jenkinsjob:`OMERO-test-integration`
 
-    :jenkinsjob:`OMERO-DEV-merge-daily`
-
-        This job triggers all the morning merge builds listed below
-
-        #. Triggers :term:`OMERO-DEV-merge-push`
-        #. Triggers :term:`OMERO-DEV-merge-build` and
-           :term:`OMERO-DEV-merge-integration`
-        #. Triggers :term:`OMERO-DEV-merge-deploy`
-        #. Triggers :term:`WEB-DEV-merge-deploy`
-        #. Triggers other downstream merge jobs
-
-        See :jenkinsjob:`the build graph <OMERO-DEV-merge-daily/lastSuccessfulBuild/BuildGraph>`
-
-    :jenkinsjob:`OMERO-DEV-merge-push`
-
-        This job merges all the PRs opened against develop
-
-        #. |merge|
-        #. Pushes the branch to :omero_scc_branch:`develop/merge/daily`
-
-    :jenkinsjob:`OMERO-DEV-merge-build`
-
-        This matrix job builds the OMERO components with Ice 3.5 or 3.6
-
-        #. Checks out :omero_scc_branch:`develop/merge/daily` 
-        #. |buildOMERO| for each version of Ice
-        #. |archiveOMEROartifacts|
-
-    :jenkinsjob:`OMERO-DEV-merge-deploy`
-
-        This job deploys the merge 5.4.x server (see
-        :ref:`deployment_servers`)
-
-    :jenkinsjob:`WEB-DEV-merge-deploy`
-
-        This job deploys the merge 5.4.x web (see
-        :ref:`deployment_servers`)
-
-    :jenkinsjob:`OMERO-DEV-merge-integration`
-
-        This job runs the integration tests of OMERO
-
-        #. Checks out :omero_scc_branch:`develop/merge/daily` 
-        #. Builds OMERO.server and starts it
-        #. Runs the OMERO.java and OMERO.py integration tests
-        #. Archives the results
-        #. Triggers downstream collection jobs:
-           :term:`OMERO-DEV-merge-integration-broken`,
-           :term:`OMERO-DEV-merge-integration-java`,
-           :term:`OMERO-DEV-merge-integration-python`
-
-    :jenkinsjob:`OMERO-DEV-merge-integration-broken`
-
-        This job collects the OMERO.java broken test results
-
-        #. Receives TestNG results under
-           :file:`components/tools/OmeroJava/target/reports/broken` from
-           :term:`OMERO-DEV-merge-integration`,
-        #. Generates TestNG report
-
-    :jenkinsjob:`OMERO-DEV-merge-integration-java`
-
-        This job collects the OMERO.java integration test results
-
-        #. Receives TestNG results under
-           :file:`components/tools/OmeroJava/target/reports/integration` from
-           :term:`OMERO-DEV-merge-integration`,
-        #. Generates TestNG report
-
-    :jenkinsjob:`OMERO-DEV-merge-integration-python`
-
-        This job collects the OMERO.py integration test results
-
-        #. Receives pytest results under
-           :file:`components/tools/OmeroPy/target/reports` from
-           :term:`OMERO-DEV-merge-integration`,
-        #. Generates pytest report
-
-    :jenkinsjob:`WEB-DEV-integration-deploy`
-
-        This job deploys the merge 5.4.x web (see
-        :ref:`deployment_servers`)
-
-    :jenkinsjob:`OMERO-DEV-merge-integration-Python27`
-
-        This job runs Python integration tests of OMERO on Python 2.7
-
-        #. Checks out :omero_scc_branch:`develop/merge/daily`
-        #. Builds OMERO.server and starts it
-        #. Runs the OMERO.py and OMERO.web integration tests
-        #. Archives the results
-
-    :jenkinsjob:`OMERO-DEV-merge-matlab`
-
-        This job runs the OMERO.matlab tests
-
-        #. Checks out :omero_scc_branch:`develop/merge/daily` 
-        #. Collects the MATLAB artifacts from :term:`OMERO-DEV-merge-build`
-        #. Runs the MATLAB unit tests under
-           :file:`components/tools/OmeroM/test/unit` and collect the results
-
-    :jenkinsjob:`OMERO-DEV-merge-robotframework`
-
-        This job runs the robot framework tests of OMERO
-
-        #. Checks out :omero_scc_branch:`develop/merge/daily` 
-        #. Builds OMERO.server and starts it
-        #. Runs the robot framework tests and collect the results
+        This job deploys an OMERO.server and runs the OMERO.java, OMERO.py
+        and OMERO.web integration tests.


### PR DESCRIPTION
Document the new merge-ci jobs including the expected deployments. Once functional, the latest-ci jobs can be added to the table as an extra column