### PR TITLE
Drop trac link

### DIFF
--- a/omero/developers/Modules/TempFileManager.rst
+++ b/omero/developers/Modules/TempFileManager.rst
@@ -68,7 +68,3 @@ and
 .. note::
 
     All contents of the generated directory will be deleted.
-
-.. seealso::
-
-    :ticket:`1534`


### PR DESCRIPTION
[Today's doc build failures](https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-docs/122/console) are linked to:

```
10:01:13      [exec] (line   74) broken    https://trac.openmicroscopy.org/ome/ticket/1534 - 500 Server Error: Internal Server Error for url: https://trac.openmicroscopy.org/ome/ticket/1534
```

Things I looked at:
 - httpd logs
 - postgresql logs
 - the ticket itself in PG

Likely editing the trac ticket would help to prevent the error, but I assume the context is no longer valuable. An alternative would be to turn trac into a static site like phpbb, but doing so will likely trigger a number of these issues that we will also have to deal with.

cc: @sbesson @manics 