### PR TITLE
web app docker template

### DIFF
--- a/omero/developers/Web/CSRF.rst
+++ b/omero/developers/Web/CSRF.rst
@@ -34,11 +34,8 @@ POST, PUT and DELETE. These requests can then be protected as follows:
     that would cause the CSRF token to be leaked, leading to a vulnerability.
 
 - On each XMLHttpRequest set a custom X-CSRFToken header to the value of the
-  CSRF token and pass the CSRF token in data with every AJAX POST request. If
-  your custom template already benefits from
-  :ref:`loading built-in jQuery <jquery_and_jquery_ui>` template you do not need to do
-  anything as it already loads ``webgateway/js/ome.csrf.js``. Otherwise simply
-  import the script as follows:
+  CSRF token and pass the CSRF token in data with every AJAX POST request.
+  You can import a jQuery-based script to do this as follows:
 
   ::
 

--- a/omero/developers/Web/CreateApp.rst
+++ b/omero/developers/Web/CreateApp.rst
@@ -17,24 +17,16 @@ follow the install instructions under :doc:`Deployment`.
 If you want to make changes to the OMERO.web code itself, go to
 :doc:`/developers/Web/EditingOmeroWeb`.
 
-Create an app from the template example
----------------------------------------
+Clone the examples repository
+-----------------------------
 
-To get started quickly, we are going to create an app from a template repository
+To get started quickly, we are going to use a repository
 that contains several example OMERO.web apps.
-
-Go to the template repository
-`omero-web-apps-examples <https://github.com/will-moore/omero-web-apps-examples>`_.
-Click 'Use this template' as `described here
-<https://help.github.com/en/articles/creating-a-repository-from-a-template>`_
-and choose a name for your new repo, for example ``omero-demo-webapps``.
-
-Go to the directory where you want your app to live and clone it:
 
 ::
 
     $ cd /path/to/dir/
-    $ git clone https://github.com/<username>/omero-demo-webapps
+    $ git clone https://github.com/will-moore/omero-web-apps-examples
 
 Run your app with OMERO.web in a Docker container
 -------------------------------------------------
@@ -42,23 +34,28 @@ Run your app with OMERO.web in a Docker container
 We will run the simplest example app from the repo. This is called
 ``minimal_webapp``.
 
-You can now use `omero-web-docker <https://github.com/ome/omero-web-docker/>`_
+You can use `omero-web-docker <https://github.com/ome/omero-web-docker/>`_
 to run the app. Here we add ``minimal_webapp`` to the installed apps and map the
-directory to the ``site-packages`` directory in the Docker instance so that our
+app directory to the ``site-packages`` directory in the Docker instance so that our
 ``minimal_webapp`` module can be imported.
 We also choose the OMERO server we want to connect to.
 You need to edit the ``demo.openmicroscopy.org`` and ``/path/to/dir/`` in the
-following commands:
+following variables:
 
 ::
 
+    # Set some variables
     $ host=demo.openmicroscopy.org
-    $ pwd=$(pwd)
-    $ echo "config append omero.web.apps '\"minimal_webapp\"'" > config.omero
-    $ appdir=/Users/willadmin/Desktop/WEB-APP-EXAMPLES/omero-web-apps-examples/minimal-webapp
-    $ sp=/opt/omero/web/venv/lib/python2.7/site-packages
-    $ docker run -it -e OMEROHOST=demo.openmicroscopy.org -p 8000:4080 -v $appdir/minimal_webapp:$sp/minimal_webapp -v $pwd/config.omero:/opt/omero/web/config/config.omero openmicroscopy/omero-web-standalone
+    $ appdir=/path/to/dir/omero-web-apps-examples/minimal-webapp/minimal_webapp
+    $ docker_appdir=/opt/omero/web/venv/lib/python2.7/site-packages/minimal_webapp
+    $ config=$(pwd)/config.omero
+    $ docker_config=/opt/omero/web/config/config.omero
 
+    # Create a config file to add "minimal_webapp" to omero.web.apps
+    $ echo "config append omero.web.apps '\"minimal_webapp\"'" > $config
+
+    # Run docker container
+    $ docker run -it -e OMEROHOST=$host -p 4080:4080 -v $appdir:$docker_appdir -v $config:$docker_config openmicroscopy/omero-web-standalone
 
 This will run Docker in the foreground, showing the output in your terminal and allowing you to
 kill the container with Ctrl-C. You should see the following lines in the output, indicating
@@ -97,7 +94,7 @@ be added to the ``sys.path``.
     /absolute-path/to-your/Virtual/<env_name>/bin/python
 
     # Create a path configuration file .pth in site-packages
-    $ echo /path/to/dir/omero-demo-webapps/minimal-webapp >> /absolute-path/to-your/Virtual/<env_name>/lib/python2.7/site-packages/minimal_webapp.pth
+    $ echo /path/to/dir/omero-web-apps-examples/minimal-webapp >> /absolute-path/to-your/Virtual/<env_name>/lib/python2.7/site-packages/minimal_webapp.pth
 
 You also need to add your app to the :property:`omero.web.apps` setting:
 
@@ -107,23 +104,45 @@ You also need to add your app to the :property:`omero.web.apps` setting:
 
 ::
 
-    $ bin/omero config append omero.web.apps '"<appname>"'
+    $ bin/omero config append omero.web.apps '"minimal_webapp"'
 
 
-Exploring your app
-------------------
+Exploring the app
+-----------------
 
-The ``minimal_wepp app`` code is well documented to explain
+The ``minimal_webapp`` code is well documented to explain
 how the app is working.
 Briefly, the app supports a single URL defined in
