### PR TITLE
Just fixed a typo in a file name

### DIFF
--- a/omero/sysadmins/unix/server-debian10-ice36.rst
+++ b/omero/sysadmins/unix/server-debian10-ice36.rst
@@ -138,7 +138,7 @@ OMERO should now be set up. To start the server run::
     omero admin start
 
 Should you wish to start OMERO automatically, a `init.d` file could be created.
-An example :download:`omero-server.init.d <walkthrough/omero-server-init.d>`
+An example :download:`omero-server-init.d <walkthrough/omero-server-init.d>`
 is available.
 
 Copy the ``init.d`` file and configure the service:

--- a/omero/sysadmins/unix/server-ubuntu1804-ice36.rst
+++ b/omero/sysadmins/unix/server-ubuntu1804-ice36.rst
@@ -143,7 +143,7 @@ OMERO should now be set up. To start the server run::
     omero admin start
 
 Should you wish to start OMERO automatically, a `init.d` file could be created.
-An example :download:`omero-server.init.d <walkthrough/omero-server-init.d>`
+An example :download:`omero-server-init.d <walkthrough/omero-server-init.d>`
 is available.
 
 Copy the ``init.d`` file and configure the service:

--- a/omero/sysadmins/unix/server-ubuntu2004-ice36.rst
+++ b/omero/sysadmins/unix/server-ubuntu2004-ice36.rst
@@ -143,7 +143,7 @@ OMERO should now be set up. To start the server run::
     omero admin start
 
 Should you wish to start OMERO automatically, a `init.d` file could be created.
-An example :download:`omero-server.init.d <walkthrough/omero-server-init.d>`
+An example :download:`omero-server-init.d <walkthrough/omero-server-init.d>`
 is available.
 
 Copy the ``init.d`` file and configure the service:


### PR DESCRIPTION
The commands are actually correct, there's just a typo in the link name.
Noticed while testing https://forum.image.sc/t/typo-in-the-ubuntu-installation-page/61748 .
