### PR TITLE
Define mandatory version variable in Sphinx configuration

### DIFF
--- a/omero/conf.py
+++ b/omero/conf.py
@@ -68,7 +68,7 @@ def get_previous_version(majornumber, minornumber=0):
 [majornumber, minornumber, patchnumber] = split_release(conf_autogen.version_openmicroscopy)
 
 # Define Sphinx version and release variables and development branch
-current_version = ".".join(str(x) for x in (majornumber, minornumber))
+version = ".".join(str(x) for x in (majornumber, minornumber))
 
 if patchnumber > 0:
     tags.add('point_release')
@@ -192,7 +192,7 @@ rst_epilog += """
                   :alt: Unsupported
 .. |Upcoming| image:: /images/upcoming.png
                :alt: Upcoming
-""" % (current_version, previousversion,
+""" % (version, previousversion,
        conf_autogen.current_dbver,
        conf_autogen.previous_dbver,
        conf_autogen.version_py,


### PR DESCRIPTION
Motivated by the fact https://omero.readthedocs.io/en/latest/sysadmins/omeroweb-upgrade.html does not include the changes from #2312

From an initial investigation, it looks like the readthedocs builds failed in https://readthedocs.org/projects/omero/builds/21096892/. This a combination of the following warning which has been present on all recent builds

```
WARNING: conf value "version" should not be empty for EPUB3
```

and the enforcement of `fail_on_warnings` in [c2ea308](https://github.com/ome/omero-documentation/commit/c2ea308dca200aea5f6435a7b560cdf0980f0d6f) to match the expectation of OME Jenkins CI.

To fix this issue, 5cb92a76a3e2705c30ffeafea1d75d5bac4f9bfd renames the `current_version` variable under `conf.py` as `version`. All rST usages of the `|current_version|` replacement should remain functional (although they could arguable be replaced by `|version|`)