-``minimal_webapp/urls.py`` which maps to the ``index`` fuction
+``minimal_webapp/urls.py`` which maps to the ``index`` function
 within ``minimal_webapp/views.py``. This uses the connection to
 OMERO, ``conn`` to load the current user's name and passes this
 to the ``index.html`` template to render the page.
 
 This page also includes the static ``app.js`` and ``app.css`` files.
-JavaScript is used to load Projects from the JSON API and
+JavaScript is used to load Projects from the :doc:`/developers/json-api` and
 display them on the page.
+
+Create an app from the template example
+---------------------------------------
+
+If you want to create your own app, you can use the example
+as a template.
+
+Go to the template repository
+`omero-web-apps-examples <https://github.com/will-moore/omero-web-apps-examples>`_.
+Click 'Use this template' as `described here
+<https://help.github.com/en/articles/creating-a-repository-from-a-template>`_
+and choose a name for your new repo, for example ``my_app``.
+
+Go to the directory where you want your app to live and clone it.
+Then run as above using a different ``appdir`` variable:
+
+::
+
+    $ cd /path/to/dir/
+    $ git clone https://github.com/<username>/my_app
+    $ appdir=/path/to/dir/my_app/minimal-webapp/minimal_webapp
+
 
 App settings
 ------------

--- a/omero/developers/Web/CreateApp.rst
+++ b/omero/developers/Web/CreateApp.rst
@@ -53,7 +53,12 @@ following commands:
 ::
 
     $ host=demo.openmicroscopy.org
-    $ docker run -it -e OMEROHOST=$host -p 4080:4080 -e CONFIG_omero_web_apps='["minimal_webapp"]' -v /path/to/dir/omero-demo-webapps/minimal-webapp/minimal_webapp:/opt/omero/web/venv/lib/python2.7/site-packages/minimal_webapp openmicroscopy/omero-web-standalone
+    $ pwd=$(pwd)
+    $ echo "config append omero.web.apps '\"minimal_webapp\"'" > config.omero
+    $ appdir=/Users/willadmin/Desktop/WEB-APP-EXAMPLES/omero-web-apps-examples/minimal-webapp
+    $ sp=/opt/omero/web/venv/lib/python2.7/site-packages
+    $ docker run -it -e OMEROHOST=demo.openmicroscopy.org -p 8000:4080 -v $appdir/minimal_webapp:$sp/minimal_webapp -v $pwd/config.omero:/opt/omero/web/config/config.omero openmicroscopy/omero-web-standalone
+
 
 This will run Docker in the foreground, showing the output in your terminal and allowing you to
 kill the container with Ctrl-C. You should see the following lines in the output, indicating

--- a/omero/developers/Web/CreateApp.rst
+++ b/omero/developers/Web/CreateApp.rst
@@ -25,8 +25,7 @@ that contains several example OMERO.web apps.
 
 ::
 
-    $ cd /path/to/dir/
-    $ git clone https://github.com/will-moore/omero-web-apps-examples
+    $ git clone git@github.com:ome/omero-web-apps-examples.git
 
 Run your app with OMERO.web in a Docker container
 -------------------------------------------------
@@ -36,25 +35,30 @@ We will run the simplest example app from the repo. This is called
 
 You can use `omero-web-docker <https://github.com/ome/omero-web-docker/>`_
 to run the app. Here we add ``minimal_webapp`` to the installed apps and map the
-app directory to the ``site-packages`` directory in the Docker instance so that our
-``minimal_webapp`` module can be imported.
-We also choose the OMERO server we want to connect to.
-You need to edit the ``demo.openmicroscopy.org`` and ``/path/to/dir/`` in the
-following variables:
+app directory to the ``site-packages`` directory in the Docker instance so that
+python can import our ``minimal_webapp`` module.
 
 ::
 
-    # Set some variables
+    # You need to be in the project directory for this to work.
+    # cd omero-web-apps-examples/
+
+    # The OMERO server we want to connect to.
     $ host=demo.openmicroscopy.org
-    $ appdir=/path/to/dir/omero-web-apps-examples/minimal-webapp/minimal_webapp
+
+    # Path to the python module for the app.
+    $ appdir=$(pwd)/minimal-webapp/minimal_webapp
+
+    # Location within Docker instance we want to link the app, so it can be imported.
     $ docker_appdir=/opt/omero/web/venv/lib/python2.7/site-packages/minimal_webapp
+
+    # This example config file installs "minimal_webapp". See the file for more details.
     $ config=$(pwd)/config.omero
+
+    # Location within Docker instance we want to mount the config.
     $ docker_config=/opt/omero/web/config/config.omero
 
-    # Create a config file to add "minimal_webapp" to omero.web.apps
-    $ echo "config append omero.web.apps '\"minimal_webapp\"'" > $config
-
-    # Run docker container
+    # Run docker container.
     $ docker run -it -e OMEROHOST=$host -p 4080:4080 -v $appdir:$docker_appdir -v $config:$docker_config openmicroscopy/omero-web-standalone
 
 This will run Docker in the foreground, showing the output in your terminal and allowing you to
@@ -141,11 +145,9 @@ that your app can be imported as before.
 
 ::
 
-    $ cd /path/to/dir/
     $ git clone https://github.com/<username>/my_app
+    $ cd my_app
 
-    # To run with Docker, update this path
-    $ appdir=/path/to/dir/my_app/minimal-webapp/minimal_webapp
     # Then run as above...
 
 

