### PR TITLE
Add section about clearing the sessions store during OMERO.web upgrade

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,6 +8,7 @@ version: 2
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: omero/conf.py
+  fail_on_warning: true
 
 # Build documentation with MkDocs
 #mkdocs:

--- a/omero/sysadmins/omeroweb-upgrade.rst
+++ b/omero/sysadmins/omeroweb-upgrade.rst
@@ -110,7 +110,7 @@ The process for clearing the session store depends on the storage backend:
   `omeroweb.filesessionstore` or  `django.contrib.sessions.backends.file`
   or if :property:`omero.web.session_engine` is unset.
 
-  Session data is stored under a temporary folder determined by the output of
+  Sessions are stored under a temporary folder determined by the output of
   `tempfile.gettempdir()`, usually `/tmp`. By default, each session is
   stored as a separate file prefixed with `sessionid` so the following command
   will delete all stored sessions::
@@ -128,7 +128,7 @@ The process for clearing the session store depends on the storage backend:
   `django.core.cache.backends.redis.RedisCache` and `LOCATION` to
   the URL of the Redis instance.
 
-  Session data is stored as key/value pairs in the Redis store with the name of
+  Sessions are stored as key/value pairs in the Redis store with the name of
   the key including `django.contrib.sessions.cache` and can be managed using
   the :program:`redis-cli` utility. Assuming a default local Redis store, the
   following command can be used to delete all the Redis keys associated with

--- a/omero/sysadmins/omeroweb-upgrade.rst
+++ b/omero/sysadmins/omeroweb-upgrade.rst
@@ -110,10 +110,10 @@ via :property:`omero.web.session_engine`:
   `omeroweb.filesessionstore` or `django.contrib.sessions.backends.file`,
   OMERO.web will use file-based sessions. The session files are stored under a
   temporary folder determined by the the output of `tempfile.gettempdir()`,
-  usually `/tmp` and prefixed either with with the value of
+  usually `/tmp` and prefixed either by the value of
   :property:`omero.web.session_cookie_name` if the property if set of by
-  `sessionid` by default.
-  For a default configuration, the the following command will
+  `sessionid` if the property is unset.
+  For a default configuration, the following command will
   typically delete all file sessions::
 
       $ rm /tmp/sessionid*

--- a/omero/sysadmins/omeroweb-upgrade.rst
+++ b/omero/sysadmins/omeroweb-upgrade.rst
@@ -105,7 +105,7 @@ stored or if the session serialization format has been modified via
 
 The process for clearing the session store depends on the storage backend:
 
-- OMERO.web session data is stored on the filesystem if the
+- OMERO.web sessions are stored on the filesystem if the
   :property:`omero.web.session_engine` property is set to either
   `omeroweb.filesessionstore` or  `django.contrib.sessions.backends.file`
   or if :property:`omero.web.session_engine` is unset.
@@ -121,7 +121,7 @@ The process for clearing the session store depends on the storage backend:
   used as the prefix of the file sessions and the command above needs
   to be modified accordingly.
 
-- OMERO.web session data is stored using the `Redis <https://redis.io/>`_ store
+- OMERO.web sessions are stored using the `Redis <https://redis.io/>`_ store
   if the :property:`omero.web.session_engine` property is set to
   `django.contrib.sessions.backends.cache` and Redis is configured via the
   :property:`omero.web.caches` property by setting the `BACKEND` to

--- a/omero/sysadmins/omeroweb-upgrade.rst
+++ b/omero/sysadmins/omeroweb-upgrade.rst
@@ -114,7 +114,7 @@ via :property:`omero.web.session_engine`:
   :property:`omero.web.session_cookie_name` if the property if set of by
   `sessionid` by default.
   For a default configuration, the the following command will
-  typically delete all file sessions:
+  typically delete all file sessions::
 
       $ rm /tmp/sessionid*
 
@@ -124,7 +124,7 @@ via :property:`omero.web.session_engine`:
   Redis cache backend, sessions are stored using keys prefixed with
   `django.contrib.sessions.cache` and can be cleared using :cmd:`redis-cli`.
   In a default configuration, the following command will delete all the
-  keys associated with OMERO.web sessions:
+  keys associated with OMERO.web sessions::
 
       $ redis-cli keys '*django.contrib.sessions.cache*'  | xargs redis-cli del
 

--- a/omero/sysadmins/omeroweb-upgrade.rst
+++ b/omero/sysadmins/omeroweb-upgrade.rst
@@ -125,7 +125,7 @@ The process for clearing the session store depends on the storage backend:
   if the :property:`omero.web.session_engine` property is set to
   `django.contrib.sessions.backends.cache` and Redis is configured via the
   :property:`omero.web.caches` property by setting the `BACKEND` to
-  'django.core.cache.backends.redis.RedisCache' and `LOCATION` to
+  `django.core.cache.backends.redis.RedisCache` and `LOCATION` to
   the URL of the Redis instance.
 
   Session data is stored as key/value pairs in the Redis store with the name of

