### PR TITLE
Server certificates: review of upgrade & troubleshooting sections

### DIFF
--- a/omero/conf.py
+++ b/omero/conf.py
@@ -392,8 +392,8 @@ def copy_legacy_redirects(app, exception):
     ]
     if app.builder.name == 'html':
         for html_src_path in redirect_files:
-            target_path = (app.outdir / html_src_path)
-            src_path = (app.srcdir / html_src_path)
+            target_path = app.outdir + '/' + html_src_path
+            src_path = app.srcdir + '/' + html_src_path
             if os.path.isfile(src_path):
                 target_dir = os.path.dirname(target_path)
                 if not os.path.exists(target_dir):

--- a/omero/conf.py
+++ b/omero/conf.py
@@ -392,8 +392,8 @@ def copy_legacy_redirects(app, exception):
     ]
     if app.builder.name == 'html':
         for html_src_path in redirect_files:
-            target_path = app.outdir + '/' + html_src_path
-            src_path = app.srcdir + '/' + html_src_path
+            target_path = (app.outdir / html_src_path)
+            src_path = (app.srcdir / html_src_path)
             if os.path.isfile(src_path):
                 target_dir = os.path.dirname(target_path)
                 if not os.path.exists(target_dir):

--- a/omero/sysadmins/client-server-ssl.rst
+++ b/omero/sysadmins/client-server-ssl.rst
@@ -16,8 +16,9 @@ Server certificate
 
 The easiest solution is to use the `omero-certificates <https://github.com/ome/omero-certificates>`_ plugin to
 generate self-signed server certificates alongside their associated configuration.
+This workflow is described in the particular sections of :doc:`unix/server-installation` documentation.
 
-It is also possible to re-use the SSL certificates used to protect OMERO.web. First convert
+Here we describe an alternative option to the usage of the `omero-certificates <https://github.com/ome/omero-certificates>`_ plugin. This option is re-using the SSL certificates used to protect OMERO.web. First convert
 the public certificate :file:`server.pem` and private key :file:`server.key`
 to the PKCS12 format where ``secret`` is the password used to protect the combined output file :file:`server.p12`::
 

--- a/omero/sysadmins/client-server-ssl.rst
+++ b/omero/sysadmins/client-server-ssl.rst
@@ -8,14 +8,18 @@ OMERO.server and clients do not automatically support host verification, so a
 is possible.
 This may result in users inadvertently transmitting their login credentials to an attacker.
 
-This can be remedied by configuring OMERO.server with a certificate (the same certificate used for OMERO.web Nginx may work), and ensuring all OMERO clients are configured to verify the server certificate before connecting.
+This can be remedied by configuring OMERO.server with a certificate and ensuring all OMERO clients are configured to verify the server certificate before connecting.
 
 
 Server certificate
 ------------------
 
-The easiest solution is to re-use the SSL certificates used to protect OMERO.web.
-First convert the public certificate :file:`server.pem` and private key :file:`server.key` to the PKCS12 format where ``secret`` is the password used to protect the combined output file :file:`server.p12`::
+The easiest solution is to use the `omero-certificates <https://github.com/ome/omero-certificates>`_ plugin to
+generate self-signed server certificates alongside their associated configuration.
+
+It is also possible to re-use the SSL certificates used to protect OMERO.web. First convert
+the public certificate :file:`server.pem` and private key :file:`server.key`
+to the PKCS12 format where ``secret`` is the password used to protect the combined output file :file:`server.p12`::
 
     openssl pkcs12 -export -out server.p12 -in server.pem -inkey server.key -passout pass:secret
 