--- a/omero/developers/Web/CreateApp.rst
+++ b/omero/developers/Web/CreateApp.rst
@@ -65,6 +65,7 @@ that OMERO.web is starting and the static files from your app are being included
 
     ...
     Starting OMERO.web
+    ...
     Copying '/opt/omero/web/venv/lib/python2.7/site-packages/minimal_webapp/static/minimal_webapp/app.css'
     Copying '/opt/omero/web/venv/lib/python2.7/site-packages/minimal_webapp/static/minimal_webapp/app.js'
     ...
@@ -135,42 +136,46 @@ Click 'Use this template' as `described here
 and choose a name for your new repo, for example ``my_app``.
 
 Go to the directory where you want your app to live and clone it.
-Then run as above using a different ``appdir`` variable:
+Then run as above with Docker or locally-installed OMERO.web, making sure
+that your app can be imported as before.
 
 ::
 
     $ cd /path/to/dir/
     $ git clone https://github.com/<username>/my_app
+
+    # To run with Docker, update this path
     $ appdir=/path/to/dir/my_app/minimal-webapp/minimal_webapp
+    # Then run as above...
 
 
 App settings
 ------------
 
 You can add settings to your app that allow configuration via the command line
-in the same way as for the base OMERO.web.
-The list of ``CUSTOM_SETTINGS_MAPPINGS`` in
-:sourcedir:`components/tools/OmeroWeb/omeroweb/settings.py` is a good
-source for examples of the different data types and parsers you can use.
+in the same way as for the base OMERO.web. The list of ``CUSTOM_SETTINGS_MAPPINGS`` in
+`settings.py <https://github.com/ome/omero-web/blob/master/omeroweb/settings.py>`_
+is a good source for examples of the different data types and parsers you can use.
 
-For example, if you want to create a user-defined setting organization-appname.foo,
+For example, if you want to create a user-defined setting appname.foo,
 that contains a dictionary of key-value pairs, you can add to
-``CUSTOM_SETTINGS_MAPPINGS`` in ``organization-appname/settings.py``::
+``CUSTOM_SETTINGS_MAPPINGS`` in ``appname/settings.py``::
 
     import json
     CUSTOM_SETTINGS_MAPPINGS = {
-        "omero.web.organization-appname.foo": ["FOO", '{"key": "val"}', json.loads]
+        "omero.web.appname.foo": ["FOO", '{"key": "val"}', json.loads]
     }
 
 From somewhere else in your app, you can then access the settings::
 
-    from organization-appname import settings
+    from appname import settings
 
     print settings.FOO
 
 Users can then configure this on the command line as follows::
 
-    $ bin/omero config set omero.web.organization-appname.foo '{"userkey": "userval"}'
+    $ bin/omero config set omero.web.appname.foo '{"userkey": "userval"}'
+
 
 Linking from Webclient
 ----------------------

--- a/omero/developers/Web/CreateApp.rst
+++ b/omero/developers/Web/CreateApp.rst
@@ -4,9 +4,6 @@ Creating an app
 The Django web site has a very good :djangodoc:`tutorial <intro/tutorial01/>`
 to get you familiar with the Django framework. The more you know about
 Django, the easier you will find it working with the OmeroWeb framework.
-One major feature of Django that we do not use in OmeroWeb is the Django
-database mapping, since all data comes from the OMERO server and is
-saved back there.
 
 All official OMERO applications can be installed from PyPI_.
 
@@ -23,108 +20,105 @@ If you want to make changes to the OMERO.web code itself, go to
 Create an app from the template example
 ---------------------------------------
 
-Go to `https://github.com/will-moore/omero-web-apps-examples <https://github.com/will-moore/omero-web-apps-examples>`_.
+To get started quickly, we are going to create an app from a template repository
+that contains several example OMERO.web apps.
+
+Go to the template repository
+`omero-web-apps-examples <https://github.com/will-moore/omero-web-apps-examples>`_.
 Click 'Use this template' as `described here
 <https://help.github.com/en/articles/creating-a-repository-from-a-template>`_
-and choose a name for your new app, for example ``omero-demo-webapp``.
+and choose a name for your new repo, for example ``omero-demo-webapps``.
 
 Go to the directory where you want your app to live and clone it:
 
 ::
 
     $ cd /path/to/dir/
-    $ git clone https://github.com/will-moore/omero-demo-webapp
+    $ git clone https://github.com/<username>/omero-demo-webapps
+
+Run your app with OMERO.web in a Docker container
+-------------------------------------------------
+
+We will run the simplest example app from the repo. This is called
+``minimal_webapp``.
 
 You can now use `omero-web-docker <https://github.com/ome/omero-web-docker/>`_
 to run the app. Here we add ``minimal_webapp`` to the installed apps and map the
 directory to the ``site-packages`` directory in the Docker instance so that our
-app is on the :envvar:`PYTHONPATH`, described in more detail below.
+``minimal_webapp`` module can be imported.
 We also choose the OMERO server we want to connect to.
 You need to edit the ``demo.openmicroscopy.org`` and ``/path/to/dir/`` in the
-following command:
+following commands:
 
 ::
 
-    $ docker run -it -e OMEROHOST=demo.openmicroscopy.org -p 4080:4080 -e CONFIG_omero_web_apps='["minimal_webapp"]' -v /path/to/dir/omero-demo-webapp/minimal-webapp/minimal_webapp:/opt/omero/web/venv/lib/python2.7/site-packages/minimal_webapp openmicroscopy/omero-web-standalone
+    $ host=demo.openmicroscopy.org
+    $ docker run -it -e OMEROHOST=$host -p 4080:4080 -e CONFIG_omero_web_apps='["minimal_webapp"]' -v /path/to/dir/omero-demo-webapps/minimal-webapp/minimal_webapp:/opt/omero/web/venv/lib/python2.7/site-packages/minimal_webapp openmicroscopy/omero-web-standalone
 
