### PR TITLE
omeroweb install version.

### DIFF
--- a/omero/developers/Web/Deployment.rst
+++ b/omero/developers/Web/Deployment.rst
@@ -23,7 +23,9 @@ Installing OMERO.web
 From OMERO 5.6.0 release, the ``omero-web`` library supports Python 3 and
 can be installed via :command:`pip`. We need to specify a location :envvar:`OMERODIR`
 to create log files and a :file:`config.xml` file. This can be any existing
-directory. We recommend you use a virtual environment::
+directory. We recommend you use a virtual environment:
+
+.. parsed-literal::
 
     $ python3 -m venv py3_venv
     $ source py3_venv/bin/activate
@@ -31,7 +33,7 @@ directory. We recommend you use a virtual environment::
     # Somewhere to create config and log files
     $ export OMERODIR=$(pwd)
 
-    $ pip install omero-web --pre
+    $ pip install 'omero-web>=\ |version_web|'
 
     Successfully installed Django-1.11.26 Pillow-6.2.1 django-pipeline-1.6.14
     future-0.18.2 gunicorn-20.0.0 omero-marshal-0.6.3 omero-py-5.6.dev5


### PR DESCRIPTION
Reviewed usage of ```pip install``` to check that ```>=``` is always quoted. 👍 

One minor fix:  Use version_web instead of ```--pre```.