--- a/omero/sysadmins/omeroweb-upgrade.rst
+++ b/omero/sysadmins/omeroweb-upgrade.rst
@@ -103,31 +103,41 @@ stored or if the session serialization format has been modified via
    Clearing the sessions store will terminate all OMERO.web sessions and log
    out all users.
 
-The process for clearing the store depends on the storage backend configured
-via :property:`omero.web.session_engine`:
+The process for clearing the session store depends on the storage backend:
 
-- if :property:`omero.web.session_engine` is either unset or set to
-  `omeroweb.filesessionstore` or `django.contrib.sessions.backends.file`,
-  OMERO.web will use file-based sessions. The session files are stored under a
-  temporary folder determined by the output of `tempfile.gettempdir()`,
-  usually `/tmp` and prefixed either by the value of
-  :property:`omero.web.session_cookie_name` if the property is set or by
-  `sessionid` if the property is unset.
-  For a default configuration, the following command will
-  typically delete all file sessions::
+- OMERO.web session data is stored on the filesystem if the
+  :property:`omero.web.session_engine` property is set to either
+  `omeroweb.filesessionstore` or  `django.contrib.sessions.backends.file`
+  or if :property:`omero.web.session_engine` is unset.
 
-      $ rm /tmp/sessionid*
+  Session data is stored under a temporary folder determined by the output of
+  `tempfile.gettempdir()`, usually `/tmp`. By default, each session is
+  stored as a separate file prefixed with `sessionid` so the following command
+  will delete all stored sessions::
 
-- if :property:`omero.web.session_engine` is set to
-  `django.contrib.sessions.backends.cache`, OMERO.web uses cached sessions
-  with a cache backend configured via :property:`omero.web.caches`. For a
-  `Redis <https://redis.io/>`_ cache backend, sessions are stored using keys
-  prefixed with `django.contrib.sessions.cache` and can be cleared using
-  :program:`redis-cli`.
-  In a default configuration, the following command will delete all the
-  keys associated with OMERO.web sessions::
+    $ rm /tmp/sessionid*
+
+  If :property:`omero.web.session_cookie_name` is set, its value will be
+  used as the prefix of the file sessions and the command above needs
+  to be modified accordingly.
+
+- OMERO.web session data is stored using the `Redis <https://redis.io/>`_ store
+  if the :property:`omero.web.session_engine` property is set to
+  `django.contrib.sessions.backends.cache` and Redis is configured via the
+  :property:`omero.web.caches` property by setting the `BACKEND` to
+  'django.core.cache.backends.redis.RedisCache' and `LOCATION` to
+  the URL of the Redis instance.
+
+  Session data is stored as key/value pairs in the Redis store with the name of
+  the key including `django.contrib.sessions.cache` and can be managed using
+  the :program:`redis-cli` utility. Assuming a default local Redis store, the
+  following command can be used to delete all the Redis keys associated with
+  OMERO.web sessions::
 
       $ redis-cli keys '*django.contrib.sessions.cache*'  | xargs redis-cli del
+
+  If Redis URL points to a different hostname, port or database number, the
+  command above needs to be adjusted accordingly.
 
 Restart OMERO.web
 ^^^^^^^^^^^^^^^^^

--- a/omero/sysadmins/omeroweb-upgrade.rst
+++ b/omero/sysadmins/omeroweb-upgrade.rst
@@ -109,9 +109,9 @@ via :property:`omero.web.session_engine`:
 - if :property:`omero.web.session_engine` is either unset or set to
   `omeroweb.filesessionstore` or `django.contrib.sessions.backends.file`,
   OMERO.web will use file-based sessions. The session files are stored under a
-  temporary folder determined by the the output of `tempfile.gettempdir()`,
+  temporary folder determined by the output of `tempfile.gettempdir()`,
   usually `/tmp` and prefixed either by the value of
-  :property:`omero.web.session_cookie_name` if the property if set of by
+  :property:`omero.web.session_cookie_name` if the property is set of by
   `sessionid` if the property is unset.
   For a default configuration, the following command will
   typically delete all file sessions::

--- a/omero/sysadmins/omeroweb-upgrade.rst
+++ b/omero/sysadmins/omeroweb-upgrade.rst
@@ -122,7 +122,7 @@ via :property:`omero.web.session_engine`:
   `django.contrib.sessions.backends.cache`, OMERO.web uses cached sessions
   with a cache backend configured via :property:`omero.web.caches`. For a
   Redis cache backend, sessions are stored using keys prefixed with
-  `django.contrib.sessions.cache` and can be cleared using :cmd:`redis-cli`.
+  `django.contrib.sessions.cache` and can be cleared using :program:`redis-cli`.
   In a default configuration, the following command will delete all the
   keys associated with OMERO.web sessions::
 

--- a/omero/sysadmins/omeroweb-upgrade.rst
+++ b/omero/sysadmins/omeroweb-upgrade.rst
@@ -87,6 +87,47 @@ All official OMERO.web plugins can be installed from PyPI_.
 You should remove all previously installed plugins and install the latest
 versions using pip.
 
