### PR TITLE
Renaming webtagging doc

### DIFF
--- a/omero/developers/Web.rst
+++ b/omero/developers/Web.rst
@@ -70,8 +70,9 @@ It also includes utilities for creating and retrieving connections to OMERO
 -  **omero-iviewer:** The `OMERO.iviewer <https://github.com/ome/omero-iviewer>`_
    is a new (currently unreleased) image viewer that supports ROI creation and editing.
 
--  **webtagging:** The `webtagging <https://github.com/MicronOxford/webtagging>`_ app
-   was developed externally by Douglas Russell. It supports 'auto' tagging based on
+-  **webtagging:** The webtagging apps `OMERO.autotag <https://github.com/German-BioImaging/omero-autotag>`_ 
+   and `OMERO.tagsearch <https://github.com/German-BioImaging/omero-tagsearch>`_
+   were developed externally by Douglas Russell. It supports 'auto' tagging based on
    image name and Tag-based filtering of data.
 
 -  **omero-mapr:** The `OMERO.mapr <https://github.com/ome/omero-mapr/>`_ app

--- a/omero/developers/Web/WebclientPlugin.rst
+++ b/omero/developers/Web/WebclientPlugin.rst
@@ -3,7 +3,8 @@ Webclient Plugins
 
 The webclient UI can be configured to include content from other web apps.
 This allows you to extend the webclient UI with your own functionality.
-This is used by the `webtagging app <https://github.com/MicronOxford/webtagging>`_
+This is used by the webtagging apps `autotag <https://github.com/German-BioImaging/omero-autotag>`_
+and `tagsearch <https://github.com/German-BioImaging/omero-tagsearch>`_,
 and there are also some examples in the `omero-webtest <https://github.com/ome/omero-webtest/>`_ repository.
 
 
@@ -170,7 +171,7 @@ list.
 ::
 
     $ omero config append omero.web.ui.center_plugins
-        '["Auto Tag", "webtagging/auto_tag_init.js.html", "auto_tag_panel"]'
+        '["Auto Tag", "omero_autotag/auto_tag_init.js.html", "auto_tag_panel"]'
 
 The right_plugins list includes the `Acquisition` tab and `Preview` tab by
 default. If you want to append the OMERO.webtest ROI plugin or your own plugin


### PR DESCRIPTION
Update of the doc to reflect the changes of the webtagging repo, split  into two: 
`omero-tagsearch` and `omero-autotag`

Cf to the two corresponding PR:
- [omero-tagsearch PR](https://github.com/German-BioImaging/omero-tagsearch/pull/5)
- [omero-autotag PR](https://github.com/German-BioImaging/omero-autotag/pull/6)