@@ -23,19 +27,15 @@ Copy :file:`server.p12` to the OMERO.server host, for instance to :file:`/etc/ss
 
 External access to OMERO.server is managed by the Glacier2 component which can be configured as follows::
 
-    # Enable authenticating ciphers.
-    omero config set omero.glacier2.IceSSL.Ciphers "ADH:HIGH:!LOW:!MD5:!EXP:!3DES:@STRENGTH"
+    omero config set omero.glacier2.IceSSL.Ciphers HIGH
     # Look for certificates in this directory, you can omit and use the full path to files instead
     omero config set omero.glacier2.IceSSL.DefaultDir /etc/ssl/omero/
     omero config set omero.glacier2.IceSSL.CertFile server.p12
     omero config set omero.glacier2.IceSSL.Password secret
-
-For even stronger security require TLS 1.2, disable anonymous ciphers and only allow ``HIGH``::
-
     omero config set omero.glacier2.IceSSL.Protocols tls1_2
     omero config set omero.glacier2.IceSSL.ProtocolVersionMin tls1_2
     omero config set omero.glacier2.IceSSL.ProtocolVersionMax tls1_2
-    omero config set omero.glacier2.IceSSL.Ciphers HIGH
+
 
 Restart OMERO.server.
 

--- a/omero/sysadmins/server-upgrade.rst
+++ b/omero/sysadmins/server-upgrade.rst
@@ -320,13 +320,40 @@ up to date to ensure that security updates are applied:
       $ # first, activate virtualenv where omero-py is installed. Then upgrade:
       $ pip install --upgrade 'omero-py>=\ |version_py|'
 
+.. _server_certificates:
 
 Server certificate
 ^^^^^^^^^^^^^^^^^^
-Since OMERO 5.6.2,  the recommended way to ensure that all OMERO server installations have, at minimum, a self-signed certificate is to use the `OMERO server certificate management plugin <https://github.com/ome/omero-certificates>`_. The plugin will generate or update your self-signed certificates and configure the OMERO.server. For the configuration to take effect, the server needs to be restarted.
-If you prefer to configure the OMERO server certificate manually, check
-:doc:`/sysadmins/client-server-ssl`.
-In OMERO.py version 5.13.0, the Anonymous Diffie-Hellman (ADH) default configuration has been removed. Please ensure that self-signed certificates have been generated and the OMERO.server configured accordingly.
+
+The server should be configured with at least a self-signed certificate to allow
+clients to establish secure connections.
+
+Since OMERO 5.6.2, the recommended way to ensure that all OMERO server installations have
+at minimum, a self-signed certificate is to use the
+`OMERO server certificate management plugin <https://github.com/ome/omero-certificates>`_.
+The plugin will generate or update your self-signed certificates and configure the OMERO.server.
+For the configuration to take effect, the server needs to be restarted.
+If you prefer to configure the OMERO server certificate manually, check:doc:`/sysadmins/client-server-ssl`.
+
+If your server has been configured with a version of `omero-certificates` older than 0.3.0 or
+manually, the configuration may need to be upgraded in particular to
+disallow the `deprecated TLS 1.0 and 1.1 protocols <https://datatracker.ietf.org/doc/html/rfc8996>`_.
+
+To do so, first upgrade `omero-certificates` to version 0.3.0 or later, remove the
+:property:`omero.glacier2.IceSSL.Protocols` and :property:`omero.glacier2.IceSSL.ProtocolVersionMax`
+configurations and finally re-execute the :cmd:`omero certificates` command:
+
+    $ pip install "omero-certificates>=0.3"
+    $ omero config set omero.glacier2.IceSSL.Protocols
+    $ omero config set omero.glacier2.IceSSL.ProtocolVersionMax
+    $ omero certificates
+
+.. note::
+
+   On distributions with a recent version of OpenSSL (1.1+), `omero certificates` will also
+   enable the TLS 1.3 protocol. Note that OMERO clients will need to be upgraded to depend
+   on `omero-blitz` 5.7.0 or greater (Java) or `omero-py` 5.15.0  or greater (Python) in order
+   to negotiate this protocol with the server.
 
 Restart your server
 ^^^^^^^^^^^^^^^^^^^

--- a/omero/sysadmins/server-upgrade.rst
+++ b/omero/sysadmins/server-upgrade.rst
@@ -333,15 +333,16 @@ at minimum, a self-signed certificate is to use the
 `OMERO server certificate management plugin <https://github.com/ome/omero-certificates>`_.
 The plugin will generate or update your self-signed certificates and configure the OMERO.server.
 For the configuration to take effect, the server needs to be restarted.
-If you prefer to configure the OMERO server certificate manually, check:doc:`/sysadmins/client-server-ssl`.
+If you prefer to configure the OMERO server certificate manually, check
+:doc:`/sysadmins/client-server-ssl`.
 
-If your server has been configured with a version of `omero-certificates` older than 0.3.0 or
-manually, the configuration may need to be upgraded in particular to
+If your server has been configured with a version of ``omero-certificates`` older than
+0.3.0 or manually, the configuration may need to be upgraded in particular to
 disallow the `deprecated TLS 1.0 and 1.1 protocols <https://datatracker.ietf.org/doc/html/rfc8996>`_.
 
-To do so, first upgrade `omero-certificates` to version 0.3.0 or later, remove the
+To do so, first upgrade ``omero-certificates`` to version 0.3.0 or later, remove the
 :property:`omero.glacier2.IceSSL.Protocols` and :property:`omero.glacier2.IceSSL.ProtocolVersionMax`
-configurations and finally re-execute the :cmd:`omero certificates` command:
+configurations and finally re-execute the :program:`omero certificates` command::
 
     $ pip install "omero-certificates>=0.3"
     $ omero config set omero.glacier2.IceSSL.Protocols
@@ -352,8 +353,8 @@ configurations and finally re-execute the :cmd:`omero certificates` command:
 
    On distributions with a recent version of OpenSSL (1.1+), `omero certificates` will also
    enable the TLS 1.3 protocol. Note that OMERO clients will need to be upgraded to depend
