### PR TITLE
List preferrred conda installation first

### DIFF
--- a/omero/users/cli/installation.rst
+++ b/omero/users/cli/installation.rst
@@ -13,16 +13,16 @@ You can create one using either ``venv`` or ``conda`` (preferred).
 If you opt for Conda_, you will need
 to install it first, see `miniconda <https://docs.conda.io/en/latest/miniconda.html>`_ for more details.
 
-To install ``omero-py`` using venv::
-
-    python3.6 -m venv myenv
-    . myenv/bin/activate
-    pip install omero-py
-
 To install ``omero-py`` using conda (preferred)::
 
     conda create -n myenv -c ome python=3.6 zeroc-ice36-python omero-py
     conda activate myenv
+
+Alternatively install ``omero-py`` using venv::
+
+    python3.6 -m venv myenv
+    . myenv/bin/activate
+    pip install omero-py
 
 The ``omero`` command is now available in the terminal where the environment has been activated::
 


### PR DESCRIPTION
If conda is the preferred way to install, it should be mentioned first.

See also: https://github.com/ome/omero-py/pull/190