### PR TITLE
pin django-cors-headers for Django 1.11

### DIFF
--- a/omero/sysadmins/unix/install-web.rst
+++ b/omero/sysadmins/unix/install-web.rst
@@ -144,7 +144,7 @@ for more details on the settings.
 
 In the virtual environment where OMERO.web is installed, install the app as **root**::
 
-  $ pip install django-cors-headers
+  $ pip install 'django-cors-headers<3.3'
 
 And add it to the list of installed apps as the **omero-web** system user::
 


### PR DESCRIPTION
https://pypi.org/project/django-cors-headers/3.3.0/ dropped
supported for Django 1.11. Ping to earlier versions to prevent
a forced upgrade of Django to 3.x.

see https://github.com/ome/omero-web-docker/issues/50