-This will run Docker interactively in the terminal.
+This will run Docker in the foreground, showing the output in your terminal and allowing you to
+kill the container with Ctrl-C. You should see the following lines in the output, indicating
+that OMERO.web is starting and the static files from your app are being included.
+
+::
+
+    ...
+    Starting OMERO.web
+    Copying '/opt/omero/web/venv/lib/python2.7/site-packages/minimal_webapp/static/minimal_webapp/app.css'
+    Copying '/opt/omero/web/venv/lib/python2.7/site-packages/minimal_webapp/static/minimal_webapp/app.js'
+    ...
+
 Now go to `http://localhost:4080/minimal_webapp/ <http://localhost:4080/minimal_webapp/>`_
 in your browser.
 You should be redirected to the login screen and then back to the ``minimal_webapp``
 page which will display your Name and list your Projects.
 
-Adding your app to your PYTHONPATH
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Run your app with locally-installed OMERO.web
+---------------------------------------------
 
-Your Django app is the directory that contains the ``urls.py`` and ``views.py``. In the
-example above, this is the ``minimal_webapp`` directory.
-This needs to be *within* a directory that is on your :envvar:`PYTHONPATH` or
-`python search path <https://docs.python.org/2/install/index.html#modifying-python-s-search-path>`_.
+If you have installed OMERO.web locally in a virtual environment
+(instead of using Docker), you can add a
+`path configuration file <https://docs.python.org/2/install/index.html#modifying-python-s-search-path>`_
+to the ``site-packages`` directory to allow the
+``minimal_webapp`` module to be imported.
 
-In the Docker example above, we mount the ``minimal_webapp`` directory within the
-``site-packages`` of the Docker image.
-
-If you have installed OMERO.web locally in a virtual environment, you can add a
-path configuration file to the ``site-packages`` directory.
-This must specify the folder that *contains* ``minimal_webapp``
+You need to specify the directory that *contains* ``minimal_webapp``
 (in this case it is the parent ``minimal-webapp`` directory) to
 be added to the ``sys.path``.
 
 ::
 
-    # Find where your python is
+    # Find where your python is (run this within your venv)
     $ which python
-    /absolute-path/to-your/Virtual/omero/bin/python
+    /absolute-path/to-your/Virtual/<env_name>/bin/python
 
     # Create a path configuration file .pth in site-packages
-    $ echo /path/to/dir/omero-demo-webapp/minimal-webapp >> /absolute-path/to-your/Virtual/omero/lib/python2.7/site-packages/minimal_webapp.pth
+    $ echo /path/to/dir/omero-demo-webapps/minimal-webapp >> /absolute-path/to-your/Virtual/<env_name>/lib/python2.7/site-packages/minimal_webapp.pth
 
-Add your app to OMERO.web
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-:property:`omero.web.apps` adds your custom application to the ``INSTALLED_APPS``,
-so that URLs are registered etc.
+You also need to add your app to the :property:`omero.web.apps` setting:
 
 .. note::
 
-    Here we use single quotes around double quotes, since we are
-    passing a double-quoted string as a json object.
+    Here we use single quotes around double quotes.
 
 ::
 
     $ bin/omero config append omero.web.apps '"<appname>"'
 
-Make your app installable from PyPI
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This is not required but it is recommended to make your app
-installable from PyPI. If you opt to do so, a few files need to be added:
+Exploring your app
+------------------
 
-- ``setup.py`` - a set-up file used to configure various aspects of the app and also used as a command line interface for packaging the app
+The ``minimal_wepp app`` code is well documented to explain
+how the app is working.
+Briefly, the app supports a single URL defined in
+``minimal_webapp/urls.py`` which maps to the ``index`` fuction
+within ``minimal_webapp/views.py``. This uses the connection to
+OMERO, ``conn`` to load the current user's name and passes this
+to the ``index.html`` template to render the page.
 
-- ``setup.cfg`` - a configuration file that contains option defaults for ``setup.py`` commands
-
-- ``MANIFEST.in`` - a file needed in certain cases to package files not automatically included
-
-See `Packaging and Distributing Projects <https://packaging.python.org/guides/distributing-packages-using-setuptools/>`_ for more details.
-
-Configuring your app name and label
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-New in OMERO 5.3.0, we support the option of configuring your OMERO.web app with a
-name and label.
-See Django `Configuring Applications <https://docs.djangoproject.com/en/1.8/ref/applications/#configuring-applications>`_.
-This allows the URL to an app to be different from its name.
-For example, OMERO.figure app is named ``omero_figure`` but the url is simply ``/figure/``
-as configured by `__init__.py <https://github.com/ome/omero-figure/blob/master/omero_figure/__init__.py>`_
-and `apps.py <https://github.com/ome/omero-figure/blob/master/omero_figure/apps.py>`_.
-
-
--  **views.py**
-   Here we are using the ``@login_required`` decorator to
-   retrieve a connection to OMERO from the session key in the HTTP
-   request (or provide a login page and redirect here). ``conn`` is passed
-   to the method arguments.
+This page also includes the static ``app.js`` and ``app.css`` files.
+JavaScript is used to load Projects from the JSON API and
+display them on the page.
 
 App settings
 ------------
@@ -159,3 +153,10 @@ Linking from Webclient
 
 If you want to add links to your app from the webclient, a number of options are
 described on :doc:`/developers/Web/LinkingFromWebclient`.
