### PR TITLE
Define extlink for versioned Ansible documentation

### DIFF
--- a/contributing/ansible-development.rst
+++ b/contributing/ansible-development.rst
@@ -18,7 +18,7 @@ using Git_ and hosted on GitHub_ under the
 The Git repositories should be named as `ansible-role-<ROLENAME>`.
 
 Each directory layout should minimally follow the standard
-`Ansible role layout <https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html#role-directory-structure>`_ including other files and folders for testing and
+:ansible_docs:`Ansible role layout <user_guide/playbooks_reuse_roles.html#role-directory-structure>` including other files and folders for testing and
 deployment. A typical role structure is shown below::
 
     defaults/           # Default variables
@@ -92,7 +92,7 @@ for examples of such files.
 
 The release of an Ansible role and its deployment to Galaxy release happens
 by triggering a role import in Galaxy using the
-`Travis integration <https://docs.ansible.com/ansible/latest/reference_appendices/galaxy.html#travis-integrations>`_
+:ansible_docs:`Travis integration <reference_appendices/galaxy.html#travis-integrations>`
 on each release tag.
 
 A PGP-signed tag of form `x.y.z` should be created for the released version

--- a/contributing/conf.py
+++ b/contributing/conf.py
@@ -61,7 +61,9 @@ contributing_extlinks = {
 
     # Doc links
     'omero_doc' : (docs_root + '/latest/omero/%s', ''),
-    'bf_doc' : (docs_root + '/latest/bio-formats/%s', '')
+    'bf_doc' : (docs_root + '/latest/bio-formats/%s', ''),
+
+    'ansible_docs' : ('https://docs.ansible.com/ansible/2.6/%s', ''),
     }
 extlinks.update(contributing_extlinks)
 

--- a/contributing/deployment-tools.rst
+++ b/contributing/deployment-tools.rst
@@ -9,8 +9,8 @@ the connections between basic repositories and the testing workflow.
 
 .. note::
 
-    This section requires a brief understanding of Ansible 
-    https://docs.ansible.com/ansible/intro_getting_started.html
+    This section requires a brief understanding of
+    :ansible_docs:`Ansible <user_guide/intro_getting_started.html>`
     and Docker engine https://docs.docker.com/.
 
 Prerequisites locations

--- a/contributing/devspace.rst
+++ b/contributing/devspace.rst
@@ -14,9 +14,9 @@ Running and maintaining Devspace requires:
 
 -  Docker engine https://docs.docker.com/.
 
-Optionally a `brief understanding of Ansible <https://docs.ansible.com/ansible/intro_getting_started.html>`_,
-`Ansible inventory <https://docs.ansible.com/ansible/intro_inventory.html>`_,
-and `Ansible playbooks <https://docs.ansible.com/ansible/playbooks.html>`_.
+Optionally a :ansible_docs:`brief understanding of Ansible <user_guide/intro_getting_started.html>`,
+:ansible_docs:`Ansible inventory <user_guide/intro_inventory.html>`,
+and :ansible_docs:`Ansible playbooks <user_guide/playbooks.html>`.
 
 Installation
 ------------


### PR DESCRIPTION
Current links point to the latest documentation which seemed to have been overhauled - see https://ci.openmicroscopy.org/view/Failing/job/CONTRIBUTING-merge-docs/1797/

This commit uses Ansible 2.6 as this is the current production Ansible version used by in the project as defined by OME [https://pypi.org/project/ome-ansible-molecule/](https://github.com/ome/ome-ansible-molecule).