### PR TITLE
Update Micron Oxford URL

### DIFF
--- a/omero/sysadmins/server-setup-examples.rst
+++ b/omero/sysadmins/server-setup-examples.rst
@@ -31,7 +31,7 @@ Micron, Oxford
 --------------
 
 The OMERO server at
-`Micron, Oxford <https://micronoxford.com>`_
+`Micron, Oxford <https://micronoxford.com/>`_
 houses two OMERO instances, the databases for both these instances, and a
 single OMERO.web instance which serves them both. The second OMERO instance
 (Raff OMERO) originated from another group's private OMERO server, which is

--- a/omero/sysadmins/server-setup-examples.rst
+++ b/omero/sysadmins/server-setup-examples.rst
@@ -31,7 +31,7 @@ Micron, Oxford
 --------------
 
 The OMERO server at
-`Micron, Oxford <http://www2.bioch.ox.ac.uk/microngroup/home.php>`_
+`Micron, Oxford <https://micronoxford.com>`_
 houses two OMERO instances, the databases for both these instances, and a
 single OMERO.web instance which serves them both. The second OMERO instance
 (Raff OMERO) originated from another group's private OMERO server, which is


### PR DESCRIPTION
Fixes failing https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-docs/518/console

```
03:18:57      [exec] (line   33) broken    http://www2.bioch.ox.ac.uk/microngroup/home.php - HTTPSConnectionPool(host='micronoxford.com', port=443): Max retries exceeded with url: / (Caused by ConnectTimeoutError(<urllib3.connection.VerifiedHTTPSConnection object at 0x7f62d3ed4950>, 'Connection to micronoxford.com timed out. (connect timeout=30)'))
```