### PR TITLE
from omero.rtypes import rdouble, rint, rstring

### DIFF
--- a/omero/developers/Python.rst
+++ b/omero/developers/Python.rst
@@ -774,6 +774,7 @@ ROIs
 ::
 
     updateService = conn.getUpdateService()
+    from omero.rtypes import rdouble, rint, rstring
 
 -  **Create ROI**
 


### PR DESCRIPTION
I got that rdouble was not loaded.

also this line is flaw

# create a rectangle shape (added to ROI below)
print(("Adding a rectangle at theZ: %s, theT: %s, X: %s, Y: %s, width: %s,")
   " height: %s" % (z, t, x, y, width, height))