### PR TITLE
Project/dataset target: convert note into a warning

### DIFF
--- a/omero/users/cli/import-target.rst
+++ b/omero/users/cli/import-target.rst
@@ -83,9 +83,9 @@ for the import of the image and linked to Project ``Proj1``.
 
 .. warning::
 
-   In the case where ``New Dataset`` exists and has been linked prior to your
-   import to some other Project (for example ``ProjP``), the ``New Dataset`` will
-   be used as the target dataset container and will be linked  both to ``ProjP``
+  If a Dataset named ``New Dataset`` already exists and has been linked prior to your
+   import to some other Project (for example ``ProjP``), this existing Dataset will
+   be used as the target Dataset container and will be linked  both to ``ProjP``
    and ``Proj1`` after the import.
 
 Importing using regular expressions

--- a/omero/users/cli/import-target.rst
+++ b/omero/users/cli/import-target.rst
@@ -81,9 +81,12 @@ import of the image and linked to the Project ``Proj1``, except in case a
 Dataset ``New Dataset`` already exists. Then, the existing Dataset will be used
 for the import of the image and linked to Project ``Proj1``.
 
-Note that ``New Dataset`` could have been linked prior to your import to some
-other Project (for example ``ProjP``). In such a case, the ``New Dataset`` will
-be linked both to ``ProjP`` and ``Proj1`` after the import.
+.. warning::
+
+   In the case where ``New Dataset`` exists and has been linked prior to your
+   import to some other Project (for example ``ProjP``), the ``New Dataset`` will
+   be used as the target dataset container and will be linked  both to ``ProjP``
+   and ``Proj1`` after the import.
 
 Importing using regular expressions
 -----------------------------------

--- a/omero/users/cli/import-target.rst
+++ b/omero/users/cli/import-target.rst
@@ -83,7 +83,7 @@ for the import of the image and linked to Project ``Proj1``.
 
 .. warning::
 
-  If a Dataset named ``New Dataset`` already exists and has been linked prior to your
+   If a Dataset named ``New Dataset`` already exists and has been linked prior to your
    import to some other Project (for example ``ProjP``), this existing Dataset will
    be used as the target Dataset container and will be linked  both to ``ProjP``
    and ``Proj1`` after the import.


### PR DESCRIPTION
Given the impact when dealing with non-unique dataset names linked to various projects, this tries to highlight the caveats associated with the current implementation as a warning on the doc page.

Note this does not resolve the underlying issue or offer an alternative semantics that does "the right thing" (see https://github.com/ome/omero-blitz/issues/91 for the reference issue). Re-reading the documentation, I found that the note is currently buried in the paragraph and should at least be elevated to another level so that consumers have to review it.