### PR TITLE
Fix 404 in pytest usage

### DIFF
--- a/omero/developers/testing.rst
+++ b/omero/developers/testing.rst
@@ -339,7 +339,7 @@ Also set :envvar:`OMERODIR` to point to the OMERO.server::
 
         pytest -h
 
-See `<https://pytest.org/en/latest/usage.html>`_ for more help in
+See `<https://docs.pytest.org/en/latest/how-to/usage.html>`_ for more help in
 running tests.
 
 Failing tests


### PR DESCRIPTION
The stable URL is still present with the additional "docs" prefix,
but if the page is being removed in "latest", we might as well go
ahead and bump.

Fixes https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-docs/771/