### PR TITLE
Replace "help" with "guides"

### DIFF
--- a/omero/index.rst
+++ b/omero/index.rst
@@ -26,7 +26,7 @@ Additional online resources can be found at:
 
 - :downloads:`Downloads <>`
 - :secvuln:`Security Advisories <>`
-- :help:`User help website <>`
+- `User guides <https://omero-guides.readthedocs.io/>`_
 - `OME YouTube channel <https://www.youtube.com/channel/UCyySB9ZzNi8aBGYqcxSrauQ>`_
   for tutorials and presentations
 - `Demo server <http://qa.openmicroscopy.org.uk/registry/demo_account/>`_ -


### PR DESCRIPTION
I noticed that the index.rst still mentioned "help" and I wanted to update just that listing, but then I noticed that `:help:` is used pervasively throughout the guides. Happy to close this if this is considered confusing, but I'd rather not take on getting rid of `:help:` at the moment.