### PR TITLE
Mention OMERODIR in the server upgrade page

### DIFF
--- a/omero/sysadmins/server-upgrade.rst
+++ b/omero/sysadmins/server-upgrade.rst
@@ -300,7 +300,8 @@ Environment variables
 If you changed the directory name where the |release| server code
 resides, make sure to update any system environment variables. Before
 restarting the server, make sure your :envvar:`PATH` system environment
-variable is pointing to the new location.
+variable is pointing to the new location. Also make sure the :envvar:`OMERODIR`
+environment variable is set to the location of the server.
 
 JVM memory settings
 """""""""""""""""""

--- a/omero/sysadmins/server-upgrade.rst
+++ b/omero/sysadmins/server-upgrade.rst
@@ -303,6 +303,8 @@ restarting the server, make sure your :envvar:`PATH` system environment
 variable is pointing to the new location. Also make sure the :envvar:`OMERODIR`
 environment variable is set to the location of the server.
 
+See :ref:`server_env` for more information.
+
 JVM memory settings
 """""""""""""""""""
 

--- a/omero/sysadmins/unix/server-installation.rst
+++ b/omero/sysadmins/unix/server-installation.rst
@@ -379,7 +379,8 @@ The following environment variables may be configured:
   :file:`python` directory to the python path. For Ice 3.6, this
   should never be required.
 :envvar:`OMERODIR`
-  The path to the OMERO.server.
+  The path to the OMERO.server. This is a requirement for all CLI plugins
+  using the Java server components (`admin`, `import`, `config`, `db`...).
 
 After making any needed changes, either source the corresponding file
 or log back in for them to take effect. Run ``env`` to check them.


### PR DESCRIPTION
See https://forum.image.sc/t/omero-server-upgrade-error-from-5-5-1-to-5-6-3/55088

There is no mention of the `OMERODIR` envvar in the server upgrade page which can lead to confusion for users upgrading from OMERO < 5.6.