### PR TITLE
Clarify CSRF token usage

### DIFF
--- a/omero/developers/json-api.rst
+++ b/omero/developers/json-api.rst
@@ -319,6 +319,10 @@ cookie of any request or from the following URL:
       "data": "eNoVq528bOqlhQqbCzKuviODTRX3PUO2"
     }
 
+If you are using the API over HTTPS, you will also need to set the ``Referer`` key in 
+request headers when supplying the CSRF token to other endpoints. The referer URI 
+needs to be an address on the same domain as the server for the token to be accepted.
+
 
 Login
 ^^^^^


### PR DESCRIPTION
Due to Django's [default security settings](https://docs.djangoproject.com/en/5.0/ref/csrf/), users connecting to the JSON API over HTTPS URLs tend to get "CSRF token invalid" messages when trying to use the API with the current instructions. This PR adds a bit of text to explain the need to supply a `Referer` header for the token checks to succeed.