### PR TITLE
Add name and description opts, add link to it from limitations

### DIFF
--- a/omero/sysadmins/limitations.rst
+++ b/omero/sysadmins/limitations.rst
@@ -89,7 +89,7 @@ The import of `OME-NGFF <https://ngff.openmicroscopy.org/latest/>`_ is currently
 Naming of OME-NGFF images in OMERO
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The default naming of the `OME-NGFF <https://ngff.openmicroscopy.org/latest/>`_ Images imported into OMERO is not intuitive at the moment. Use the ``-n NAME`` option of the :doc:`command-line (CLI) importer </users/cli/import>` to achieve explicit naming.
+The default naming of the `OME-NGFF <https://ngff.openmicroscopy.org/latest/>`_ Images imported into OMERO is not intuitive at the moment. Use the :option:`omero import -n` option to achieve explicit naming.
 
 Depth of scanning prior to import
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/omero/users/cli/import.rst
+++ b/omero/users/cli/import.rst
@@ -32,8 +32,6 @@ Some of the options available to the import command are:
 
 .. option:: -h, --help
 
-    Examples of options available to the import command,
-
 .. option:: -s SERVER, -p PORT, -U USERNAME, -g GROUPNAME
 
     To avoid prompts for servername, port, username and group, use::
@@ -50,7 +48,6 @@ Some of the options available to the import command are:
 
     See :doc:`import-target` for more information on import targets.
 
-
 .. option:: -n NAME, --name NAME
 .. option:: -x DESCRIPTION, --description DESCRIPTION
 
@@ -59,10 +56,9 @@ Some of the options available to the import command are:
         $ omero import image.tif -n "control image1" -x "PBS Control"
         $ omero import image.tif --name image2.tif --description "negative control"
 
+.. option:: --logprefix [LOGPREFIX]
 
-  --logprefix [LOGPREFIX]               Directory or file prefix for --file and --errs
-  --file [FILE]                         File for storing the standard output from the Java process
-  --errs [ERRS]                         File for storing the standard error from the Java process
+    Directory or file prefix for --file and --errs
 
 .. option:: --file FILE
 

--- a/omero/users/cli/import.rst
+++ b/omero/users/cli/import.rst
@@ -56,10 +56,6 @@ Some of the options available to the import command are:
         $ omero import image.tif -n "control image1" -x "PBS control"
         $ omero import image.tif --name image2 --description second_batch
 
-.. option:: --logprefix [LOGPREFIX]
-
-    Directory or file prefix for --file and --errs
-
 .. option:: --file FILE
 
     File for storing the standard output from the Java process

--- a/omero/users/cli/import.rst
+++ b/omero/users/cli/import.rst
@@ -40,16 +40,25 @@ Some of the options available to the import command are:
 
         $ omero import -s SERVER -p PORT -u USER -g GROUP image.tif
 
-.. option:: -d DATASET_ID, -r SCREEN_ID, -T TARGET, --target TARGET, -n NAME, --name NAME, -x DESCRIPTION, --description DESCRIPTION
+.. option:: -d DATASET_ID, -r SCREEN_ID, -T TARGET, --target TARGET
     
     To import images into a Dataset::
 
         $ omero import image.tif -d 2
         $ omero import image.tif -T Dataset:id:2
         $ omero import image.tif -T Dataset:name:Sample01
-        $ omero import image.tif --name "Control image1" --description "PBS Control" -T Dataset:name:Controls
 
     See :doc:`import-target` for more information on import targets.
+
+
+.. option:: -n NAME, --name NAME
+.. option:: -x DESCRIPTION, --description DESCRIPTION
+
+    To change name of image and add a description::
+
+        $ omero import image.tif -n "control image1" -x "PBS Control"
+        $ omero import image.tif --name image2.tif --description "negative control"
+
 
   --logprefix [LOGPREFIX]               Directory or file prefix for --file and --errs
   --file [FILE]                         File for storing the standard output from the Java process

--- a/omero/users/cli/import.rst
+++ b/omero/users/cli/import.rst
@@ -51,7 +51,7 @@ Some of the options available to the import command are:
 .. option:: -n NAME, --name NAME
 .. option:: -x DESCRIPTION, --description DESCRIPTION
 
-    To change name of image and add a description::
+    To change the name of an image and add a description::
 
         $ omero import image.tif -n "control image1" -x "PBS control"
         $ omero import image.tif --name image2 --description second_batch

--- a/omero/users/cli/import.rst
+++ b/omero/users/cli/import.rst
@@ -53,8 +53,8 @@ Some of the options available to the import command are:
 
     To change name of image and add a description::
 
-        $ omero import image.tif -n "control image1" -x "PBS Control"
-        $ omero import image.tif --name image2.tif --description "negative control"
+        $ omero import image.tif -n "control image1" -x "PBS control"
+        $ omero import image.tif --name image2 --description second_batch
 
 .. option:: --logprefix [LOGPREFIX]
 

--- a/omero/users/cli/import.rst
+++ b/omero/users/cli/import.rst
@@ -40,13 +40,14 @@ Some of the options available to the import command are:
 
         $ omero import -s SERVER -p PORT -u USER -g GROUP image.tif
 
-.. option:: -d DATASET_ID, -r SCREEN_ID, -T TARGET, --target TARGET
+.. option:: -d DATASET_ID, -r SCREEN_ID, -T TARGET, --target TARGET, -n NAME, --name NAME, -x DESCRIPTION, --description DESCRIPTION
     
     To import images into a Dataset::
 
         $ omero import image.tif -d 2
         $ omero import image.tif -T Dataset:id:2
         $ omero import image.tif -T Dataset:name:Sample01
+        $ omero import image.tif --name "Control image1" --description "PBS Control" -T Dataset:name:Controls
 
     See :doc:`import-target` for more information on import targets.
 


### PR DESCRIPTION
see https://github.com/ome/omero-documentation/issues/2249 for background.

Adds -n and -x options.

@sbesson Also added one example of usage. To be honest, I was confused myself, cf. paragraph "java options" of the same doc which seems to be asking for two double-dashes. Nevertheless, tested the example which I added as well as the variants -n and --name and -x and --description, all works.
