### PR TITLE
omero.db.poolsize matters for OMERO DB connection scaling

### DIFF
--- a/omero/developers/Server/ScalingOmero.rst
+++ b/omero/developers/Server/ScalingOmero.rst
@@ -27,6 +27,8 @@ database, after ``max_connections`` invocations, all further attempts to
 connect to the server would fail with "too many connection" exceptions.
 Instead, OMERO uses a **connection pool** in front of Postgres, which
 manages many more simultaneous attempts to connect to the database.
+OMERO's connection pool size as determined by :property:`omero.db.poolsize`
+should be lower than ``max_connection``.
 
 With the default ``max_connection`` set to 64,
 it is possible to execute 500 queries simultaneously without database

--- a/omero/developers/Server/ScalingOmero.rst
+++ b/omero/developers/Server/ScalingOmero.rst
@@ -28,9 +28,9 @@ connect to the server would fail with "too many connection" exceptions.
 Instead, OMERO uses a **connection pool** in front of Postgres, which
 manages many more simultaneous attempts to connect to the database.
 OMERO's connection pool size as determined by :property:`omero.db.poolsize`
-should be lower than ``max_connection``.
+should be lower than ``max_connections``.
 
-With the default ``max_connection`` set to 64,
+With the default ``max_connections`` set to 64,
 it is possible to execute 500 queries simultaneously without database
 exceptions. Instead, one receives server exceptions.
 


### PR DESCRIPTION
Staged at https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-docs/lastSuccessfulBuild/artifact/omero/_build/html/developers/Server/ScalingOmero.html#database-connections.