### PR TITLE
pin version to match rtd ones

### DIFF
--- a/omero/conf.py
+++ b/omero/conf.py
@@ -392,8 +392,8 @@ def copy_legacy_redirects(app, exception):
     ]
     if app.builder.name == 'html':
         for html_src_path in redirect_files:
-            target_path = app.outdir + '/' + html_src_path
-            src_path = app.srcdir + '/' + html_src_path
+            target_path = (app.outdir / html_src_path)
+            src_path = (app.srcdir / html_src_path)
             if os.path.isfile(src_path):
                 target_dir = os.path.dirname(target_path)
                 if not os.path.exists(target_dir):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Sphinx
-sphinx-rtd-theme
+sphinx==7.2.0
+sphinx-rtd-theme==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-sphinx==7.2.0
+sphinx==7.2.5
 sphinx-rtd-theme==1.3.0


### PR DESCRIPTION
The requirements file is used by merge-ci job
this PR pins the requirements so it matches the version used on rtd

--exclude