### PR TITLE
remove pg version 10, no longer available for downloads

### DIFF
--- a/omero/sysadmins/version-requirements.rst
+++ b/omero/sysadmins/version-requirements.rst
@@ -330,13 +330,6 @@ If no version is provided, a suitable repository is indicated.
       - Ubuntu
       - Homebrew
       - FreeBSD Ports
-    * - 10
-      - 6 (`postgresql <https://yum.postgresql.org/10/redhat/rhel-6-x86_64/>`__),
-	7 (`postgresql <https://yum.postgresql.org/10/redhat/rhel-7-x86_64/>`__),
-	8 (`postgresql <https://yum.postgresql.org/10/redhat/rhel-8-x86_64/>`__)
-      - 14.04, 16.04, 18.04 (`postgresql <https://apt.postgresql.org/pub/repos/apt/>`__)
-      - Yes
-      - Yes
     * - 11
       - 6 (`postgresql <https://yum.postgresql.org/11/redhat/rhel-6-x86_64/>`__), 7 (`postgresql <https://yum.postgresql.org/11/redhat/rhel-7-x86_64/>`__), 8 (`postgresql <https://yum.postgresql.org/11/redhat/rhel-8-x86_64/>`__)
       - 16.04, 18.04, 20.04 (`postgresql <https://apt.postgresql.org/pub/repos/apt/>`__)

--- a/omero/sysadmins/version-requirements.rst
+++ b/omero/sysadmins/version-requirements.rst
@@ -291,7 +291,7 @@ OMERO support policies
       - Nov 2022
       - |Upcoming|
       - |Recommended|
-      - |Supported|
+      - |Deprecated|
     * - 11
       - Oct 2018
       - Nov 2023


### PR DESCRIPTION
No more version 10 available at https://download.postgresql.org/pub/repos/yum/