### PR TITLE
specify min java version

### DIFF
--- a/omero/conf.py
+++ b/omero/conf.py
@@ -73,7 +73,7 @@ rst_epilog += """
 .. |version_web|  replace:: %s
 .. |iceversion| replace:: 3.6.5
 .. |postgresversion| replace:: 11
-.. |javaversion| replace:: 11
+.. |javaversion_recommended| replace:: 11
 .. |javaversion_min| replace:: 8
 .. |version_dropbox|  replace:: %s
 

--- a/omero/conf.py
+++ b/omero/conf.py
@@ -74,6 +74,7 @@ rst_epilog += """
 .. |iceversion| replace:: 3.6.5
 .. |postgresversion| replace:: 11
 .. |javaversion| replace:: 11
+.. |javaversion_min| replace:: 8
 .. |version_dropbox|  replace:: %s
 
 .. |Broken| image:: /images/broken.png

--- a/omero/sysadmins/unix/server-centos7-ice36.rst
+++ b/omero/sysadmins/unix/server-centos7-ice36.rst
@@ -35,9 +35,9 @@ Installing prerequisites
 
 **The following steps are run as root.**
 
-Install Java |javaversion|, Ice |iceversion| and PostgreSQL |postgresversion|:
+Install Java |javaversion_recommended|, Ice |iceversion| and PostgreSQL |postgresversion|:
 
-To install Java |javaversion| and other dependencies:
+To install Java |javaversion_recommended| and other dependencies:
 
 .. literalinclude:: walkthrough/walkthrough_centos7.sh
     :start-after: #start-step01

--- a/omero/sysadmins/unix/server-centos8-ice36.rst
+++ b/omero/sysadmins/unix/server-centos8-ice36.rst
@@ -35,9 +35,9 @@ Installing prerequisites
 
 **The following steps are run as root.**
 
-Install Java |javaversion|, Ice |iceversion| and PostgreSQL |postgresversion|:
+Install Java |javaversion_recommended|, Ice |iceversion| and PostgreSQL |postgresversion|:
 
-To install Java |javaversion| and other dependencies:
+To install Java |javaversion_recommended| and other dependencies:
 
 .. literalinclude:: walkthrough/walkthrough_centos8.sh
     :start-after: #start-step01

--- a/omero/sysadmins/unix/server-debian10-ice36.rst
+++ b/omero/sysadmins/unix/server-debian10-ice36.rst
@@ -34,9 +34,9 @@ Installing prerequisites
 
 **The following steps are run as root.**
 
-Install Java |javaversion|, Ice |iceversion| and PostgreSQL |postgresversion|:
+Install Java |javaversion_recommended|, Ice |iceversion| and PostgreSQL |postgresversion|:
 
-To install Java |javaversion| and other dependencies:
+To install Java |javaversion_recommended| and other dependencies:
 
 .. literalinclude:: walkthrough/walkthrough_debian10.sh
     :start-after: #start-step01

--- a/omero/sysadmins/unix/server-debian9-ice36.rst
+++ b/omero/sysadmins/unix/server-debian9-ice36.rst
@@ -34,9 +34,9 @@ Installing prerequisites
 
 **The following steps are run as root.**
 
-Install Java |javaversion|, Ice |iceversion| and PostgreSQL |postgresversion|:
+Install Java |javaversion_recommended|, Ice |iceversion| and PostgreSQL |postgresversion|:
 
-To install Java |javaversion| and other dependencies:
+To install Java |javaversion_recommended| and other dependencies:
 
 .. literalinclude:: walkthrough/walkthrough_debian9.sh
     :start-after: #start-step01

--- a/omero/sysadmins/unix/server-installation.rst
+++ b/omero/sysadmins/unix/server-installation.rst
@@ -135,7 +135,8 @@ If possible, install one of the following packages:
       - java-11-openjdk
 
 OMERO works with the OpenJDK JRE provided by most systems, or with
-Oracle Java. Version |javaversion| or later is required.
+Oracle Java. Version |javaversion_min| or later is required.
+Version |javaversion_recommended| is recommended.
 
 Your system may already provide a suitable JRE, in which case no extra steps
 are necessary. Linux distributions usually provide OpenJDK, and older MacOS X

--- a/omero/sysadmins/unix/server-ubuntu1804-ice36.rst
+++ b/omero/sysadmins/unix/server-ubuntu1804-ice36.rst
@@ -34,9 +34,9 @@ Installing prerequisites
 
 **The following steps are run as root.**
 
-Install Java |javaversion|, Ice |iceversion| and PostgreSQL |postgresversion|:
+Install Java |javaversion_recommended|, Ice |iceversion| and PostgreSQL |postgresversion|:
 
-To install Java |javaversion| and other dependencies:
+To install Java |javaversion_recommended| and other dependencies:
 
 .. literalinclude:: walkthrough/walkthrough_ubuntu1804.sh
     :start-after: #start-step01

--- a/omero/sysadmins/unix/server-ubuntu2004-ice36.rst
+++ b/omero/sysadmins/unix/server-ubuntu2004-ice36.rst
@@ -34,9 +34,9 @@ Installing prerequisites
 
 **The following steps are run as root.**
 
-Install Java |javaversion|, Ice |iceversion| and PostgreSQL 12:
+Install Java |javaversion_recommended|, Ice |iceversion| and PostgreSQL 12:
 
-To install Java |javaversion| and other dependencies:
+To install Java |javaversion_recommended| and other dependencies:
 
 .. literalinclude:: walkthrough/walkthrough_ubuntu2004.sh
     :start-after: #start-step01

--- a/omero/users/clients-overview.rst
+++ b/omero/users/clients-overview.rst
@@ -16,7 +16,7 @@ installations worldwide, OMERO has been shown to be relatively easy to install
 and get running.
 
 OMERO.insight and OMERO.importer are desktop applications written in Java
-and require Java |javaversion| (or higher) to be installed on the user's
+and require Java |javaversion_min| (or higher) to be installed on the user's
 computer (this can easily be installed from `<https://java.com/>`_ if it is not
 already included in your OS).
 

--- a/omero/users/index.rst
+++ b/omero/users/index.rst
@@ -16,7 +16,7 @@ several Java client applications, as well as Python and C++ bindings
 and a Django-based web application.
 
 The OMERO clients are cross-platform. To run on your computer they require
-Java |javaversion| or higher to be installed. This can easily be installed
+Java |javaversion_min| or higher to be installed. This can easily be installed
 from `<https://java.com/>`_ if it is not already included in your OS. The
 OMERO.insight client gets all of its information from a remote OMERO.server —
 the location of which is specified at login. Since this connection utilises a


### PR DESCRIPTION
The Java version in ``conf.py`` is mainly used for the server installation
Client side requirement is still at Java 1.8
see https://github.com/ome/omero-insight/blob/master/build.gradle#L19

cc @sukunis 