### PR TITLE
Django links

### DIFF
--- a/common/conf.py
+++ b/common/conf.py
@@ -188,7 +188,7 @@ extlinks = {
     'zeroc': ('https://zeroc.com/%s', ''),
     'zerocforum': ('https://forums.zeroc.com/discussion/%s', ''),
     'zerocdoc': ('https://doc.zeroc.com/%s', ''),
-    'djangodoc': ('https://docs.djangoproject.com/en/1.8/%s', ''),
+    'djangodoc': ('https://docs.djangoproject.com/en/1.11/%s', ''),
     'doi': ('https://dx.doi.org/%s', ''),
     'pypi': ('https://pypi.org/project/%s', ''),
     }

--- a/omero/developers/PythonBlitzGateway.rst
+++ b/omero/developers/PythonBlitzGateway.rst
@@ -85,38 +85,6 @@ loading).
     >>> conn.close()
 
 
-Unicode
-"""""""
-
-When unwrapping ``omero.rtypes.rstring`` attributes from
-``omero.model.object`` instances as shown above,
-the ``BlitzObjectWrapper`` subclasses will decode the utf8-encoded
-string and return the resulting unicode string.
-
-However, some methods added to ``BlitzObjectWrappers``
-will return regular strings as follows::
-
-    BlitzObjectWrapper.getName()            except ExperimenterWrapper.getName() and LogicalChannelWrapper.getName()
-    BlitzObjectWrapper.getDescription()
-    AnnotationWrapper.getNs()
-    FileAnnotationWrapper.getFileName()
-    TagAnnotationWrapper.getValue()
-    CommentAnnotationWrapper.getValue()
-    MapAnnotationWrapper.getValue()  - list of strings
-    PlateWrapper.getColumnLabels() / getRowLabels()   - list of strings or integers
-    WellWrapper.getWellPos()
-    ColorHolder.getHtml() / getCss()
-    ChannelWrapper.getLut()
-    ImageWrapper.getChannelLabels()  - list of strings
-
-When using unicode strings, care must be taken when printing to
-the console if they include non-ASCII characters as
-`described here <https://pythonhosted.org/kitchen/unicode-frustrations.html>`_.
-
-When using the BlitzGateway in the OMERO.web framework,
-Django will convert strings into unicode strings so it is safe to
-use either. See Django :djangodoc:`Unicode data <ref/unicode/#general-string-handling>`.
-
 Wrapper coverage
 """"""""""""""""
 

--- a/omero/developers/PythonBlitzGateway.rst
+++ b/omero/developers/PythonBlitzGateway.rst
@@ -115,9 +115,7 @@ the console if they include non-ASCII characters as
 
 When using the BlitzGateway in the OMERO.web framework,
 Django will convert strings into unicode strings so it is safe to
-use either. See Django
-`Unicode data <https://docs.djangoproject.com/en/1.8/ref/unicode/#general-string-handling>`_.
-
+use either. See Django :djangodoc:`Unicode data <ref/unicode/#general-string-handling>`.
 
 Wrapper coverage
 """"""""""""""""

--- a/omero/developers/Web/CreateApp.rst
+++ b/omero/developers/Web/CreateApp.rst
@@ -115,7 +115,7 @@ Exploring the app
 -----------------
 
 The `minimal_webapp code <https://github.com/ome/omero-web-apps-examples/tree/master/minimal-webapp>`_
-is well documented to explain how the app is working.
+is well-documented to explain how the app is working.
 Briefly, the app supports a single URL defined in
 ``minimal_webapp/urls.py`` which maps to the ``index`` function
 within ``minimal_webapp/views.py``. This uses the connection to

--- a/omero/developers/Web/CreateApp.rst
+++ b/omero/developers/Web/CreateApp.rst
@@ -21,7 +21,7 @@ Clone the examples repository
 -----------------------------
 
 To get started quickly, we are going to use the
-`omero-web-apps-examples <https://github.com/ome/omero-web-apps-examples>`_
+`omero web apps examples <https://github.com/ome/omero-web-apps-examples>`_
 repository which contains two sample OMERO.web apps.
 Clone the repo to a location of your choice:
 

--- a/omero/developers/Web/CreateApp.rst
+++ b/omero/developers/Web/CreateApp.rst
@@ -20,9 +20,10 @@ If you want to make changes to the OMERO.web code itself, go to
 Clone the examples repository
 -----------------------------
 
