### PR TITLE
Fix omero.security.ignore_case markup 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,9 +13,10 @@ Initial setup
 Sphinx
 ------
 
-The Sphinx documentation system can be obtained by issuing::
+The Sphinx documentation system and the readthedocs theme can be obtained by issuing::
 
     pip install Sphinx
+    pip install sphinx-rtd-theme
 
 Most Linux distributions will also provide it in a python-sphinx package
 (or similar).

--- a/README.rst
+++ b/README.rst
@@ -15,8 +15,7 @@ Sphinx
 
 The Sphinx documentation system and the readthedocs theme can be obtained by issuing::
 
-    pip install Sphinx
-    pip install sphinx-rtd-theme
+    pip install -r requirements.txt
 
 Most Linux distributions will also provide it in a python-sphinx package
 (or similar).

--- a/omero/sysadmins/config.rst
+++ b/omero/sysadmins/config.rst
@@ -2051,6 +2051,7 @@ omero.security.ignore_case
 Whether to ignore the case of the username during login (`true` or
 `false`). Default: `false` (JSmith and jsmith will be considered two
 different users).
+
 .. warning::
 
    Before enabling this feature, lower the case of all usernames in OMERO


### PR DESCRIPTION
See https://omero.readthedocs.io/en/v5.6.11-1/sysadmins/config.html#omero.security.ignore_case for the current rendering.

With this PR the warning should display correctly.
The change has also been applied upstream in https://github.com/ome/omero-common/pull/44