### PR TITLE
remove reference to build number

### DIFF
--- a/omero/sysadmins/server-upgrade.rst
+++ b/omero/sysadmins/server-upgrade.rst
@@ -171,12 +171,9 @@ directory, you are safe to follow the following upgrade procedure:
 
     $ cd ..
     $ mv OMERO.server OMERO.server-old
-    $ unzip OMERO.server-|version_openmicroscopy|-ice36-byy.zip
-    $ ln -s OMERO.server-||version_openmicroscopy|-ice36-byy OMERO.server
+    $ unzip OMERO.server-|version_openmicroscopy|-ice36.zip
+    $ ln -s OMERO.server-||version_openmicroscopy|-ice36 OMERO.server
     $ cp OMERO.server-old/etc/grid/config.xml OMERO.server/etc/grid
-
-.. note::
-    ``byy`` **needs to be replaced** by the appropriate build number of OMERO.server.
 
 .. _upgradedb:
 

--- a/omero/sysadmins/unix/server-installation.rst
+++ b/omero/sysadmins/unix/server-installation.rst
@@ -269,7 +269,7 @@ of Ice installed, unpack it:
 
 .. parsed-literal::
 
-    $ unzip OMERO.server-|version_openmicroscopy|-ice36-byy.zip
+    $ unzip OMERO.server-|version_openmicroscopy|-ice36.zip
 
 If your system does not provide an :program:`unzip` command by
 default, install one of the following:
@@ -297,7 +297,7 @@ typing later, to reflect what you set :envvar:`OMERO_PREFIX` to in the
 
 .. parsed-literal::
 
-    $ ln -s OMERO.server-|version_openmicroscopy|-ice36-byy OMERO.server
+    $ ln -s OMERO.server-|version_openmicroscopy|-ice36 OMERO.server
 
 This will also ease installation of newer versions of the server at a
 later date, by simply updating the link.


### PR DESCRIPTION
We use GHA. we no longer have a build number
see https://downloads.openmicroscopy.org/omero/5.6.8/artifacts/