### PR TITLE
set-up

### DIFF
--- a/omero/sysadmins/unix/server-debian9-ice36.rst
+++ b/omero/sysadmins/unix/server-debian9-ice36.rst
@@ -125,9 +125,6 @@ added in two files in order to allow connection.
     :start-after: #start-seclevel
     :end-before: #end-seclevel
 
-Run ``python -m py_compile OMERO.server/lib/python/omero/clients.py`` to recompile the file.
-
-
 Running OMERO.server
 --------------------
 

--- a/omero/sysadmins/unix/server-debian9-ice36.rst
+++ b/omero/sysadmins/unix/server-debian9-ice36.rst
@@ -54,6 +54,10 @@ To install Ice |iceversion|:
     :start-after: #start-recommended-ice
     :end-before: #end-recommended-ice
 
+To make Ice available to all users, set the environment using :download:`omero-ice36.env <walkthrough/omero-ice36.env>`::
+
+    cat omero-ice36.env >> /etc/profile
+   
 As part of the installation of Ice, two new daemons are installed and automatically started.
 In order for the OMERO.server to start correctly,
 they both should be disabled by running the following command::

--- a/omero/sysadmins/unix/server-ubuntu1804-ice36.rst
+++ b/omero/sysadmins/unix/server-ubuntu1804-ice36.rst
@@ -54,6 +54,11 @@ To install Ice |iceversion|:
     :start-after: #start-recommended-ice
     :end-before: #end-recommended-ice
 
+To make Ice available to all users, set the environment using :download:`omero-ice36.env <walkthrough/omero-ice36.env>`::
+
+    cat omero-ice36.env >> /etc/profile
+  
+
 As part of the installation of Ice, two new daemons are installed and automatically started.
 In order for the OMERO.server to start correctly,
 they both should be disabled by running the following command::

--- a/omero/sysadmins/unix/server-ubuntu1804-ice36.rst
+++ b/omero/sysadmins/unix/server-ubuntu1804-ice36.rst
@@ -126,9 +126,6 @@ added in two files in order to allow connection.
     :start-after: #start-seclevel
     :end-before: #end-seclevel
 
-Run ``python -m py_compile OMERO.server/lib/python/omero/clients.py`` to recompile the file.
-
-
 Running OMERO.server
 --------------------
 


### PR DESCRIPTION
Clarify point raised in https://forum.image.sc/t/problem-when-installing-omero-server-5-5-ubuntu-18-04-server-hyper-v/26695
This also removed a compile line no longer required.
the troubleshooting page was fixed but not the walkthrough
cc @MartinSt80 