### PR TITLE
exclude zeroc forum

### DIFF
--- a/omero/conf.py
+++ b/omero/conf.py
@@ -186,7 +186,8 @@ linkcheck_ignore += [r'http://localhost:\d+/?', 'http://localhost/',
     'https://testng.org/',
     # Those below may start working with Sphinx 2.1, see sphinx-doc #6381.
     'https://www.cloudflare.com/',
-    'https://www.zenoss.com/'
+    'https://www.zenoss.com/',
+    'https://forums.zeroc.com/*'
 ]
 
 exclude_patterns = ['sysadmins/unix/walkthrough/requirements*',


### PR DESCRIPTION
 * No error when checked locally on mac
 * no error when I run ``curl -Is https://forums.zeroc.com/discussion/6631/ice-3-6-0-and-ice-touch-3-6-0-released | head -1
HTTP/1.1 200 OK`` in the devspace container

--exclude
 
