### PR TITLE
Add PostgreSQL 13 and 14 to the version requirements table

### DIFF
--- a/omero/sysadmins/version-requirements.rst
+++ b/omero/sysadmins/version-requirements.rst
@@ -317,8 +317,22 @@ OMERO support policies
       - |Recommended|
       - |Recommended|
     * - 12
-      - Oct 2019
+      - Sep 2019
       - Nov 2024
+      - |Upcoming|
+      - |Upcoming|
+      - |Supported|
+      - |Supported|
+    * - 13
+      - Sep 2020
+      - Nov 2025
+      - |Upcoming|
+      - |Upcoming|
+      - |Supported|
+      - |Supported|
+    * - 14
+      - Sep 2021
+      - Nov 2026
       - |Upcoming|
       - |Upcoming|
       - |Supported|
@@ -352,6 +366,16 @@ If no version is provided, a suitable repository is indicated.
     * - 12
       - 6 (`postgresql <https://yum.postgresql.org/12/redhat/rhel-6-x86_64/>`__), 7 (`postgresql <https://yum.postgresql.org/12/redhat/rhel-7-x86_64/>`__), 8 (`postgresql <https://yum.postgresql.org/12/redhat/rhel-8-x86_64/>`__)
       - 16.04, 18.04, 20.04 (`postgresql <https://apt.postgresql.org/pub/repos/apt/>`__)
+      - Yes
+      - Yes
+    * - 13
+      - 7 (`postgresql <https://yum.postgresql.org/13/redhat/rhel-7-x86_64/>`__)
+      - 16.04, 18.04, 20.04 (`postgresql <https://apt.postgresql.org/pub/repos/apt/>`__)
+      - Yes
+      - Yes
+    * - 14
+      - 7 (`postgresql <https://yum.postgresql.org/14/redhat/rhel-7-x86_64/>`__)
+      - 18.04, 20.04 (`postgresql <https://apt.postgresql.org/pub/repos/apt/>`__)
       - Yes
       - Yes
     * - Details


### PR DESCRIPTION
Tentatively mark both versions under the same support levels as PostgreSQL 12 for the OMERO 5.6 series but as discussed this morning testing is on its way.