### PR TITLE
changed to walkthrough_ubuntu1804 from walkthrough_debian9

### DIFF
--- a/omero/sysadmins/unix/server-ubuntu1804-ice36.rst
+++ b/omero/sysadmins/unix/server-ubuntu1804-ice36.rst
@@ -63,7 +63,7 @@ they both should be disabled by running the following command::
 
 To install PostgreSQL |postgresversion|:
 
-.. literalinclude:: walkthrough/walkthrough_debian9.sh
+.. literalinclude:: walkthrough/walkthrough_ubuntu1804.sh
     :start-after: # install Postgres
     :end-before: #end-step01
 


### PR DESCRIPTION
Postgresql10 installation fails if "http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" (debian9) is used.
"http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main" works
Walkthrough link should be changed?