+
+
+Releasing your app
+------------------
+
+The :doc:`/developers/Web/ReleaseApp` page has some useful steps to
+take when you are preparing to release your app.

--- a/omero/developers/Web/CreateApp.rst
+++ b/omero/developers/Web/CreateApp.rst
@@ -14,26 +14,49 @@ All official OMERO applications can be installed from PyPI_.
 Getting set up
 --------------
 
-In order to deploy OMERO.web in a development or testing environment please 
+In order to deploy OMERO.web in a development or testing environment,
+you can use Docker as described below (recommended) or 
 follow the instructions under :doc:`Deployment`.
-
-You should make sure that you can access the webclient on
-your local machine before starting to develop your own code. Be sure to
-use the correct port number, e.g.
-
--  `http://localhost:4080/webclient/ <http://localhost:4080/webclient/>`_
-
-When you edit and save your app, Django will automatically detect this and you
-only need to refresh your browser to see the changes.
 
 If you want to make changes to the OMERO.web code itself, go to
 :doc:`/developers/Web/EditingOmeroWeb`.
 
-You can place your app anywhere on your :envvar:`PYTHONPATH`,
-as long as it can be imported by OMERO.web.
+Use the app template
+--------------------
+
+Go to `https://github.com/will-moore/omero-web-apps-examples <https://github.com/will-moore/omero-web-apps-examples>`_.
+Click 'Use this template' as `described here
+<https://help.github.com/en/articles/creating-a-repository-from-a-template>`_.
+
+Choose a name for your new app, for example ``omero-demo-webapp``.
+Go to the directory where you want your app to live and clone it:
+
+::
+
+    $ cd /path/to/dir/
+    $ git clone https://github.com/will-moore/omero-demo-webapp
+
+You can now use `omero-web-docker <https://github.com/ome/omero-web-docker/>`_
+to run this. Here we add ``minimal_webapp`` to the installed apps and map the
+directory to the ``site-packages`` directory in the Docker instance.
+We also choose the OMERO server we want to connect to.
+You need to edit the ``demo.openmicroscopy.org`` and ``/path/to/dir/`` in the
+following command:
+
+::
+
+    $ docker run -it -e OMEROHOST=demo.openmicroscopy.org -p 4080:4080 -e CONFIG_omero_web_apps='["minimal_webapp"]' -v /path/to/dir/omero-demo-webapp/minimal-webapp/minimal_webapp:/opt/omero/web/venv/lib/python2.7/site-packages/minimal_webapp openmicroscopy/omero-web-standalone
+
+This will run Docker interactively in the terminal.
+Now go to `http://localhost:4080/minimal_webapp/ <http://localhost:4080/minimal_webapp/>`_.
+You should be redirected to the login screen and then back to the ``minimal_webapp``
+page which will display your Name and list your Projects.
 
 Creating an app
 ---------------
+
+You can place your app anywhere on your :envvar:`PYTHONPATH`,
+as long as it can be imported by OMERO.web.
 
 We suggest you use `GitHub <https://github.com/>`_ (as we do) since it is much easier for us to
 help you with any problems you have if we can see your code. The steps below

--- a/omero/developers/Web/CreateApp.rst
+++ b/omero/developers/Web/CreateApp.rst
@@ -22,6 +22,7 @@ Clone the examples repository
 
 To get started quickly, we are going to use a repository
 that contains several example OMERO.web apps.
+Clone the app to a location of your choice:
 
 ::
 
@@ -33,7 +34,7 @@ Run your app with OMERO.web in a Docker container
 We will run the simplest example app from the repo. This is called
 ``minimal_webapp``.
 
-You can use `omero-web-docker <https://github.com/ome/omero-web-docker/>`_
+The following walk-through uses `omero-web-docker <https://github.com/ome/omero-web-docker/>`_
 to run the app. Here we add ``minimal_webapp`` to the installed apps and map the
 app directory to the ``site-packages`` directory in the Docker instance so that
 python can import our ``minimal_webapp`` module.
@@ -59,7 +60,7 @@ python can import our ``minimal_webapp`` module.
     $ docker_config=/opt/omero/web/config/config.omero
 
     # Run docker container.
-    $ docker run -it -e OMEROHOST=$host -p 4080:4080 -v $appdir:$docker_appdir -v $config:$docker_config openmicroscopy/omero-web-standalone
+    $ docker run -it --rm -e OMEROHOST=$host -p 4080:4080 -v $appdir:$docker_appdir -v $config:$docker_config openmicroscopy/omero-web-standalone
 
 This will run Docker in the foreground, showing the output in your terminal and allowing you to
 kill the container with Ctrl-C. You should see the following lines in the output, indicating
@@ -68,11 +69,10 @@ that OMERO.web is starting and the static files from your app are being included
 ::
 
     ...
-    Starting OMERO.web
-    ...
     Copying '/opt/omero/web/venv/lib/python2.7/site-packages/minimal_webapp/static/minimal_webapp/app.css'
     Copying '/opt/omero/web/venv/lib/python2.7/site-packages/minimal_webapp/static/minimal_webapp/app.js'
     ...
+    Starting OMERO.web...
 
 Now go to `http://localhost:4080/minimal_webapp/ <http://localhost:4080/minimal_webapp/>`_
 in your browser.

--- a/omero/developers/Web/CreateApp.rst
+++ b/omero/developers/Web/CreateApp.rst
@@ -11,7 +11,7 @@ Getting set up
 --------------
 
 In order to deploy OMERO.web in a development or testing environment,
