### PR TITLE
Adjust text about server backups

### DIFF
--- a/omero/developers/Server/Clustering.rst
+++ b/omero/developers/Server/Clustering.rst
@@ -47,8 +47,6 @@ redirected to it.
 
 .. seealso:: :doc:`/developers/Server/ScalingOmero`
 
-.. _read-only:
-
 Read-Only
 ---------
 

--- a/omero/developers/Server/Clustering.rst
+++ b/omero/developers/Server/Clustering.rst
@@ -47,6 +47,8 @@ redirected to it.
 
 .. seealso:: :doc:`/developers/Server/ScalingOmero`
 
+.. _read-only:
+
 Read-Only
 ---------
 

--- a/omero/sysadmins/server-backup-and-restore.rst
+++ b/omero/sysadmins/server-backup-and-restore.rst
@@ -69,8 +69,7 @@ Frequent backups taken while the server is still running are usually
 sufficient but you should be aware that they may not be consistent
 snapshots. The **safest** course of action is to perform
 backups during server downtime when possible, especially if you think you
-may need the backup. An alternative would be to restart the server so as
-to be in :ref:`read-only` mode for the duration of the backup process.
+may need the backup.
 
 You need to back up *(3)* only before you make changes. You can copy it into 
 ``/OMERO/backup`` to ensure it is kept safe::

--- a/omero/sysadmins/server-backup-and-restore.rst
+++ b/omero/sysadmins/server-backup-and-restore.rst
@@ -69,7 +69,8 @@ Frequent backups taken while the server is still running are usually
 sufficient but you should be aware that they may not be consistent
 snapshots. The **safest** course of action is to perform
 backups during server downtime when possible, especially if you think you
-may need the backup.
+may need the backup. An alternative would be to restart the server so as
+to be in :ref:`read-only` mode for the duration of the backup process.
 
 You need to back up *(3)* only before you make changes. You can copy it into 
 ``/OMERO/backup`` to ensure it is kept safe::

--- a/omero/sysadmins/server-backup-and-restore.rst
+++ b/omero/sysadmins/server-backup-and-restore.rst
@@ -63,9 +63,9 @@ OMERO.server has three main backup sources:
     (assumed to be :file:`/OMERO`)
 3.  OMERO.server configuration
 
-.. warning:: You must back up *(1)* and *(2)* regularly.
+.. warning:: You must back up *(1)* and *(2)* frequently.
 
-Regular backups taken while the server is still running are usually
+Frequent backups taken while the server is still running are usually
 sufficient but you should be aware that they may not be consistent
 snapshots. The **safest** course of action is to perform
 backups during server downtime when possible, especially if you think you
@@ -113,7 +113,7 @@ Other database backup configurations are outside the scope of this
 document but can be researched on the `PostgreSQL website <https://www.postgresql.org/docs/10/backup.html>`_
 *(Chapter 25. Backup and Restore)*.
 
-.. note:: Regular backups of your PostgreSQL database are crucial; you do not 
+.. note:: Frequent backups of your PostgreSQL database are crucial; you do not
     want to be in the position of trying to restore your server without one.
 
 .. note:: Consider OMERO database dumps to be sensitive and be
@@ -127,7 +127,7 @@ Backing up your binary data store
 To simplify backup locations we have, in this document, located all
 database and configuration backups under ``/OMERO``, your :doc:`binary data
 store <unix/server-binary-repository>`. The entire contents of ``/OMERO`` should be
-backed up regularly as this will, especially if this document's
+backed up frequently as this will, especially if this document's
 conventions are followed, contain all the relevant data to restore your
 OMERO.server installation in the unlikely event of a system failure,
 botched upgrade or user malice.


### PR DESCRIPTION
Emphasize backing up *often* and point out that read-only mode can assist consistency. Staged at https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-docs/lastSuccessfulBuild/artifact/omero/_build/html/sysadmins/server-backup-and-restore.html.