### PR TITLE
Bump omero-server to 5.5.4

### DIFF
--- a/omero/autogen_db_version.py
+++ b/omero/autogen_db_version.py
@@ -50,7 +50,7 @@ print 'previous_dbver = "OMERO%d.%d%s__%d"' % previous_mmp
 
 print 'version_bioformats = "6.1.1"'
 print 'version_blitz = "5.5.3"'
-print 'version_server = "5.5.3"'
+print 'version_server = "5.5.4"'
 print 'version_romio = "5.5.2"'
 print 'version_renderer = "5.5.2"'
 print 'version_common = "5.5.2"'


### PR DESCRIPTION
I inadvertently listed the previous version of omero-server (5.5.3) which was missing from docs.openmicroscopy.org/omero-server making it a natural candidate for the next bump. However, 5.5.3 was never updated in blitz and so it never got released via https://ci.openmicroscopy.org/job/OMERO-DEV-release-artifacts/

see: https://trello.com/c/wz8CUzS2/28-version-history-pr