-you can use Docker as described below (recommended) or 
+you can use Docker as described below or
 follow the install instructions under :doc:`Deployment`.
 
 If you want to make changes to the OMERO.web code itself, go to
@@ -28,11 +28,42 @@ Clone the app to a location of your choice:
 
     $ git clone git@github.com:ome/omero-web-apps-examples.git
 
-Run your app with OMERO.web in a Docker container
--------------------------------------------------
-
 We will run the simplest example app from the repo. This is called
 ``minimal_webapp``.
+
+Run your app with locally-installed OMERO.web
+---------------------------------------------
+
+If you have installed ``omero-web`` locally in a virtual environment
+as described in :doc:`Deployment`, you can simply install
+the minimal-webapp example via pip:
+
+::
+
+    $ cd omero-web-apps-examples/minimal-webapp
+    $ pip install -e .
+
+This installs the source code directly, allowing you to work on
+the installed code.
+
+You also need to add your app to the :property:`omero.web.apps` setting:
+
+.. note::
+
+    Here we use single quotes around double quotes.
+
+::
+
+    $ bin/omero config append omero.web.apps '"minimal_webapp"'
+
+Now you can restart your omero-web server and go to
+`http://localhost:4080/minimal_webapp/ <http://localhost:4080/minimal_webapp/>`_
+in your browser.
+You should be redirected to the login screen and then back to the ``minimal_webapp``
+page which will display your Name and list your Projects.
+
+Run your app with OMERO.web in a Docker container
+-------------------------------------------------
 
 The following walk-through uses `omero-web-docker <https://github.com/ome/omero-web-docker/>`_
 to run the app. Here we add ``minimal_webapp`` to the installed apps and map the
@@ -78,39 +109,6 @@ Now go to `http://localhost:4080/minimal_webapp/ <http://localhost:4080/minimal_
 in your browser.
 You should be redirected to the login screen and then back to the ``minimal_webapp``
 page which will display your Name and list your Projects.
-
-Run your app with locally-installed OMERO.web
----------------------------------------------
-
-If you have installed OMERO.web locally in a virtual environment
-(instead of using Docker), you can add a
-`path configuration file <https://docs.python.org/2/install/index.html#modifying-python-s-search-path>`_
-to the ``site-packages`` directory to allow the
-``minimal_webapp`` module to be imported.
-
-You need to specify the directory that *contains* ``minimal_webapp``
-(in this case it is the parent ``minimal-webapp`` directory) to
-be added to the ``sys.path``.
-
-::
-
-    # Find where your python is (run this within your venv)
-    $ which python
-    /absolute-path/to-your/Virtual/<env_name>/bin/python
-
-    # Create a path configuration file .pth in site-packages
-    $ echo /path/to/dir/omero-web-apps-examples/minimal-webapp >> /absolute-path/to-your/Virtual/<env_name>/lib/python2.7/site-packages/minimal_webapp.pth
-
-You also need to add your app to the :property:`omero.web.apps` setting:
-
-.. note::
-
-    Here we use single quotes around double quotes.
-
-::
-
-    $ bin/omero config append omero.web.apps '"minimal_webapp"'
-
 
 Exploring the app
 -----------------

--- a/omero/developers/Web/Deployment.rst
+++ b/omero/developers/Web/Deployment.rst
@@ -5,17 +5,15 @@ Getting set up
 --------------
 
 You will need to have an OMERO server running that you can connect to. This
-could be on your own machine or you can connect to an
-external OMERO server.
+could be on your own machine ``localhost`` or you can connect to a
+remote OMERO server.
 
-Using Docker
-------------
+The preferred option for developing OMERO.web apps is to install
+``omero-web`` on your machine as described below.
 
-If you are not working on the OMERO.web code itself, you can use
+However, it is also possible to use
 `omero-web-docker <https://github.com/ome/omero-web-docker/>`_
-to run OMERO.web. This allows you to develop your own OMERO.web
-app without needing to install OMERO.web on your development machine.
-
+to run OMERO.web in a Docker container.
 If you are using this option, you can go directly to the
 :doc:`/developers/Web/CreateApp` page which describes this process.
 
@@ -23,7 +21,7 @@ Installing OMERO.web
 --------------------
 
 From OMERO 5.6.0 release, the ``omero-web`` library supports Python 3 and
-can be installed via ``pip``. We recommend you use a virtual environment:
+can be installed via ``pip``. We recommend you use a virtual environment::
 
     $ python3 -m venv py3_venv
     $ source py3_venv/bin/activate
@@ -39,9 +37,9 @@ Using the lightweight development server
 
 All that is required to use the Django lightweight development server
 is to set the :property:`omero.web.application_server` configuration option,
-turn :property:`omero.web.debug` on.
-We also configure a remote server to connect to, and then
-start the server up.
+and turn :property:`omero.web.debug` on.
+If you want to connect to a remote server, add that as shown.
+Then start up the development server to run in the foreground:
 
 ::
 
@@ -55,9 +53,12 @@ start the server up.
     Validating models...
 
     0 errors found
-    Django version 1.8, using settings 'omeroweb.settings'
+    Django version 1.11, using settings 'omeroweb.settings'
     Starting development server at http://127.0.0.1:4080/
     Quit the server with CONTROL-C.
+
+You should now be able to open http://localhost:4080 in your browser,
+choose the OMERO server and login.
 
 Using WSGI
 ----------

--- a/omero/developers/Web/Deployment.rst
+++ b/omero/developers/Web/Deployment.rst
@@ -22,33 +22,33 @@ If you are using this option, you can go directly to the
 Installing OMERO.web
 --------------------
 