-   on `omero-blitz` 5.7.0 or greater (Java) or `omero-py` 5.15.0  or greater (Python) in order
-   to negotiate this protocol with the server.
+   on ``omero-blitz`` 5.7.0 or greater (Java) or ``omero-py`` 5.15.0  or greater (Python)
+   in order to negotiate this protocol with the server.
 
 Restart your server
 ^^^^^^^^^^^^^^^^^^^

--- a/omero/sysadmins/server-upgrade.rst
+++ b/omero/sysadmins/server-upgrade.rst
@@ -351,10 +351,11 @@ configurations and finally re-execute the :program:`omero certificates` command:
 
 .. note::
 
-   On distributions with a recent version of OpenSSL (1.1+), `omero certificates` will also
-   enable the TLS 1.3 protocol. Note that OMERO clients will need to be upgraded to depend
-   on ``omero-blitz`` 5.7.0 or greater (Java) or ``omero-py`` 5.15.0  or greater (Python)
-   in order to negotiate this protocol with the server.
+   From version 0.3.0, ``omero certificates`` adds TLS 1.3 to the list of protocols
+   supported server-side for establishing the secure connection on systems where the
+   protocol is supported. In order to negotiate this protocol, clients will also need
+   to be upgraded to depend on ``omero-blitz`` 5.7.0 or greater (Java) or ``omero-py``
+   5.15.0 or greater (Python).
 
 Restart your server
 ^^^^^^^^^^^^^^^^^^^

--- a/omero/sysadmins/server-upgrade.rst
+++ b/omero/sysadmins/server-upgrade.rst
@@ -330,7 +330,7 @@ clients to establish secure connections.
 
 Since OMERO 5.6.2, the recommended way to ensure that all OMERO server installations have
 at minimum, a self-signed certificate is to use the
-`OMERO server certificate management plugin <https://github.com/ome/omero-certificates>`_.
+`omero-certificates <https://pypi.org/project/omero-certificates/>`_ plugin.
 The plugin will generate or update your self-signed certificates and configure the OMERO.server.
 For the configuration to take effect, the server needs to be restarted.
 If you prefer to configure the OMERO server certificate manually, check
@@ -340,7 +340,8 @@ If your server has been configured with a version of ``omero-certificates`` olde
 0.3.0 or manually, the configuration may need to be upgraded in particular to
 disallow the `deprecated TLS 1.0 and 1.1 protocols <https://datatracker.ietf.org/doc/html/rfc8996>`_.
 
-To do so, first upgrade ``omero-certificates`` to version 0.3.0 or later, remove the
+To do so, activate the virtual environment where the server Python dependencies are installed,
+upgrade ``omero-certificates`` to version 0.3.0 or later, remove the
 :property:`omero.glacier2.IceSSL.Protocols` and :property:`omero.glacier2.IceSSL.ProtocolVersionMax`
 configurations and finally re-execute the :program:`omero certificates` command::
 
@@ -351,11 +352,10 @@ configurations and finally re-execute the :program:`omero certificates` command:
 
 .. note::
 
-   From version 0.3.0, ``omero certificates`` adds TLS 1.3 to the list of protocols
-   supported server-side for establishing the secure connection on systems where the
-   protocol is supported. In order to negotiate this protocol, clients will also need
-   to be upgraded to depend on ``omero-blitz`` 5.7.0 or greater (Java) or ``omero-py``
-   5.15.0 or greater (Python).
+   From version 0.3.0, the :program:`omero certificates` command adds TLS 1.3 to the list of
+   TLS protocols allowed assuming the OMERO.server enviroment supports the protocol.
+   In order to negotiate this protocol, clients will also need to be upgraded to depend
+   on ``omero-blitz`` 5.7.0 or greater (Java) or ``omero-py`` 5.15.0 or greater (Python).
 
 Restart your server
 ^^^^^^^^^^^^^^^^^^^

--- a/omero/sysadmins/troubleshooting.rst
+++ b/omero/sysadmins/troubleshooting.rst
@@ -155,21 +155,23 @@ Please see the :doc:`/sysadmins/server-security` page for more information.
 SSL connection issues
 ^^^^^^^^^^^^^^^^^^^^^
 
