### PR TITLE
Add reference to DH-key exchange issues and potential solution to CentOS7 install docs

### DIFF
--- a/omero/sysadmins/unix/server-centos7-ice36.rst
+++ b/omero/sysadmins/unix/server-centos7-ice36.rst
@@ -119,6 +119,15 @@ Configure the database and the location of the data directory:
     :start-after: #start-seclevel
     :end-before: #end-seclevel
 
+Additionally on CentOS7, it is necessary to prevent the OMERO.server from advertising Diffie-Hellmann key exchange to the clients. 
+While this key-exchange algorithm is disabled in the OMERO side, if it is advertised it can lead to client errors
+(e.g. omero-py>=5.13.0), which will fail to connect to OMERO because of a dh-key error. To prevent this, it might be necessary to remove 
+Diffie-Hellmann key exchange from the IceSSL configuration. On CentOS7, this can be done by running the following code:
+
+.. literalinclude:: walkthrough/walkthrough_centos7.sh
+    :start-after: #start-diffie-hellman
+    :end-before: #end-diffie-hellman
+
 See also :doc:`../client-server-ssl`.
 
 Running OMERO.server

--- a/omero/sysadmins/unix/walkthrough/walkthrough_centos7.sh
+++ b/omero/sysadmins/unix/walkthrough/walkthrough_centos7.sh
@@ -102,6 +102,7 @@ omero certificates
 omero config set omero.glacier2.IceSSL.Ciphers=HIGH:!DH
 #end-diffie-hellman
 
+
 #start-step06: As root, run the scripts to start OMERO automatically
 cp omero-server-systemd.service /etc/systemd/system/omero-server.service
 

--- a/omero/sysadmins/unix/walkthrough/walkthrough_centos7.sh
+++ b/omero/sysadmins/unix/walkthrough/walkthrough_centos7.sh
@@ -102,7 +102,6 @@ omero certificates
 omero config set omero.glacier2.IceSSL.Ciphers=HIGH:!DH
 #end-diffie-hellman
 
-
 #start-step06: As root, run the scripts to start OMERO automatically
 cp omero-server-systemd.service /etc/systemd/system/omero-server.service
 


### PR DESCRIPTION
As discussed extensively on image.sc  https://forum.image.sc/t/omero-login-ssl-error-dh-key/79574/12, there are some issues with CentOS7 and dh-key parameters for omero-py>=5.13.0. As a stopgap before a more permanent fix in omero-server or omero-certifactes, I propose adding a bit of documentation to this guide.