-You will need to follow the install instructions for OMERO.web,
-either as a standalone install, or as part of the OMERO.server install.
+From OMERO 5.6.0 release, the ``omero-web`` library supports Python 3 and
+can be installed via ``pip``. We recommend you use a virtual environment:
 
-If you want to connect to a remote server, you can add the server to the
-:property:`omero.web.server_list` and choose that server when you log in.
-You should enable :property:`omero.web.debug` and start a lightweight
-development Web server on your local machine.
+    $ python3 -m venv py3_venv
+    $ source py3_venv/bin/activate
 
-.. note:: Since OMERO 5.2, the OMERO.web framework no longer bundles
-    a copy of the Django package, instead manual installation of
-    the Django dependency is required. It is highly recommended to use
-    `Django 1.8`_ (LTS) which requires Python 2.7. For more information
-    see :ref:`python-requirements` on the
-    :doc:`/sysadmins/version-requirements` page.
+    $ pip install "omero-web==v5.6.dev5"
+
+    Successfully installed Django-1.11.26 Pillow-6.2.1 django-pipeline-1.6.14
+    future-0.18.2 gunicorn-20.0.0 omero-marshal-0.6.3 omero-py-5.6.dev5
+    omero-web-5.6.dev5 pytz-2019.3 zeroc-ice-3.6.5
 
 Using the lightweight development server
 ----------------------------------------
 
 All that is required to use the Django lightweight development server
 is to set the :property:`omero.web.application_server` configuration option,
-turn :property:`omero.web.debug` on and start the server up:
+turn :property:`omero.web.debug` on.
+We also configure a remote server to connect to, and then
+start the server up.
 
 ::
 
-    $ bin/omero config set omero.web.application_server development
-    $ bin/omero config set omero.web.debug True
-    $ bin/omero web start
+    $ omero config set omero.web.application_server development
+    $ omero config set omero.web.debug True
+    $ omero config append omero.web.server_list `["server.address", 4064, "name"]
+    $ omero web start
     INFO:__main__:Application Starting...
     INFO:root:Processing custom settings for module omeroweb.settings
     ...
@@ -69,8 +69,8 @@ using the following commands:
 
 ::
 
-    $ bin/omero config set omero.web.application_server 'wsgi-tcp'
-    $ bin/omero web config nginx-development > nginx-development.conf
+    $ omero config set omero.web.application_server 'wsgi-tcp'
+    $ omero web config nginx-development > nginx-development.conf
 
 Start NGINX and the Gunicorn worker processes running one thread
 listening on 127.0.0.1:4080 that will autoreload on source change:
@@ -78,8 +78,8 @@ listening on 127.0.0.1:4080 that will autoreload on source change:
 ::
 
     $ nginx -c $PWD/nginx-development.conf
-    $ bin/omero config set omero.web.application_server.max_requests 1
-    $ bin/omero config set omero.web.wsgi_args -- "--reload"
-    $ bin/omero web start
+    $ omero config set omero.web.application_server.max_requests 1
+    $ omero config set omero.web.wsgi_args -- "--reload"
+    $ omero web start
 
 Next: Get started by :doc:`/developers/Web/CreateApp`....

--- a/omero/developers/Web/Deployment.rst
+++ b/omero/developers/Web/Deployment.rst
@@ -5,8 +5,27 @@ Getting set up
 --------------
 
 You will need to have an OMERO server running that you can connect to. This
-will typically be on your own machine, although you can also connect to an
-external OMERO server. You can add the server to the
+could be on your own machine or you can connect to an
+external OMERO server.
+
+Using Docker
+------------
+
+If you are not working on the OMERO.web code itself, you can use
+`omero-web-docker <https://github.com/ome/omero-web-docker/>`_
+to run OMERO.web. This allows you to develop your own OMERO.web
+app without needing to install OMERO.web on your development machine.
+
+If you are using this option, you can go directly to the
+:doc:`/developers/Web/CreateApp` page which describes this process.
+
+Installing OMERO.web
+--------------------
+
+You will need to follow the install instructions for OMERO.web,
+either as a standalone install, or as part of the OMERO.server install.
+
+If you want to connect to a remote server, you can add the server to the
 :property:`omero.web.server_list` and choose that server when you log in.
 You should enable :property:`omero.web.debug` and start a lightweight
 development Web server on your local machine.

--- a/omero/developers/Web/ReleaseApp.rst
+++ b/omero/developers/Web/ReleaseApp.rst
@@ -1,0 +1,32 @@
+Release an app
+==============
+
+When you are ready to share your app with others, you can improve
+the install process by making your app installable via ``pip``.
+You may also wish to configure the app label to make the app URL
+more user-friendly.
+
+Make your app installable from PyPI
+-----------------------------------
+
+This is not required but it is recommended to make your app
+installable from PyPI. If you opt to do so, a few files need to be added:
+
+- ``setup.py`` - a set-up file used to configure various aspects of the app and also used as a command line interface for packaging the app
+
+- ``setup.cfg`` - a configuration file that contains option defaults for ``setup.py`` commands
+
+- ``MANIFEST.in`` - a file needed in certain cases to package files not automatically included
+
+See `Packaging and Distributing Projects <https://packaging.python.org/guides/distributing-packages-using-setuptools/>`_ for more details.
+
+Configuring your app name and label
+-----------------------------------
+
+We support the option of configuring your OMERO.web app with a name and label.
+See Django `Configuring Applications <https://docs.djangoproject.com/en/1.8/ref/applications/#configuring-applications>`_.
+This allows the URL to an app to be different from its name.
+For example, OMERO.figure app is named ``omero_figure`` but the url is simply ``/figure/``
+as configured by `__init__.py <https://github.com/ome/omero-figure/blob/master/omero_figure/__init__.py>`_
+and `apps.py <https://github.com/ome/omero-figure/blob/master/omero_figure/apps.py>`_.
+

