### PR TITLE
Handle GH redirects from help to docs

### DIFF
--- a/omero/conf.py
+++ b/omero/conf.py
@@ -210,7 +210,9 @@ linkcheck_ignore += [
     # Timeouts which may be fixed in a newer version
     'https://micronoxford.com/',
     github_root + 'ome/',
-    r'https://help.openmicroscopy.org/.*#.*']
+    r'https://help.openmicroscopy.org/.*#.*',
+    r'https://docs.github.com/.*',
+]
 
 exclude_patterns = ['sysadmins/unix/walkthrough/requirements*',
                     'downloads/inplace', 'downloads/cli',

--- a/omero/developers/Web/CreateApp.rst
+++ b/omero/developers/Web/CreateApp.rst
@@ -135,7 +135,7 @@ as a template.
 Go to the template repository
 `omero-web-apps-examples <https://github.com/will-moore/omero-web-apps-examples>`_.
 Click 'Use this template' as `described here
-<https://docs.github.com/en/articles/creating-a-repository-from-a-template>`_
+<https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template>`_
 and choose a name for your new repo, for example ``my_app``.
 
 Go to the directory where you want your app to live and clone it.

--- a/omero/developers/Web/CreateApp.rst
+++ b/omero/developers/Web/CreateApp.rst
@@ -135,7 +135,7 @@ as a template.
 Go to the template repository
 `omero-web-apps-examples <https://github.com/will-moore/omero-web-apps-examples>`_.
 Click 'Use this template' as `described here
-<https://help.github.com/en/articles/creating-a-repository-from-a-template>`_
+<https://docs.github.com/en/articles/creating-a-repository-from-a-template>`_
 and choose a name for your new repo, for example ``my_app``.
 
 Go to the directory where you want your app to live and clone it.

--- a/omero/developers/scripts/index.rst
+++ b/omero/developers/scripts/index.rst
@@ -74,7 +74,7 @@ scripts will be lost.
 To keep your scripts up to date, we recommend you use a Github repository to
 manage your scripts. If you are not familiar with
 :devs_doc:`using git <using-git.html>`, you can use the
-`GitHub app for your OS <https://docs.github.com/articles/set-up-git>`_
+`GitHub app for your OS <https://docs.github.com/en/get-started/quickstart/set-up-git>`_
 (available for Mac and Windows but not Linux). The basic workflow is:
 
 -  fork our

--- a/omero/developers/scripts/index.rst
+++ b/omero/developers/scripts/index.rst
@@ -74,7 +74,7 @@ scripts will be lost.
 To keep your scripts up to date, we recommend you use a Github repository to
 manage your scripts. If you are not familiar with
 :devs_doc:`using git <using-git.html>`, you can use the
-`GitHub app for your OS <https://help.github.com/articles/set-up-git>`_
+`GitHub app for your OS <https://docs.github.com/articles/set-up-git>`_
 (available for Mac and Windows but not Linux). The basic workflow is:
 
 -  fork our

--- a/omero/index.rst
+++ b/omero/index.rst
@@ -54,7 +54,7 @@ file contents and propose your file changes to the OME team using
 `Pull Requests`_. Alternatively, click on "Edit on GitHub" in the
 menu.
 
-.. _Pull Requests: https://help.github.com/articles/about-pull-requests/
+.. _Pull Requests: https://docs.github.com/articles/about-pull-requests/
 
 .. toctree::
     :maxdepth: 1

--- a/omero/index.rst
+++ b/omero/index.rst
@@ -54,7 +54,7 @@ file contents and propose your file changes to the OME team using
 `Pull Requests`_. Alternatively, click on "Edit on GitHub" in the
 menu.
 
-.. _Pull Requests: https://docs.github.com/articles/about-pull-requests/
+.. _Pull Requests: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests
 
 .. toctree::
     :maxdepth: 1

--- a/omero/sysadmins/installing-scripts.rst
+++ b/omero/sysadmins/installing-scripts.rst
@@ -25,7 +25,7 @@ Once in the directory, scripts cannot be automatically updated and any
 additional ones will be lost when you upgrade your server installation. 
 Therefore, we recommend you use a Github repository to manage your scripts. If 
 you are not familiar with :devs_doc:`using git <using-git.html>`, you can use 
-the `GitHub app for your OS <https://docs.github.com/articles/set-up-git>`_
+the `GitHub app for your OS <https://docs.github.com/en/get-started/quickstart/set-up-git>`_
 (available for Mac and Windows but not Linux). The basic workflow is:
 
 -  fork our 

--- a/omero/sysadmins/installing-scripts.rst
+++ b/omero/sysadmins/installing-scripts.rst
@@ -25,7 +25,7 @@ Once in the directory, scripts cannot be automatically updated and any
 additional ones will be lost when you upgrade your server installation. 
 Therefore, we recommend you use a Github repository to manage your scripts. If 
 you are not familiar with :devs_doc:`using git <using-git.html>`, you can use 
-the `GitHub app for your OS <https://help.github.com/articles/set-up-git>`_
+the `GitHub app for your OS <https://docs.github.com/articles/set-up-git>`_
 (available for Mac and Windows but not Linux). The basic workflow is:
 
 -  fork our 


### PR DESCRIPTION
see: https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-docs/1186/console

```
01:06:13 (developers/scripts/index: line   74) broken    https://help.github.com/articles/set-up-git - 403 Client Error: Forbidden for url: https://docs.github.com/articles/set-up-git
01:06:13 (developers/Web/CreateApp: line  135) broken    https://help.github.com/en/articles/creating-a-repository-from-a-template - 403 Client Error: Forbidden for url: https://docs.github.com/en/articles/creating-a-repository-from-a-template
01:06:13 (           index: line   51) broken    https://help.github.com/articles/about-pull-requests/ - 403 Client Error: Forbidden for url: https://docs.github.com/articles/about-pull-requests/
```