### PR TITLE
Add annotation examples from saeri scripts

### DIFF
--- a/omero/developers/Python.rst
+++ b/omero/developers/Python.rst
@@ -353,6 +353,8 @@ Read data
 
 -  **Get Links between Objects and Annotations**
 
+::
+
     # Find Images linked to Annotation(s), move them to another Annotation
     for link in conn.getAnnotationLinks('Image', ann_ids=[ann_id]):
         print "Image:", link.getParent().name

--- a/omero/developers/Python.rst
+++ b/omero/developers/Python.rst
@@ -593,7 +593,7 @@ Write data
     with open(file_to_upload, 'w') as f:
         f.write('annotation test')
     # create the original file and file annotation (uploads the file etc.)
-    namespace = "imperial.training.demo"
+    namespace = "my.custom.demo.namespace"
     print "\nCreating an OriginalFile and FileAnnotation"
     file_ann = conn.createFileAnnfromLocalFile(
         file_to_upload, mimetype="text/plain", ns=namespace, desc=None)
@@ -612,7 +612,7 @@ Write data
     # Go through all the annotations on the Dataset. Download any file annotations
     # we find. Filter by namespace is optional
     print "\nAnnotations on Dataset:", dataset.getName()
-    namespace = "imperial.training.demo"
+    namespace = "my.custom.demo.namespace"
     for ann in dataset.listAnnotations(ns=namespace):
         if isinstance(ann, omero.gateway.FileAnnotationWrapper):
             print "File ID:", ann.getFile().getId(), ann.getFile().getName(), \

--- a/omero/developers/Python.rst
+++ b/omero/developers/Python.rst
@@ -224,10 +224,10 @@ Read data
 
 -  **Get Objects by their ID or attributes**
 
-   The first argument for conn.getObjects() or conn.getObject() is the object type.
+   The first argument for ``conn.getObjects()`` or ``conn.getObject()`` is the object type.
    This is not case sensitive. Supported types are
-   "project", "dataset", "image", "screen", "plate", "plateacquisition", "acquisition", "well",
-   "roi", "shape", "experimenter", "experimentergroup", "originalfile", "fileset", "annotation"
+   ``project``, ``dataset``, ``image``, ``screen``, ``plate``, ``plateacquisition``, ``acquisition``, ``well``,
+   ``roi``, ``shape``, ``experimenter``, ``experimentergroup``, ``originalfile``, ``fileset``, ``annotation``
 
 ::
 
@@ -242,8 +242,8 @@ Read data
 
 -  **Get different types of Annotations***
 
-   Supported types are: "tagannotation", "longannotation", "booleanannotation", "fileannotation",
-   "doubleannotation", "termannotation", "timestampannotation", "mapannotation"
+   Supported types are: ``tagannotation``, ``longannotation``, ``booleanannotation``, ``fileannotation``,
+   ``doubleannotation``, ``termannotation``, ``timestampannotation``, ``mapannotation``
 
 ::
 

--- a/omero/developers/Python.rst
+++ b/omero/developers/Python.rst
@@ -546,7 +546,7 @@ Write data
     link = omero.model.ProjectDatasetLinkI()
     # We can use a 'loaded' object, but we might get an Exception
     # link.setChild(dataset_obj)
-    # Better to use an 'unloaded' objects (loaded = False)
+    # Better to use an 'unloaded' object (loaded = False)
     link.setChild(omero.model.DatasetI(dataset_obj.id.val, False))
     link.setParent(omero.model.ProjectI(projectId, False))
     conn.getUpdateService().saveObject(link)
@@ -1346,4 +1346,3 @@ It is relatively straightforward to take the code samples above and
 re-use them in OMERO.scripts. This allows the code to be run on the
 OMERO server and called from either the OMERO.insight client or
 OMERO.web by any users of the server. See :doc:`/developers/scripts/user-guide`.
-


### PR DESCRIPTION
Add missing examples to the OMERO Python page, based on code needed by @ilamarengo 

See https://github.com/ome/ome-documentation/issues/2009

cc @jburel, @pwalczysko