### PR TITLE
switch to new output command

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -43,7 +43,7 @@ jobs:
           elif [[ "omeroweb-install" =~ .*"$file".* ]]; then
               value="${value} omeroweb-install"
           fi
-          echo "::set-output name=value::$value"
+          echo "value=$value" >> $GITHUB_OUTPUT
       # - name: Create Pull Request
       #  uses: peter-evans/create-pull-request@v4
       #  with:


### PR DESCRIPTION
Check that the build is green
Background https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ 