### PR TITLE
Mention docker-example-omero on install pages

### DIFF
--- a/omero/sysadmins/index.rst
+++ b/omero/sysadmins/index.rst
@@ -78,7 +78,9 @@ provided for several systems, with detailed step-by-step instructions.
 Reading through the :doc:`unix/server-installation` and
 :doc:`unix/install-web/web-deployment` pages first
 is recommended as this explains the entire process rather than just being a
-series of commands.
+series of commands. Users who would like to run OMERO with Docker can find
+example instructions at `Docker example OMERO
+<https://github.com/ome/docker-example-omero>`_.
 
 .. toctree::
     :maxdepth: 1

--- a/omero/sysadmins/unix/server-installation.rst
+++ b/omero/sysadmins/unix/server-installation.rst
@@ -13,6 +13,9 @@ This should be read in conjunction with :doc:`../version-requirements`.
 Since 5.6, a new :envvar:`OMERODIR` variable is used, you should first unset :envvar:`OMERO_HOME`
 (if set) before beginning the installation process.
 
+Users who would like to run OMERO with Docker can find
+example instructions at `Docker example OMERO
+<https://github.com/ome/docker-example-omero>`_.
 
 **Recommended:**
 


### PR DESCRIPTION
For any users who wish to find out about our support for Docker, it seems the best place to start is searching image.sc
https://forum.image.sc/search?q=docker%20omero

After reading a lot of those posts I eventually found https://github.com/ome/docker-example-omero.
This is also linked-to from https://www.openmicroscopy.org/explore/ but I never thought to start there. It seems the OMERO install docs are the best place to mention Docker support.