### PR TITLE
Update link to website deployment playbook.

### DIFF
--- a/contributing/jekyll.rst
+++ b/contributing/jekyll.rst
@@ -1,4 +1,4 @@
-Jekyll hosted websites
+Jekyll-hosted websites
 ======================
 
 A number of OME websites are produced using `Jekyll <https://jekyllrb.com/>`_,

--- a/contributing/jekyll.rst
+++ b/contributing/jekyll.rst
@@ -80,7 +80,7 @@ static website and then deploying it on the web server:
   [Travis CI](https://travis-ci.org/openmicroscopy/www.openmicroscopy.org) and 
   deployed as an asset of the associated `GitHub release <https://github.com/openmicroscopy/www.openmicroscopy.org/releases>`_
 - a PR can then be opened against the
-  `Website deployment playbook <https://github.com/openmicroscopy/prod-playbooks/blob/master/www/www-jekyll.yml>`_ to consume the new release asset
+  `Website deployment playbook <https://github.com/openmicroscopy/prod-playbooks/blob/master/www/www-static.yml>`_ to consume the new release asset
 - the sysadmin team will then run the playbook to update the live website
 
 OME Blog


### PR DESCRIPTION
Staged at https://ci.openmicroscopy.org/job/CONTRIBUTING-merge-docs/ws/src/contributing/_build/html/jekyll.html#id1. Should turn [CONTRIBUTING-merge-docs](https://ci.openmicroscopy.org/job/CONTRIBUTING-merge-docs/) green.

I *think* this is correct but yell if I should have chosen `www-deploy.yml` instead.