### PR TITLE
Add documentation for omero.logging properties

### DIFF
--- a/omero/developers/logging.rst
+++ b/omero/developers/logging.rst
@@ -36,10 +36,14 @@ that changes to the logging configuration are `automatically reloaded at
 regular intervals
 <https://logback.qos.ch/manual/configuration.html#autoScan>`_.
 
-By default, the output from logback is sent to:
-``var/log/<servername>.log``. Once files reach a size of 500MB, they are
-rolled over to ``<servername>.log.1``, ``<servername>.log.2``, etc. Once
-the files have rolled over, you can safely delete or compress (bzip2,
+By default, the output from logback is sent to a file named :file:`<servername>.log`
+under the directory specified by :property:`omero.logging.directory`, by
+default :file:`var/log`.
+Once files reach a size specified by :property:`omero.logging.logsize`, 500MB
+by default, they are rolled over to :file:`<servername>.log.1`,
+:file:`<servername>.log.2`, etc. The maximum of rotated log files is specified
+by :property:`omero.logging.lognum`.
+Once the files have rolled over, you can safely delete or compress (bzip2,
 gzip, zip) them. Alternatively, once you are comfortable with the
 stability of your server, you can either reduce logging or the number
 and size of the files kept. **Note:** if something goes wrong with your
@@ -49,9 +53,9 @@ issues.
 In addition, each import process logs to a file under the managed
 repository which matches the timestamped fileset directory's name.
 For example, if an imported fileset is uploaded to
-``/OMERO/ManagedRepository/userA_1/2013-06/17/12-00-00.000``, then
+:file:`/OMERO/ManagedRepository/userA_1/2013-06/17/12-00-00.000`, then
 the log file can be found under
-``/OMERO/ManagedRepository/userA_1/2013-06/17/12-00-00.000.log``.
+:file:`/OMERO/ManagedRepository/userA_1/2013-06/17/12-00-00.000.log`.
 
 Python servers
 --------------
@@ -63,25 +67,14 @@ For example, the config file for Processor-0 can be found in
 ``var/master/servers/Processor-0/config/config``. These values come from
 :file:`etc/grid/templates.xml`.
 
-All the "omero.logging.\*" properties can be overwritten in your
-:file:`etc/grid/default.xml` file. See the "Profile" properties block
-for how to configure for your site.
-
-Similar to logback, logging is configured to be written to
-``var/log/<servername>.log`` and to maintain 9 backups of at most 500MB.
+Similar to the Java servers, logging is configured to be written to
+:file:`var/log/<servername>.log` and to maintain 9 backups of at most 500MB
+by default. All the ``omero.logging`` properties can be specified via configuration - 
+see :ref:`log_configuration` for more details
 
 stdout and stderr
 -----------------
 
 Though all components try to avoid it, some output will still go to
 stdout/stderr. On non-Windows systems, all of this output will be sent
-to the ``var/log/master.out`` and ``var/log/master.err`` files.
-
-Windows stdout and stderr
--------------------------
-
-On Windows, the state of stdout and stderr is somewhat different. No
-information will be written to master.out, master.err, or similar files.
-Instead, what logging is produced will go to the Windows Event Viewer,
-but finding error situations can be considerably more challenging (See
-:ticket:`1449` for more information).
+to the :file:`var/log/master.out` and :file:`var/log/master.err` files.

--- a/omero/sysadmins/config.rst
+++ b/omero/sysadmins/config.rst
@@ -991,6 +991,61 @@ LDAP server bind DN (if required; can be empty)
 Default: `[empty]`
 
 
+.. _log_configuration:
+
+Logging
+-------
+
+.. property:: omero.logging.directory
+
+omero.logging.directory
+^^^^^^^^^^^^^^^^^^^^^^^
+Relative server directory where the log files should be stored.
+
+Default: `var/log/`
+
+.. property:: omero.logging.level
+
+omero.logging.level
+^^^^^^^^^^^^^^^^^^^
+Specifies the threshold for the Python servers log files. Logging messages
+which are less severe than this value will be ignored. For a list of
+available values, see https://docs.python.org/3/library/logging.html#levels.
+
+Default: `20`
+
+.. property:: omero.logging.lognum
+
+omero.logging.lognum
+^^^^^^^^^^^^^^^^^^^^
+If omero.logging.timedlog is false or unset, specifies the
+number of old server log files that should be kept. Old log
+files will be saved by appending the extensions '.1', '.2' etc.
+
+Default: `9`
+
+.. property:: omero.logging.logsize
+
+omero.logging.logsize
+^^^^^^^^^^^^^^^^^^^^^
+If omero.logging.timedlog is false or unset, specifies the
+maximum size of the server log files in bytes above which a
+new log file should be created.
+
+Default: `5000000`
+
+.. property:: omero.logging.timedlog
+
+omero.logging.timedlog
+^^^^^^^^^^^^^^^^^^^^^^
+Whether the server log files should be rotated at a certain time
+interval. If true, log files will be rolled over at midnight.
+Otherwise, log files will be rolled over at a predetermined size,
+see omero.logging.logsize for more information.
+
+Default: `false`
+
+
 .. _mail_configuration:
 
 Mail


### PR DESCRIPTION
See https://github.com/ome/openmicroscopy/issues/6225

The first commit was created by the combination of https://github.com/ome/openmicroscopy/pull/6393 and https://github.com/ome/omero-py/pull/416 and adds the logging properties to the glossary

The second commit updates the developers logging page to reference the new properties and mention the configurability