### PR TITLE
Move background reading section up one level

### DIFF
--- a/omero/sysadmins/index.rst
+++ b/omero/sysadmins/index.rst
@@ -54,11 +54,12 @@ an existing component, or just looking for more background information, there
 is a section about the server within the :doc:`/developers/index`;
 the best starting point is the :doc:`/developers/Server` for developers.
 
+******************
 Background reading
-##################
+******************
 
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 1
     :titlesonly:
 
     whatsnew

--- a/omero/sysadmins/index.rst
+++ b/omero/sysadmins/index.rst
@@ -54,9 +54,9 @@ an existing component, or just looking for more background information, there
 is a section about the server within the :doc:`/developers/index`;
 the best starting point is the :doc:`/developers/Server` for developers.
 
-******************
-Background reading
-******************
+**************************
+Requirements & limitations
+**************************
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
This section contains a few essential pages notably around versions requirements and the current layout hides these pages from the left-side navigation