+.. _clearing_session_store:
+
+Clear the sessions store (optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+During an upgrade, it might be necessary to clear the sessions store
+before restarting OMERO.web. This is the case when either OMERO.web or
+Django introduced backwards incompatible changes in the way sessions are
+stored or if the session serialization format has been modified via
+:property:`omero.web.session_serializer`.
+
+.. warning::
+
+   Clearing the sessions store will terminate all OMERO.web sessions and log
+   out all users.
+
+The process for clearing the store depends on the storage backend configured
+via :property:`omero.web.session_engine`:
+
+- if :property:`omero.web.session_engine` is either unset or set to
+  `omeroweb.filesessionstore` or `django.contrib.sessions.backends.file`,
+  OMERO.web will use file-based sessions. The session files are stored under a
+  temporary folder determined by the the output of `tempfile.gettempdir()`,
+  usually `/tmp` and prefixed either with with the value of
+  :property:`omero.web.session_cookie_name` if the property if set of by
+  `sessionid` by default.
+  For a default configuration, the the following command will
+  typically delete all file sessions:
+
+      $ rm /tmp/sessionid*
+
+- if :property:`omero.web.session_engine` is set to
+  `django.contrib.sessions.backends.cache`, OMERO.web uses cached sessions
+  with a cache backend configured via :property:`omero.web.caches`. For a
+  Redis cache backend, sessions are stored using keys prefixed with
+  `django.contrib.sessions.cache` and can be cleared using :cmd:`redis-cli`.
+  In a default configuration, the following command will delete all the
+  keys associated with OMERO.web sessions:
+
+      $ redis-cli keys '*django.contrib.sessions.cache*'  | xargs redis-cli del
+
 Restart OMERO.web
 ^^^^^^^^^^^^^^^^^
 

--- a/omero/sysadmins/omeroweb-upgrade.rst
+++ b/omero/sysadmins/omeroweb-upgrade.rst
@@ -111,7 +111,7 @@ via :property:`omero.web.session_engine`:
   OMERO.web will use file-based sessions. The session files are stored under a
   temporary folder determined by the output of `tempfile.gettempdir()`,
   usually `/tmp` and prefixed either by the value of
-  :property:`omero.web.session_cookie_name` if the property is set of by
+  :property:`omero.web.session_cookie_name` if the property is set or by
   `sessionid` if the property is unset.
   For a default configuration, the following command will
   typically delete all file sessions::

--- a/omero/sysadmins/omeroweb-upgrade.rst
+++ b/omero/sysadmins/omeroweb-upgrade.rst
@@ -121,8 +121,9 @@ via :property:`omero.web.session_engine`:
 - if :property:`omero.web.session_engine` is set to
   `django.contrib.sessions.backends.cache`, OMERO.web uses cached sessions
   with a cache backend configured via :property:`omero.web.caches`. For a
-  Redis cache backend, sessions are stored using keys prefixed with
-  `django.contrib.sessions.cache` and can be cleared using :program:`redis-cli`.
+  `Redis <https://redis.io/>`_ cache backend, sessions are stored using keys
+  prefixed with `django.contrib.sessions.cache` and can be cleared using
+  :program:`redis-cli`.
   In a default configuration, the following command will delete all the
   keys associated with OMERO.web sessions::
 

--- a/omero/sysadmins/troubleshooting.rst
+++ b/omero/sysadmins/troubleshooting.rst
@@ -408,6 +408,15 @@ more details. There are a few known possibilities:
    if all of the prerequisites were installed from
    :doc:`OMERO.web deployment <unix/install-web/web-deployment>`.
 
+OMERO.web fails with start
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If OMERO.web fails to start either with an error or type
+``binascii.Error: Incorrect padding`` or ``json.decoder.JSONDecodeError``,
+your existing sessions are likely incompatible and you will need to follow
+the steps indicated at :ref:`clearing_session_store` to clear the sessions
+store.
+
 .. _client_performance:
 
 Troubleshooting performance issues with the clients

--- a/omero/sysadmins/troubleshooting.rst
+++ b/omero/sysadmins/troubleshooting.rst
@@ -408,8 +408,8 @@ more details. There are a few known possibilities:
    if all of the prerequisites were installed from
    :doc:`OMERO.web deployment <unix/install-web/web-deployment>`.
 
-OMERO.web fails with start
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+OMERO.web fails to start
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 If OMERO.web fails to start either with an error or type
 ``binascii.Error: Incorrect padding`` or ``json.decoder.JSONDecodeError``,


### PR DESCRIPTION
See https://github.com/ome/omero-web/pull/435, https://github.com/ome/omero-web/issues/459 and https://github.com/ome/omero-web/issues/383 for more context about the requirement for this new optional section
See also https://docs.djangoproject.com/en/3.2/topics/http/sessions/ for some reference documentation about the different types of Django session store backends.

Motivated by some of the changes introduced in OMERO.web 5.18.0. It is expected the same issues will arise when switching to Django 4.2 and this could happen anytime if the session serialization format is modified.

A new paragraph about common issues when OMERO.server fails to start is also added to the troubleshooting section and this PR should create a link that can be reference from UPGRADING.md in the source code repo.