### PR TITLE
point to tag instead of master

### DIFF
--- a/omero/developers/Web.rst
+++ b/omero/developers/Web.rst
@@ -17,7 +17,7 @@ makes it possible to extend OMERO.web with your own apps.
 
 Since version 5.14.0, OMERO.web depends on Django 3.2.x. 
 Plugin developers should read the
-`Guide <https://github.com/ome/omero-web/blob/master/MIGRATION_TO_DJANGO_32_GUIDE.md>`_
+`Guide <https://github.com/ome/omero-web/blob/v5.14.0/MIGRATION_TO_DJANGO_32_GUIDE.md>`_
 detailing how to migrate their plugin(s) to Django 3.2.x.
 
 OMERO.web infrastructure


### PR DESCRIPTION
This point to the tag. That will prevent the broken link
Page to be reviewed/migrated at a later stage.