### PR TITLE
Fix link to example scripts

### DIFF
--- a/omero/developers/scripts/index.rst
+++ b/omero/developers/scripts/index.rst
@@ -46,7 +46,7 @@ include:
 
 - `OMERO scripts <https://github.com/glencoesoftware/omero-user-scripts>`_ -
   Glencoe Software
-- `Example scripts <https://github.com/ome/omero-example-scripts>`_
+- `Example scripts <https://github.com/openmicroscopy/omero-example-scripts>`_
   - OME Team
 - `Fixing scripts <https://github.com/ppouchin/omero-user-scripts>`_ - Pierre 
   Pouchin


### PR DESCRIPTION
Fixes https://github.com/ome/omero-documentation/issues/2189 

Just fix broken link to example scripts repo.