-Deployment platforms show a trend of making the transport layer security
-policy tighter by default. The recommended way to overcome SSL
-connection issues for OMERO clients connecting to the server is to
-employ the `omero-certificates
-<https://pypi.org/project/omero-certificates/>`_ plugin available from
-PyPI_:
+ - ``javax.net.ssl.SSLHandshakeException: DH ServerKeyExchange does not comply to algorithm constraints``
+ - `` javax.net.ssl.SSLHandshakeException: The server selected protocol version TLS10 is not accepted by client preferences [TLS12]``
+ - ``SSL handshake failure: The parameter is incorrect.``
+ - ``reason = SSL error occurred for new outgoing connection: remote address = XXX.XXX.XXX.XXX:4064 dh key too small```
 
-.. literalinclude:: unix/walkthrough/walkthrough_debian10.sh
-    :start-after: #start-seclevel
-    :end-before: #end-seclevel
+These errors indicate the client is unable to establish a secure connection
+with the server. Deployment platforms show a trend of making the transport
+layer security policy tighter by default.
 
-Restart the OMERO.server as normal for the changes to take effect.
+The recommended way to overcome SSL connection issues for OMERO clients
+connecting to the server is to use the
+`omero-certificates <https://pypi.org/project/omero-certificates/>`_
+plugin available from PyPI_.
 
-An alternative approach is to add the parameter ``@SECLEVEL=0`` to the
-server SSL configuration.
+Follow the instructions from :ref:`server_certificates` to create and
+configure self-signed certificates as necessary on the OMERO.server and
+restart it as normal for the changes to take effect.
 
 Server crashes with...
 ----------------------

--- a/omero/sysadmins/troubleshooting.rst
+++ b/omero/sysadmins/troubleshooting.rst
@@ -156,9 +156,9 @@ SSL connection issues
 ^^^^^^^^^^^^^^^^^^^^^
 
  - ``javax.net.ssl.SSLHandshakeException: DH ServerKeyExchange does not comply to algorithm constraints``
- - `` javax.net.ssl.SSLHandshakeException: The server selected protocol version TLS10 is not accepted by client preferences [TLS12]``
+ - ``javax.net.ssl.SSLHandshakeException: The server selected protocol version TLS10 is not accepted by client preferences [TLS12]``
  - ``SSL handshake failure: The parameter is incorrect.``
- - ``reason = SSL error occurred for new outgoing connection: remote address = XXX.XXX.XXX.XXX:4064 dh key too small```
+ - ``reason = SSL error occurred for new outgoing connection: remote address = XXX.XXX.XXX.XXX:4064 dh key too small``
 
 These errors indicate the client is unable to establish a secure connection
 with the server. Deployment platforms show a trend of making the transport


### PR DESCRIPTION
Hopefully, this brings a conclusion to the great OMERO TLS saga of the Summer 2023 which was partly driven by this image.sc post [^1] and led to various OMERO component releases [^2] [^3] [^4] [^5]. This PR aims to amend the reference OMERO documentation to capture the new requirement in terms of OMERO.server certificates.

As a quick preamble, the problem space is complex as we are dealing with server/client connection issues across a set of environments spanning different versions (& sometimes compilation options) of OpenSSL, Java and Python. This complexity was demonstrated to some extent by the extent of the testing required in order to review, approve and release the set of changes aforementioned.

Probably as important as the code changes, we want to communicate efficiently the impact of these changes with the appropriate level of details/language e.g. end-users wants to understand why they cannot connect to the server or system administrators want to know about to upgrade the server without necessarily feeling they have to understand why ADH configurations have been removed.

This PR amends the three main sections of the reference documentation discussing SSL to capture the latest code/plugin improvements and remove unnecessary technical details:

- the section about the server certificates in the OMERO.server upgrade page is supplemented with instructions about upgrading configurations created by old `omero-certificates` version
- the client/server section is amended to remove all references to weak ciphers or security settings
- the troubleshooting section is supplemented with concrete examples of SSL errors that could be received by an end-user and a link to the certificates section of the server upgrade page

A few notes:
- one of the limitations for the ugprade section is to produce an easy answer to the question "do I need to modify my server SSL configuration?". The current approach as per [^1] and the upcoming OMERO.py 5.16.1 [^6] is to teach various `omero` commands to print loud warnings about the outdated server-side SSL configurations
- the [Client Server SSL verification](https://omero.readthedocs.io/en/stable/sysadmins/client-server-ssl.html#client-server-ssl-verification) has been minimally changed but could possibly use a second round of review (outside the scope of this PR) especially for reviewing the validity the latter sections around certificate authority and client host verification. Arguably, this is the most relevant candidate for a reference page containing the technical details associated with SSL issues if this was deemed to be useful.

Critical feedback and suggestions very welcome in order to find the best wording

[^1]: https://forum.image.sc/t/omero-login-ssl-error-dh-key/79574/17
[^2]: https://github.com/ome/omero-certificates/blob/0.3.0/CHANGELOG.md
[^3]: https://github.com/ome/omero-blitz/blob/v5.7.0/CHANGELOG.md
[^4]: https://github.com/ome/omero-blitz/blob/v5.7.1/CHANGELOG.md
[^5]: https://github.com/ome/omero-py/blob/v5.15.0/CHANGELOG.md#5160-september-2023 
[^6]: https://github.com/ome/omero-py/pull/382