-To get started quickly, we are going to use a repository
-that contains several example OMERO.web apps.
-Clone the app to a location of your choice:
+To get started quickly, we are going to use the
+`omero-web-apps-examples <https://github.com/ome/omero-web-apps-examples>`_
+repository which contains two sample OMERO.web apps.
+Clone the repo to a location of your choice:
 
 ::
 
@@ -113,8 +114,8 @@ page which will display your Name and list your Projects.
 Exploring the app
 -----------------
 
-The ``minimal_webapp`` code is well documented to explain
-how the app is working.
+The `minimal_webapp code <https://github.com/ome/omero-web-apps-examples/tree/master/minimal-webapp>`_
+is well documented to explain how the app is working.
 Briefly, the app supports a single URL defined in
 ``minimal_webapp/urls.py`` which maps to the ``index`` function
 within ``minimal_webapp/views.py``. This uses the connection to

--- a/omero/developers/Web/ReleaseApp.rst
+++ b/omero/developers/Web/ReleaseApp.rst
@@ -24,7 +24,8 @@ Configuring your app name and label
 -----------------------------------
 
 We support the option of configuring your OMERO.web app with a name and label.
-See Django `Configuring Applications <https://docs.djangoproject.com/en/1.8/ref/applications/#configuring-applications>`_.
+:djangodoc:`Configuring Applications <ref/applications/#configuring-applications>`.
+
 This allows the URL to an app to be different from its name.
 For example, OMERO.figure app is named ``omero_figure`` but the url is simply ``/figure/``
 as configured by `__init__.py <https://github.com/ome/omero-figure/blob/master/omero_figure/__init__.py>`_

--- a/omero/developers/Web/ReleaseApp.rst
+++ b/omero/developers/Web/ReleaseApp.rst
@@ -24,10 +24,9 @@ Configuring your app name and label
 -----------------------------------
 
 We support the option of configuring your OMERO.web app with a name and label.
-:djangodoc:`Configuring Applications <ref/applications/#configuring-applications>`.
+See :djangodoc:`Configuring Applications <ref/applications/#configuring-applications>`.
 
 This allows the URL to an app to be different from its name.
 For example, OMERO.figure app is named ``omero_figure`` but the url is simply ``/figure/``
 as configured by `__init__.py <https://github.com/ome/omero-figure/blob/master/omero_figure/__init__.py>`_
 and `apps.py <https://github.com/ome/omero-figure/blob/master/omero_figure/apps.py>`_.
-

--- a/omero/sysadmins/config.rst
+++ b/omero/sysadmins/config.rst
@@ -2210,7 +2210,7 @@ Default: `None`
 
 omero.web.login_redirect
 ^^^^^^^^^^^^^^^^^^^^^^^^
-Redirect to the given location after logging in. It only supports arguments for :djangodoc:`Django reverse function <ref/urlresolvers/#django.core.urlresolvers.reverse>`. For example: ``'{"redirect": ["webindex"], "viewname": "load_template", "args":["userdata"], "query_string": {"experimenter": -1}}'``
+Redirect to the given location after logging in. It only supports arguments for :djangodoc:`Django reverse function <ref/urlresolvers/#reverse>`. For example: ``'{"redirect": ["webindex"], "viewname": "load_template", "args":["userdata"], "query_string": {"experimenter": -1}}'``
 
 Default: `{}`
 
@@ -2226,7 +2226,7 @@ Default: `weblogin`
 
 omero.web.middleware
 ^^^^^^^^^^^^^^^^^^^^
-Warning: Only system administrators should use this feature. List of Django middleware classes in the form [{"class": "class.name", "index": FLOAT}]. See https://docs.djangoproject.com/en/1.8/topics/http/middleware/. Classes will be ordered by increasing index
+Warning: Only system administrators should use this feature. List of Django middleware classes in the form [{"class": "class.name", "index": FLOAT}]. See :djangodoc:`Django middleware <topics/http/middleware/>`. Classes will be ordered by increasing index
 
 Default: `[{"index": 1, "class": "django.middleware.common.BrokenLinkEmailsMiddleware"},{"index": 2, "class": "django.middleware.common.CommonMiddleware"},{"index": 3, "class": "django.contrib.sessions.middleware.SessionMiddleware"},{"index": 4, "class": "django.middleware.csrf.CsrfViewMiddleware"},{"index": 5, "class": "django.contrib.messages.middleware.MessageMiddleware"},{"index": 6, "class": "django.middleware.clickjacking.XFrameOptionsMiddleware"}]`
 


### PR DESCRIPTION
Small doc fixes I noticed:

 - Update Django doc links to 1.11 (teach some links to use the : djangodoc: helper)
 - Remove Unicode section from BlitzGateway page - no longer relevant.