### PR TITLE
fix the link

### DIFF
--- a/omero/sysadmins/config.rst
+++ b/omero/sysadmins/config.rst
@@ -500,7 +500,7 @@ Default: `psql`
 omero.db.properties
 ^^^^^^^^^^^^^^^^^^^
 Properties to set on OMERO.server's JDBC connection to the database.
-See https://jdbc.postgresql.org/documentation/head/connect.html
+See https://jdbc.postgresql.org/documentation/use/#connecting-to-the-database
 
 Default: `[empty]`
 


### PR DESCRIPTION
fix the link. this will be overridden when a new release openmicroscopy
The correct fix is https://github.com/ome/omero-model/pull/86 but it will require a full stack release