--- a/omero/developers/Web/WritingTemplates.rst
+++ b/omero/developers/Web/WritingTemplates.rst
@@ -34,7 +34,7 @@ that do not require an OMERO login (e.g. public home page) etc.
 
 If you want your pages to extend the webclient application, you can use
 templates from 
-:sourcedir:`omeroweb/webclient/templates/webclient/base <components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base>`.
+`omeroweb/webclient/templates/webclient/base <https://github.com/ome/omero-web/tree/master/omeroweb/webclient/templates/webclient/base>`_.
 
 These templates are described in more detail below.
 
@@ -178,7 +178,7 @@ These blocks can be used to add content to specific points in the page.
     links required by the parent template.
 
 
-See :source:`base_header.html <components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/base/base_header.html>` 
+See `base_header.html <https://github.com/ome/omero-web/blob/master/omeroweb/webgateway/templates/webgateway/base/base_header.html>`_
 for full template details.
 
 
@@ -210,5 +210,5 @@ extent it (see above). In addition, they also add the following blocks:
 -  right: The right column
 
 See 
-:source:`container3.html <components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/base/container3.html>` 
+`container3.html <https://github.com/ome/omero-web/blob/master/omeroweb/webgateway/templates/webgateway/base/container3.html>`_
 for full template details.

--- a/omero/developers/Web/WritingViews.rst
+++ b/omero/developers/Web/WritingViews.rst
@@ -5,7 +5,7 @@ This page contains info on how to write your own views.py code, including
 documentation on the :file:`webclient/views.py` and
 :file:`webgateway/views.py` code. Although we aim to provide some useful notes
 and examples here, you will find the best source of examples is
-:source:`the code itself <components/tools/OmeroWeb/omeroweb/webclient/views.py>`.
+`the code itself <https://github.com/ome/omero-web/blob/master/omeroweb/webclient/views.py>`_.
 
 @Decorators
 -----------

--- a/omero/developers/index.rst
+++ b/omero/developers/index.rst
@@ -109,6 +109,7 @@ Web
     Web
     Web/Deployment
     Web/CreateApp
+    Web/ReleaseApp
     Web/LinkingFromWebclient
     Web/WebclientPlugin
     Web/EditingOmeroWeb

--- a/omero/developers/testing.rst
+++ b/omero/developers/testing.rst
@@ -339,7 +339,7 @@ To make use of the more advanced options available in `pytest` that are not
 accessible using :program:`setup.py test`, the :program:`py.test` script can
 be used directly. To use this :envvar:`PYTHONPATH` must contain the path to
 the OMERO Python libraries, see |BlitzGateway| as well as the  path to the
-:sourcedir:`OMERO Python test library <components/tools/OmeroPy/src/omero/testlib/>`.
+`OMERO Python test library <https://github.com/ome/omero-py/blob/master/src/omero/testlib/__init__.py>`_.
 Alternatively, the `pytest` plugin :pypi:`pytest-pythonpath` can be used to
 add paths to :envvar:`PYTHONPATH` specifically for `pytest`.
 
@@ -511,7 +511,7 @@ There is one custom marker defined:
 Using the Python test library
 """""""""""""""""""""""""""""
 
-The :source:`OMERO Python test library <components/tools/OmeroPy/src/omero/testlib/__init__.py>`
+The `OMERO Python test library <https://github.com/ome/omero-py/blob/master/src/omero/testlib/__init__.py>`_
 defines an abstract ``ITest`` class that implements the connection set up as
 well as many methods shared amongst all Python integration tests.
 
@@ -574,7 +574,7 @@ Images can be imported using the ``ITest.import_fake_file()`` method::
 Writing OMERO.web tests
 """""""""""""""""""""""
 
-For OMERO.web integration tests, the :source:`OMERO.web test library <components/tools/OmeroWeb/omeroweb/testlib/__init__.py>`
+For OMERO.web integration tests, the `OMERO.web test library <https://github.com/ome/omero-web/blob/master/omeroweb/testlib/__init__.py>`_
 defines an abstract ``IWebTest`` class that inherits from ``ITest`` and
 also implements Django clients at the class setup using the
 :djangodoc:`Django testing tools <topics/testing/tools>`.

--- a/omero/developers/testing.rst
+++ b/omero/developers/testing.rst
@@ -339,7 +339,7 @@ To make use of the more advanced options available in `pytest` that are not
 accessible using :program:`setup.py test`, the :program:`py.test` script can
 be used directly. To use this :envvar:`PYTHONPATH` must contain the path to
 the OMERO Python libraries, see |BlitzGateway| as well as the  path to the
-`OMERO Python test library <https://github.com/ome/omero-py/blob/master/src/omero/testlib/__init__.py>`_.
+:sourcedir:`OMERO Python test library <components/tools/OmeroPy/src/omero/testlib/>`.
 Alternatively, the `pytest` plugin :pypi:`pytest-pythonpath` can be used to
 add paths to :envvar:`PYTHONPATH` specifically for `pytest`.
 


### PR DESCRIPTION
This describes an alternative workflow for getting started with web app development, using a template app and Docker for OMERO.web.

To test:
 - Follow new instructions in CreateApp page.
 - Should get to a ```/minimal_webapp``` page as described.
