### PR TITLE
Make the scope of in place import more explicit

### DIFF
--- a/omero/sysadmins/in-place-import.rst
+++ b/omero/sysadmins/in-place-import.rst
@@ -68,18 +68,18 @@ into, and then use their own OMERO accounts to import data. Alternatively,
 each OMERO user can be given an OS account with access rights to the data
 storage as well as the managed repository.
 
+Also, there is still some data duplication when
+:model_doc:`pyramids <omero-pyramid/>` are generated. We are
+hoping to find a work-around for this in the future.
+
 For soft linking with :literal:`--transfer=ln_s` it has been noticed
 that some plate imports run rather more slowly than usual. Other
 operations may also be affected. In determining if or how to use
 in-place import at your high-content screening facility, we thus
 recommend time profiling with representative data, and alerting us to
-any significant disappointments.
-
-Also, there is still some data duplication when
-:model_doc:`pyramids <omero-pyramid/>` are generated. We are
-hoping to find a work-around for this in the future.
-
-Do not use this procedure to create links on data inside the ManagedRepository.
+any significant disappointments. **Additionally, do not use soft links
+when pointing to data inside the ManagedRepository. If the originals
+are deleted, the data will be lost.**
 
 .. _safety_tips:
 

--- a/omero/sysadmins/in-place-import.rst
+++ b/omero/sysadmins/in-place-import.rst
@@ -70,7 +70,7 @@ storage as well as the managed repository.
 
 Also, there is still some data duplication when
 :model_doc:`pyramids <omero-pyramid/>` are generated. We are
-hoping to find a work-around for this in the future.
+hoping to find a workaround for this in the future.
 
 For soft linking with :literal:`--transfer=ln_s` it has been noticed
 that some plate imports run rather more slowly than usual. Other

--- a/omero/sysadmins/in-place-import.rst
+++ b/omero/sysadmins/in-place-import.rst
@@ -13,8 +13,8 @@ improvements planned to enable a more user-friendly experience. This
 users, in-place import is essential for their use of OMERO.
 
 This feature is designed to allow imaging facilities to import large datasets
-into OMERO while keeping them safely stored in a secure location on the file system which is
-read-only for users. Leaving the data in a user's file system **is very
+into OMERO while keeping them safely stored on the file system in a secure location that is
+*read-only* for users. Leaving the data in a user's file system **is very
 dangerous** as they may forget they need to keep it or move to a different
 institution. **Under no circumstances should in-place import be used with
 temporary storage.**

--- a/omero/sysadmins/in-place-import.rst
+++ b/omero/sysadmins/in-place-import.rst
@@ -3,9 +3,9 @@
 In-place import
 ===============
 
-In-place import allows files which are already present on the server machine
-to be imported into OMERO without the need to upload them over an OMERO login session. This requires
-users to have shell (|SSH|, etc.) access to the server machine,
+In-place import allows files which are accessible from the OMERO.server's filesystem
+to be imported into OMERO without the need to upload them over an OMERO login session.
+This requires users to have shell (|SSH|, etc.) access to the server machine,
 and so there are a number of :ref:`limitations <limitations>`
 to this implementation. Development of this feature is on-going, with
 improvements planned to enable a more user-friendly experience. This

--- a/omero/sysadmins/in-place-import.rst
+++ b/omero/sysadmins/in-place-import.rst
@@ -77,9 +77,13 @@ that some plate imports run rather more slowly than usual. Other
 operations may also be affected. In determining if or how to use
 in-place import at your high-content screening facility, we thus
 recommend time profiling with representative data, and alerting us to
-any significant disappointments. **Additionally, do not use soft links
-when pointing to data inside the ManagedRepository. If the originals
-are deleted, the data will be lost.**
+any significant disappointments.
+
+.. warning::
+
+    Do not use soft links when pointing to data inside the
+    ManagedRepository. If the originals are deleted, the data will be
+    lost.
 
 .. _safety_tips:
 

--- a/omero/sysadmins/in-place-import.rst
+++ b/omero/sysadmins/in-place-import.rst
@@ -4,7 +4,7 @@ In-place import
 ===============
 
 In-place import allows files which are already present on the server machine
-to be imported into OMERO without the need to copy them into OMERO's ManagedRepository. This requires
+to be imported into OMERO without the need to upload them over an OMERO login session. This requires
 users to have shell (|SSH|, etc.) access to the server machine,
 and so there are a number of :ref:`limitations <limitations>`
 to this implementation. Development of this feature is on-going, with

--- a/omero/sysadmins/in-place-import.rst
+++ b/omero/sysadmins/in-place-import.rst
@@ -4,7 +4,7 @@ In-place import
 ===============
 
 In-place import allows files which are already present on the server machine
-to be imported into OMERO without the need to copy them. This requires
+to be imported into OMERO without the need to copy them into OMERO's ManagedRepository. This requires
 users to have shell (|SSH|, etc.) access to the server machine,
 and so there are a number of :ref:`limitations <limitations>`
 to this implementation. Development of this feature is on-going, with
@@ -13,7 +13,7 @@ improvements planned to enable a more user-friendly experience. This
 users, in-place import is essential for their use of OMERO.
 
 This feature is designed to allow imaging facilities to import large datasets
-into OMERO while keeping them safely stored in a secure repository which is
+into OMERO while keeping them safely stored in a secure location on the file system which is
 read-only for users. Leaving the data in a user's file system **is very
 dangerous** as they may forget they need to keep it or move to a different
 institution. **Under no circumstances should in-place import be used with
@@ -78,6 +78,8 @@ any significant disappointments.
 Also, there is still some data duplication when
 :model_doc:`pyramids <omero-pyramid/>` are generated. We are
 hoping to find a work-around for this in the future.
+
+Do not use this procedure to create links on data inside the ManagedRepository.
 
 .. _safety_tips:
 


### PR DESCRIPTION
Replaces: https://github.com/ome/ome-documentation/pull/1983

The fact that one should not create links on data inside the ManagedRepository because of the the logic used for the database management is noted explicitly.

cc: @mtbc 