### PR TITLE
Remove broken centos 6 link

### DIFF
--- a/omero/sysadmins/version-requirements.rst
+++ b/omero/sysadmins/version-requirements.rst
@@ -154,7 +154,7 @@ General overview for `RHEL
       - |Upcoming|
       - |Upcoming|
       - |Recommended|
-      - `Reference <https://access.redhat.com/support/policy/updates/errata#Life_Cycle_Dates>`__
+      - `Reference <https://wiki.centos.org/About/Product>`__
 
 RHEL/CentOS 7 is supported at present. Given the long life
 of enterprise releases, we intend to support only the latest release

--- a/omero/sysadmins/version-requirements.rst
+++ b/omero/sysadmins/version-requirements.rst
@@ -245,7 +245,7 @@ Package lists
     * - Operating system
       - Details
     * - CentOS 6 / RHEL 6
-      - `Reference <http://mirror.centos.org/centos/6/os/x86_64/Packages/>`__
+      - EOL
     * - CentOS 7 / RHEL 7
       - `Reference <http://mirror.centos.org/centos/7/os/x86_64/Packages/>`__
     * - Ubuntu


### PR DESCRIPTION
Removes the broken link to the Centos 6 packages. Also unifies the links to the Centos version specifications, instead of using https://access.redhat.com/support/policy/updates/errata#Life_Cycle_Dates for Centos 8 only (which looked a bit odd to me).