### PR TITLE
Remove link to expired website

### DIFF
--- a/omero/developers/scripts/index.rst
+++ b/omero/developers/scripts/index.rst
@@ -131,10 +131,6 @@ others to see and share.
 scripts. You should use the :doc:`style-guide` to ensure your script interacts
 with the OMERO clients in a usable way.
 
-If you are a biologist with no previous programming experience, you may find
-the `Python for Biologists 
-<https://pythonforbiologists.com/introduction/>`_ free online course helpful.
-
 Contributing back to the community
 ----------------------------------
 


### PR DESCRIPTION
Old website is available at https://web.archive.org/web/20210220104531/https://pythonforbiologists.com/introduction.

There is a website at https://www.pythonforbiologists.org/ which seems unrelated. Additionally looking at the bottom of https://web.archive.org/web/20210126160535/https://pythonforbiologists.com/python-for-biologists-online-course, I realized the online training was no longer free.

Rather than trying to find an alternative, proposing to remove this link. 