### PR TITLE
Construct GitHub links using "ome" organization.

### DIFF
--- a/common/conf.py
+++ b/common/conf.py
@@ -123,7 +123,7 @@ else:
 if "SOURCE_USER" in os.environ and len(os.environ.get('SOURCE_USER')) > 0:
     user = os.environ.get('SOURCE_USER')
 else:
-    user = 'openmicroscopy'
+    user = 'ome'
 
 github_root = 'https://github.com/'
 omero_github_root = github_root + user + '/openmicroscopy/'


### PR DESCRIPTION
Bring more GitHub links into the now-ignored-for-linkchecking "ome" organization instead of having them redirected there.