### PR TITLE
help: update link

### DIFF
--- a/contributing/ci-docs.rst
+++ b/contributing/ci-docs.rst
@@ -223,7 +223,7 @@ The following set of jobs is used to review or publish the content of the
 		   to allow	 deployment to a non-GitHub URL) then pushes the resulting
 		   branch to :omehelp_scc_branch:`gh-pages`
 		#. The GitHub Pages service updates the content of
-		   https://help.staging.openmicroscopy.org
+		   https://snoopycrimecop.github.io/ome-help
 
 	:jenkinsjob:`OME-help-release`
 

--- a/contributing/jekyll.rst
+++ b/contributing/jekyll.rst
@@ -111,7 +111,7 @@ html.
 Once a PR is open against the ‘master’ branch and has passed Travis, you can
 build the staging site for review by triggering the
 :jenkinsjob:`OME-help-staging` job. The
-site will be viewable at `<https://help.staging.openmicroscopy.org>`_.
+site will be viewable at `<https://snoopycrimecop.github.io/ome-help>`_.
 
 Once the PR is merged, running the :jenkinsjob:`OME-help-release` build will
 open a PR to transfer the content to the ‘gh-pages’ branch. Once that PR is


### PR DESCRIPTION
Fix failure for now
help section to be adjusted when we switch to read the docs