### PR TITLE
Move "Reusing OMERO sessions" from public to web dev

### DIFF
--- a/omero/developers/Web/Webclient.rst
+++ b/omero/developers/Web/Webclient.rst
@@ -95,11 +95,16 @@ under an ``OME`` module.
 Reusing OMERO sessions
 ----------------------
 
-In some situations you may wish to automatically log in to OMERO.web using
-an existing session key that can be passed as a query parameters.
+When integrating other applications with OMERO.web you may want to
+automatically log in to OMERO.web using an existing OMERO session key.
+The session can be passed as a query parameter.
 For example a direct link to image will look as follows::
 
     https://your_host/webgateway/img_detail/IMAGE_ID/?server=SERVER_ID&bsession=OMERO_SESSION_KEY
+
+This provides full access to OMERO.web, in the same way that logging in with a
+username and password would.
+It is therefore unsuited for giving others temporary access to data.
 
 .. note::
 

--- a/omero/developers/Web/Webclient.rst
+++ b/omero/developers/Web/Webclient.rst
@@ -92,3 +92,21 @@ Additional code is in static scripts, with functions generally name-spaced
 under an ``OME`` module.
 
 
+Reusing OMERO sessions
+----------------------
+
+In some situations you may wish to automatically log in to OMERO.web using
+an existing session key that can be passed as a query parameters.
+For example a direct link to image will look as follows::
+
+    https://your_host/webgateway/img_detail/IMAGE_ID/?server=SERVER_ID&bsession=OMERO_SESSION_KEY
+
+.. note::
+
+    The `SERVER_ID` should match the index from the list set using
+    :property:`omero.web.server_list` from the server session
+    you created. If your list contains only one server, the index will be 1.
+
+For more details about how to create an OMERO session see
+:doc:`server-side session </developers/Server/Sessions>` or
+use the :doc:`command line interface </users/cli/sessions>` to create one.

--- a/omero/sysadmins/public.rst
+++ b/omero/sysadmins/public.rst
@@ -120,25 +120,6 @@ users to be able to log in, the login page can always be accessed using a link
 of the form `\https://your_host/webclient/login/`.
 
 
-Reusing OMERO sessions
-----------------------
-
-As an alternative to granting permanent public access to the data, the
-OMERO.web framework supports password-less, OMERO session key-based
-authentication. For example a direct link to image will look as follows::
-
-    https://your_host/webgateway/img_detail/IMAGE_ID/?server=SERVER_ID&bsession=OMERO_SESSION_KEY
-
-.. note::
-
-    The `SERVER_ID` should match the index from the list set using
-    :property:`omero.web.server_list` from the server session
-    you created. If your list contains only one server, the index will be 1.
-
-For more details about how to create an OMERO session see
-:doc:`server-side session </developers/Server/Sessions>` or
-use the :doc:`command line interface </users/cli/sessions>` to create one.
-
 .. _hosting_data_example:
 
 Full example of hosting data for a publication


### PR DESCRIPTION
"Reusing OMERO sessions" isn't suitable for public sharing since it provides a full read-write session with access to all data. Including it in the public user doc implies it's somewhat equivalent.

Background: https://forum.image.sc/t/omero-public-datasets-with-permanent-session-id/44939