### PR TITLE
Help2guides

### DIFF
--- a/omero/conf.py
+++ b/omero/conf.py
@@ -108,7 +108,7 @@ oo_root = 'https://www.openmicroscopy.org'
 oo_site_root = oo_root + '/site'
 lists_root = 'http://lists.openmicroscopy.org.uk'
 downloads_root = 'https://downloads.openmicroscopy.org'
-help_root = 'https://help.openmicroscopy.org'
+help_root = 'https://omero-guides.readthedocs.io/en/latest'
 docs_root = 'https://docs.openmicroscopy.org'
 imagesc_root = 'https://forum.image.sc'
 

--- a/omero/developers/Model/Containers.rst
+++ b/omero/developers/Model/Containers.rst
@@ -28,6 +28,5 @@ constraint: a Folder may *not* contain itself, even indirectly.
 The OMERO graphical clients offer very limited support for Folders. At
 present Folders may be most useful for those working with their data via
 the |OmeroApi| and its gateways or with the :doc:`OMERO.cli obj plugin
-</developers/cli/obj>`. The :help:`measurement tool
-<measurement-tool.html>` in OMERO.insight shows the Folders that ROIs
+</developers/cli/obj>`. The `measurement tool` in OMERO.insight shows the Folders that ROIs
 are in. OMERO.web is yet to provide support for Folders.

--- a/omero/developers/Model/KeyValuePairs.rst
+++ b/omero/developers/Model/KeyValuePairs.rst
@@ -88,9 +88,8 @@ This permits the flexible attachment of key-value pairs to
 any of the OME types which are annotatable. Such annotations
 attached to key UI elements like images and datasets will be
 presented by the clients, and can be edited with the
-appropriate permissions. See :help:`Managing Data
-<managing-data.html#keyvalue>` on :help:`OMERO User Help<>`
-for more information.
+appropriate permissions. See the section on :help:`Data Annotation
+<introduction/docs/annotate.html>` in the User guides for more information.
 See examples of creating MapAnnotations in :doc:`Java </developers/Java>`
 and :doc:`Python </developers/Python>` pages.
 

--- a/omero/developers/Web/WebGateway.rst
+++ b/omero/developers/Web/WebGateway.rst
@@ -7,7 +7,7 @@ rendering images and accessing data on the OMERO server via URLs.
 .. note::
 
     The OMERO.web client also supports URLs linking to specified data in
-    OMERO. See the :help:`OMERO.web user guides <>` for more details.
+    OMERO. See the :help:`OMERO.web User guides <>` for more details.
 
 Web services
 ------------

--- a/omero/developers/Web/WebGateway.rst
+++ b/omero/developers/Web/WebGateway.rst
@@ -7,7 +7,7 @@ rendering images and accessing data on the OMERO server via URLs.
 .. note::
 
     The OMERO.web client also supports URLs linking to specified data in
-    OMERO. See the :help:`OMERO.web User guides <>` for more details.
+    OMERO. See the :help:`OMERO.figure User guide <figure/docs/omero_figure.html>` for more details.
 
 Web services
 ------------

--- a/omero/index.rst
+++ b/omero/index.rst
@@ -26,7 +26,7 @@ Additional online resources can be found at:
 
 - :downloads:`Downloads <>`
 - :secvuln:`Security Advisories <>`
-- :help:`User help website <>`
+- `User guides <https://omero-guides.readthedocs.io/>`_
 - `OME YouTube channel <https://www.youtube.com/channel/UCyySB9ZzNi8aBGYqcxSrauQ>`_
   for tutorials and presentations
 - `Demo server <http://qa.openmicroscopy.org.uk/registry/demo_account/>`_ -

--- a/omero/index.rst
+++ b/omero/index.rst
@@ -26,7 +26,7 @@ Additional online resources can be found at:
 
 - :downloads:`Downloads <>`
 - :secvuln:`Security Advisories <>`
-- `User guides <https://omero-guides.readthedocs.io/>`_
+- :help:`User guides <>`
 - `OME YouTube channel <https://www.youtube.com/channel/UCyySB9ZzNi8aBGYqcxSrauQ>`_
   for tutorials and presentations
 - `Demo server <http://qa.openmicroscopy.org.uk/registry/demo_account/>`_ -

--- a/omero/sysadmins/cli/light-admins.rst
+++ b/omero/sysadmins/cli/light-admins.rst
@@ -7,7 +7,7 @@ of the server's underlying permissions restrictions is described in
 :doc:`developer documentation</developers/Server/LightAdmins>`.
 OMERO.web offers easy management of restrictions and is recommended for
 setting up restricted administrators via its :help:`Admin tab
-<facility-manager#lightadmin>`.
+<introduction/docs/group-user-management.html>`.
 
 OMERO.cli does not offer easy management of restrictions because support
 is yet to be added. In the meantime it can already manipulate

--- a/omero/sysadmins/cli/usergroup.rst
+++ b/omero/sysadmins/cli/usergroup.rst
@@ -30,7 +30,7 @@ can be passed as optional arguments to the :program:`omero user add` command.
 For managing the permissions of restricted administrators,
 :doc:`OMERO.cli does provide means <light-admins>` but that functionality
 is not yet offered in a friendly manner by the :program:`omero user` command.
-The :help:`OMERO.web Admin interface <facility-manager#lightadmin>` is
+The :help:`OMERO.web Admin interface <introduction/docs/group-user-management.html>` is
 recommended for this task instead.
 
 If you are using ldap as an authentication backend, you can create

--- a/omero/sysadmins/index.rst
+++ b/omero/sysadmins/index.rst
@@ -5,7 +5,7 @@ System Administrator Documentation
 This documentation begins with information aimed at OS-level administrators
 and moves on to day-to-day management of OMERO for facility managers (who may
 find it useful to read the
-:help:`Facility Managers help guide <facility-manager.html>` for an overview
+:help:`Facility Managers section <example_facility_manager.html>` for an overview
 first).
 
 ***************
@@ -170,7 +170,7 @@ tasks on behalf of all users.
 
     - Command Line Interface guides for :doc:`cli/usergroup` and
       :doc:`/users/cli/chown`
-    - :help:`Facility Managers help guide <facility-manager.html>`
+    - :help:`Wlakthrough for Facility Managers <example_facility_manager.html>`
 
 ***********************
 Data Import and Storage

--- a/omero/sysadmins/index.rst
+++ b/omero/sysadmins/index.rst
@@ -5,7 +5,7 @@ System Administrator Documentation
 This documentation begins with information aimed at OS-level administrators
 and moves on to day-to-day management of OMERO for facility managers (who may
 find it useful to read the
-:help:`Facility Managers section <example_facility_manager.html>` for an overview
+:help:`Facility Managers walkthrough <example_facility_manager.html>` for an overview
 first).
 
 ***************

--- a/omero/sysadmins/mapping-restricted-admins.rst
+++ b/omero/sysadmins/mapping-restricted-admins.rst
@@ -10,7 +10,7 @@ administrator privileges,
 see :doc:`/sysadmins/restricted-admins`.
 The OMERO.web user interface form for creation and editing of
 restricted administrators
-(see the :help:`creating Administrators with restricted privileges <introduction/docs/group-user-management.html>` section)
+(see the :help:`Web Interface: Managing Users <introduction/docs/group-user-management.html>` section)
 collates the server-side privileges
 into fewer options and gives the options user-friendly
 names. Here, the mapping of the OMERO.web options to the 

--- a/omero/sysadmins/mapping-restricted-admins.rst
+++ b/omero/sysadmins/mapping-restricted-admins.rst
@@ -10,7 +10,7 @@ administrator privileges,
 see :doc:`/sysadmins/restricted-admins`.
 The OMERO.web user interface form for creation and editing of
 restricted administrators
-(see the :help:`creating Administrators with restricted privileges <facility-manager.html#lightadmin>` section)
+(see the :help:`creating Administrators with restricted privileges <introduction/docs/group-user-management.html>` section)
 collates the server-side privileges
 into fewer options and gives the options user-friendly
 names. Here, the mapping of the OMERO.web options to the 

--- a/omero/sysadmins/public.rst
+++ b/omero/sysadmins/public.rst
@@ -183,10 +183,10 @@ considered "published".
    Project/Dataset/Image hierarchy prepared for the move by the author.
 #. If you have used OMERO.figure to create your figures for publication, you
    can always find the original data by using the 'info' tab, as shown in the
-   :help:`OMERO.figure Help guide <figure.html#info>` (OMERO.figure supports a
+   :help:`OMERO.figure creation guide <figure/docs/omero_figure.html>` (OMERO.figure supports a
    complete figure creation workflow, including exporting figures into image
    processing applications for final adjustments - see the
-   :help:`OMERO.figure Help guide <figure.html>` for full details).
+   :help:`OMERO.figure User guide <figure/docs/index.html>` for full details).
 #. Having all the data belong to one user simplifies the UI experience for
    public users. If necessary, ownership of data can be transferred using the
    'Chown' privilege (see :doc:`restricted-admins` and

--- a/omero/sysadmins/public.rst
+++ b/omero/sysadmins/public.rst
@@ -221,7 +221,7 @@ analysis which produced the published numerical data.
 Key-Value pairs can be used to add more detailed information about the
 study and publication. For example, go to `Schleicher_etal_figure1_a <https://omero.lifesci.dundee.ac.uk/webclient/?show=project-27936>`_
 and expand the 'Key-Value Pairs' section in the right-hand pane to display
-the content (see the :help:`Managing data guide <managing-data.html#keyvalue>` for information on using Key-Value pairs).
+the content (see the :help:`Annotate User guide <introduction/docs/annotate.html>` for information on using Key-Value pairs).
 
 Configuring URLs
 ^^^^^^^^^^^^^^^^

--- a/omero/sysadmins/public.rst
+++ b/omero/sysadmins/public.rst
@@ -182,7 +182,7 @@ considered "published".
    cuts the cross-links in the original group and preserves the
    Project/Dataset/Image hierarchy prepared for the move by the author.
 #. If you have used OMERO.figure to create your figures for publication, you
-   can always find the original data by using the 'info' tab, as shown in the
+   can always find the original data by using the 'info' tab inside the OMERO.figure app, see the
    :help:`OMERO.figure creation guide <figure/docs/omero_figure.html>` (OMERO.figure supports a
    complete figure creation workflow, including exporting figures into image
    processing applications for final adjustments - see the

--- a/omero/sysadmins/restricted-admins.rst
+++ b/omero/sysadmins/restricted-admins.rst
@@ -321,7 +321,7 @@ existing containers owned by the new owner. Since OMERO 5.4.0,
 OMERO.web enables Organizers with :term:`Write Data` privilege
 to create new containers belonging to other users,
 see the :help:`Manage Images in Datasets/Projects <introduction/docs/data-management.html#manage-images-in-datasets-projects>`
-section of our Help documentation.
+section of our User guides.
 Except the links created during
 creation of new Datasets inside others' Projects in OMERO.web,
 any links created by the Organizer will belong to the Organizer,

--- a/omero/sysadmins/restricted-admins.rst
+++ b/omero/sysadmins/restricted-admins.rst
@@ -320,7 +320,7 @@ data and to link the data to those containers or to already
 existing containers owned by the new owner. Since OMERO 5.4.0,
 OMERO.web enables Organizers with :term:`Write Data` privilege
 to create new containers belonging to other users,
-see the :help:`OMERO.web in Data structure <introduction/docs/data-management.html>`
+see the :help:`Manage Images in Datasets/Projects <introduction/docs/data-management.html#manage-images-in-datasets-projects>`
 section of our Help documentation.
 Except the links created during
 creation of new Datasets inside others' Projects in OMERO.web,

--- a/omero/sysadmins/restricted-admins.rst
+++ b/omero/sysadmins/restricted-admins.rst
@@ -28,7 +28,7 @@ still a powerful user so each must be a highly trusted individual.
 
 Full administrators in OMERO can create new administrators with
 restricted privileges using the OMERO.web interface, see the
-:help:`Facility managers section <example_facility_manager.html>` in our User guides.
+:help:`Web Interface: Managing Users <introduction/docs/group-user-management.html>` in our User guides.
 OMERO.cli does not yet support easy management of
 restrictions nor does it offer the helpful :doc:`permissions mapping
 <mapping-restricted-admins>` but advanced users may :doc:`use OMERO.cli

--- a/omero/sysadmins/restricted-admins.rst
+++ b/omero/sysadmins/restricted-admins.rst
@@ -359,7 +359,7 @@ Client Details:
   of ownership (possible only in CLI, will be addressed in the 5.4.x
   series). Creation of Projects, Datasets
   or Screens for other users in OMERO.web is possible since OMERO 5.4.0,
-  see :help:`Data structure (OMERO.web) <introduction/docs/data-management.html>`.
+  see the :help:`Manage Images in Datasets/Projects <introduction/docs/data-management.html#manage-images-in-datasets-projects>`
   All the Group and User Organizing actions are possible if all
   :term:`Create and Edit Groups`, :term:`Create and Edit Users` and
   :term:`Add Users to Groups` privileges are given. It is also reasonable

--- a/omero/sysadmins/restricted-admins.rst
+++ b/omero/sysadmins/restricted-admins.rst
@@ -136,7 +136,7 @@ Client Details:
   executed using OMERO.web or CLI.
 
 - OMERO.web: allows viewing and downloading the data,
-  see :help:`Viewing Data <iviewer/docs/index.html>`.
+  see :help:`Viewing Data <iviewer/docs/index.html>` and :help:`Downloading Data <download/docs/index.html>`
 
 - CLI: allows listing all images, groups and users and downloading the data::
 

--- a/omero/sysadmins/restricted-admins.rst
+++ b/omero/sysadmins/restricted-admins.rst
@@ -28,8 +28,8 @@ still a powerful user so each must be a highly trusted individual.
 
 Full administrators in OMERO can create new administrators with
 restricted privileges using the OMERO.web interface, see the
-:help:`facility managers guide <facility-manager.html#lightadmin>` in our Help
-documentation. OMERO.cli does not yet support easy management of
+:help:`Facility managers section <example_facility_manager.html>` in our User guides.
+OMERO.cli does not yet support easy management of
 restrictions nor does it offer the helpful :doc:`permissions mapping
 <mapping-restricted-admins>` but advanced users may :doc:`use OMERO.cli
 to adjust the restrictions <cli/light-admins>` on an administrator.
@@ -136,7 +136,7 @@ Client Details:
   executed using OMERO.web or CLI.
 
 - OMERO.web: allows viewing and downloading the data,
-  see :help:`Viewing Data <viewing-data>`.
+  see :help:`Viewing Data <iviewer/docs/index.html>`.
 
 - CLI: allows listing all images, groups and users and downloading the data::
 
@@ -191,8 +191,8 @@ Client details:
 - OMERO.importer or OMERO.insight: you have to be a member of the group
   you want to import to in OMERO.importer or OMERO.insight. Login as the
   administrator with restricted privileges and perform the import for
-  others as described in the chapter of the Help documentation
-  :help:`import for others <facility-manager#import>`.
+  others as described in the chapter of the User guides
+  :help:`import for others <upload/docs/import-desktop-client.html#import-for-another-user>`.
 
 - CLI: documentation is available covering :doc:`/users/cli/import` and
   :doc:`/users/cli/import-target` (see also the videos on import on the
@@ -250,10 +250,7 @@ Client details:
   attachments with results and annotate (for example tag, key-value pairs,
   rating, commenting). These actions are not permitted in Private groups
   with images belonging to others.
-  See Help guides for :help:`rendering <managing-data#rendering>`,
-  :help:`annotating <managing-data#annotating>`,
-  :help:`attaching files <managing-data#attach>`,
-  :help:`attaching data <managing-data#attach>`.
+  See :help:`User guides example <example.html>`.
 
 - CLI: Upload of official scripts is allowed (in any group type,
   see :doc:`/developers/scripts/user-guide` and below).
@@ -302,7 +299,7 @@ where owner of the data is not in data group.
 For moving data between groups, usage of OMERO.web is highly recommended.
 The Organizer can create new containers (Projects, Datasets) on behalf of
 data owner in OMERO.web conveniently as part of the Move to Group command in
-OMERO.web (:help:`Move to Group <group-owner#move>`). The containers and
+OMERO.web (:help:`Move to Group <introduction/docs/data-management.html#movedowners>`). The containers and
 links of data to containers will belong to data owner. For new container
 creation and linking, the :term:`Write Data` privilege is necessary.
 CLI can be used for the move action as well,
@@ -323,7 +320,7 @@ data and to link the data to those containers or to already
 existing containers owned by the new owner. Since OMERO 5.4.0,
 OMERO.web enables Organizers with :term:`Write Data` privilege
 to create new containers belonging to other users,
-see the :help:`OMERO.web in Data structure <facility-manager#data>`
+see the :help:`OMERO.web in Data structure <introduction/docs/data-management.html>`
 section of our Help documentation.
 Except the links created during
 creation of new Datasets inside others' Projects in OMERO.web,
@@ -362,7 +359,7 @@ Client Details:
   of ownership (possible only in CLI, will be addressed in the 5.4.x
   series). Creation of Projects, Datasets
   or Screens for other users in OMERO.web is possible since OMERO 5.4.0,
-  see :help:`Data structure (OMERO.web) <facility-manager#data>`.
+  see :help:`Data structure (OMERO.web) <introduction/docs/data-management.html>`.
   All the Group and User Organizing actions are possible if all
   :term:`Create and Edit Groups`, :term:`Create and Edit Users` and
   :term:`Add Users to Groups` privileges are given. It is also reasonable

--- a/omero/sysadmins/server-permissions.rst
+++ b/omero/sysadmins/server-permissions.rst
@@ -141,7 +141,7 @@ The various permission levels are:
 
 .. seealso::
 
-    :help:`Users guide for data management and sharing <data-management.html>`
+    :help:`Users guide for data management and sharing <introduction/docs/data-management.html>`
      Workflow guide describing the basics of data management and sharing with links to more detailed permissions documentation
 
 Changing group permissions

--- a/omero/sysadmins/server-permissions.rst
+++ b/omero/sysadmins/server-permissions.rst
@@ -49,8 +49,8 @@ administrator (either a full admin or a restricted admin with the correct
 privileges) or by one of the group owners assigned by the administrator (group
 owners would typically include the PI of the lab). The group's owners or
 administrators can also choose the permission level for that group. See the
-:help:`Help guide for managing groups
-<sharing-data.html#owner>` for more information about how to administrate them
+:help:`User guides for managing groups and users
+<introduction/docs/group-user-management.html>` for more information about how to administrate them
 in OMERO.
 
 Group permission levels
@@ -101,7 +101,7 @@ The various permission levels are:
       -  Scientists submitting a publication could move data to a read-only
          group as part of the publication workflow, making them publicly
          available via a URL for reviewers and readers (see the
-         :help:`Help guide for public data <publish.html#public>`).
+         :help:`Users guide for public data <introduction/docs/data-publication.html>`).
       -  For an institutional repository where data are being archived and
          then available for other users in the institute to view; this could
          be standard storage of all original data, or for data that is
@@ -141,7 +141,7 @@ The various permission levels are:
 
 .. seealso::
 
-    :help:`Help guide for sharing data <sharing-data.html>`
+    :help:`Users guide for sharing data <introduction/docs/group-user-management.html>`
      Workflow guide covering the groups and permissions system
 
 Changing group permissions

--- a/omero/sysadmins/server-permissions.rst
+++ b/omero/sysadmins/server-permissions.rst
@@ -142,7 +142,7 @@ The various permission levels are:
 .. seealso::
 
     :help:`Users guide for sharing data <introduction/docs/group-user-management.html>`
-     Workflow guide covering the groups and permissions system
+     Workflow guide describing the basics of data management and sharing with links to more detailed permissions documentation
 
 Changing group permissions
 --------------------------

--- a/omero/sysadmins/server-permissions.rst
+++ b/omero/sysadmins/server-permissions.rst
@@ -141,7 +141,7 @@ The various permission levels are:
 
 .. seealso::
 
-    :help:`Users guide for sharing data <introduction/docs/group-user-management.html>`
+    :help:`Users guide for data management and sharing <data-management.html>`
      Workflow guide describing the basics of data management and sharing with links to more detailed permissions documentation
 
 Changing group permissions

--- a/omero/users/cli/chgrp.rst
+++ b/omero/users/cli/chgrp.rst
@@ -24,7 +24,7 @@ How to move data
 ^^^^^^^^^^^^^^^^
 
 * Using CLI: See below
-* :help:`OMERO.web <introduction/docs/data-management.html>`
+* Using OMERO.web: See :help:`User guides <introduction/docs/data-management.html>`
 
 The :program:`omero chgrp` command moves objects between groups. Further help is
 available using the ``-h`` option::

--- a/omero/users/cli/chgrp.rst
+++ b/omero/users/cli/chgrp.rst
@@ -23,7 +23,7 @@ Who may move data
 How to move data
 ^^^^^^^^^^^^^^^^
 
-* CLI: See below
+* Using CLI: See below
 * :help:`OMERO.web <introduction/docs/data-management.html>`
 
 The :program:`omero chgrp` command moves objects between groups. Further help is

--- a/omero/users/cli/chgrp.rst
+++ b/omero/users/cli/chgrp.rst
@@ -24,7 +24,7 @@ How to move data
 ^^^^^^^^^^^^^^^^
 
 * CLI: See below
-* :help:`OMERO.web and OMERO.insight<sharing-data#moving>`
+* :help:`OMERO.web <introduction/docs/data-management.html>`
 
 The :program:`omero chgrp` command moves objects between groups. Further help is
 available using the ``-h`` option::

--- a/omero/users/clients-overview.rst
+++ b/omero/users/clients-overview.rst
@@ -23,7 +23,7 @@ already included in your OS).
 Our :help:`User guides<>` provide a series of
 workflow-based guides to performing common actions in the client applications,
 such as importing and viewing data, exporting images, drawing and analyzing of ROIs.
-tool. 
+ 
 
 Our partners within the OME consortium are also producing new clients and
 modules for OMERO, integrating additional functionality, particularly for more

--- a/omero/users/clients-overview.rst
+++ b/omero/users/clients-overview.rst
@@ -22,7 +22,7 @@ already included in your OS).
 
 Our :help:`User guides<>` provide a series of
 workflow-based guides to performing common actions in the client applications,
-such as importing and viewing data, exporting images and using the measuring
+such as importing and viewing data, exporting images, drawing and analyzing of ROIs.
 tool. 
 
 Our partners within the OME consortium are also producing new clients and

--- a/omero/users/clients-overview.rst
+++ b/omero/users/clients-overview.rst
@@ -20,7 +20,7 @@ and require Java |javaversion_min| (or higher) to be installed on the user's
 computer (this can easily be installed from `<https://java.com/>`_ if it is not
 already included in your OS).
 
-Our user assistance :help:`help website<>` provides a series of
+Our :help:`User guides<>` provide a series of
 workflow-based guides to performing common actions in the client applications,
 such as importing and viewing data, exporting images and using the measuring
 tool. 
@@ -84,8 +84,8 @@ A number of apps are available to add functionality to OMERO.web, such as
 `OMERO.iviewer <https://www.openmicroscopy.org/omero/iviewer/>`_.
 See the main website for a `list of released apps <https://www.openmicroscopy.org/omero/apps/>`_.
 
-For more information and guides to using OMERO.web, see our
-:help:`help website <>`.
+For more information and guides to using OMERO.web, visit
+:help:`User guides <>`.
 
 .. _omero-insight:
 
@@ -99,8 +99,7 @@ OMERO.insight
 
 OMERO.insight provides a number of tools for accessing and using data in an
 OMERO server. Figures :ref:`omero_insight_screenshot_5_2` and
-:ref:`omero_insight_5_2_viewer` present the user interface. To find out more,
-see the :help:`OMERO.insight user guides <>`.
+:ref:`omero_insight_5_2_viewer` present the user interface.
 
 .. _omero_insight_screenshot_5_2:
 .. figure:: /images/insight.png

--- a/omero/users/clients-overview.rst
+++ b/omero/users/clients-overview.rst
@@ -124,9 +124,8 @@ yet for OMERO.web are:
   intensity measurements of defined regions-of-interest (ROIs)
 - image import
 
-Our user assistance :help:`help website <>` features a number of
-workflow-based guides to importing, viewing, managing and exporting your data
-using OMERO.insight.
+We recommend to use OMERO.insight mainly for imports and concentrate on OMERO.web for all other workflows.
+See our :help:`User guides <>` for a number of workflows showing how to import data using OMERO.insight and how to view, manage and export data using OMERO.web.
 
 .. _omero-importer:
 

--- a/omero/users/index.rst
+++ b/omero/users/index.rst
@@ -57,10 +57,9 @@ Additional resources
     which could help OMERO meet your research needs more fully.
 
 -   You can try out OMERO without committing to installing your own server by
-    applying for an account on our :help:`demo server <demo-server>`.
+    applying for an account on our `demo server <https://www.openmicroscopy.org/explore/>`_.
 
--   Workflow-based user assistance guides are provided on our
-    :help:`help website <>`.
+-   The :help:`User guides<>` offer workflow-based assistance.
 
 -   The `OME YouTube channel <https://www.youtube.com/channel/UCyySB9ZzNi8aBGYqcxSrauQ>`_ features
     tutorials and presentations.

--- a/omero/users/whatsnew.rst
+++ b/omero/users/whatsnew.rst
@@ -6,5 +6,5 @@ Updates and new features for OMERO 5.6 include:
 - Decoupled OMERO.py and OMERO.web to allow more frequent releases.
 - Filter Images by Map Annotations in OMERO.web.
 
-See the :help:`User help website <>` for information on how to incorporate
+See the :help:`User guides <>` for information on how to incorporate
 these new features into your current workflows.


### PR DESCRIPTION
use omero-guides url instead of help.o.org

This PR replaces https://github.com/ome/omero-documentation/pull/2366