### PR TITLE
Fix outdated cli install for users

### DIFF
--- a/omero/users/cli/installation.rst
+++ b/omero/users/cli/installation.rst
@@ -24,14 +24,14 @@ To install omero-py using pip in a conda environment with Python 3.11 on Ubuntu 
     conda create -n myenv python=3.11
     conda activate myenv
     pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp311-cp311-manylinux_2_28_x86_64.whl
-    pip install omero-py==5.19.5
+    pip install omero-py
 
 Alternatively install ``omero-py`` using venv with Python 3.9 or higher::
 
     python -m venv myenv
     . myenv/bin/activate
     pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp311-cp311-manylinux_2_28_x86_64.whl
-    pip install omero-py==5.19.5
+    pip install omero-py
 
 
 

--- a/omero/users/cli/installation.rst
+++ b/omero/users/cli/installation.rst
@@ -46,18 +46,3 @@ The ``import`` functionality requires a supported version of :ref:`version requi
 
 To install Java, go to :doc:`/sysadmins/unix/server-installation`
 and select the walkthrough corresponding to your OS.
-
-omero-py < 5.8.0
-^^^^^^^^^^^^^^^^
-
-If you are using an older version of ``omero-py`` you must download the JARs manually and place them under the :envvar:`OMERODIR` directory:
-
-#. download the OMERO.server zip from the `Downloads page <https://www.openmicroscopy.org/omero/downloads/>`_
-#. unzip the zip file 
-#. set ``$OMERODIR`` to the unzipped directory::
-
-    export OMERODIR=/path/to/OMERO.server-x.x.x-ice36-bxx
-
-The ``import`` functionality is now available::
-
-    omero import /path/to/image.tiff

--- a/omero/users/cli/installation.rst
+++ b/omero/users/cli/installation.rst
@@ -5,7 +5,7 @@ Installation
     but may be supported in the future.
 
 Since OMERO 5.6, only Python 3 is supported.
-We assume that you have already installed Python 3.6 or higher. You can ensure that your python executable is correct with the ``python --version`` command.
+We assume that you have already installed Python 3.9 or higher. You can ensure that your python executable is correct with the ``python --version`` command.
 
 We recommend installing client library ``omero-py`` and the |CLI| plugins
 in a Python virtual environment.

--- a/omero/users/cli/installation.rst
+++ b/omero/users/cli/installation.rst
@@ -15,17 +15,23 @@ to install it first, see `miniconda <https://docs.conda.io/en/latest/miniconda.h
 
 .. Note:: On Ubuntu 20.04, you may need to install ``libssl-dev`` before installing the |CLI|.
 
+Before installing ``omero-py``, we recommend to install the `Zeroc IcePy 3.6 <https://zeroc.com/ice/downloads/3.6>`_ Python bindings.
 
-To install ``omero-py`` using conda (preferred)::
+Our commercial partner `Glencoe Software <https://www.glencoesoftware.com>`_ has produced several Python wheels to install the Ice-Python bindings depending on the desired Python version and the operating system. Please visit the `Ice binaries for omero <https://www.glencoesoftware.com/blog/2023/12/08/ice-binaries-for-omero.html>`_ page to find the full URLs to the wheels that are used in the examples below.
 
-    conda create -n myenv -c conda-forge python=3.8 omero-py
+To install omero-py using pip in a conda environment with Python 3.11 on Ubuntu 22.04::
+
+    conda create -n myenv python=3.11
     conda activate myenv
+    pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp311-cp311-manylinux_2_28_x86_64.whl
+    pip install omero-py==5.19.5
 
-Alternatively install ``omero-py`` using venv with Python 3.7 or higher::
+Alternatively install ``omero-py`` using venv with Python 3.9 or higher::
 
     python -m venv myenv
     . myenv/bin/activate
-    pip install omero-py
+    pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp311-cp311-manylinux_2_28_x86_64.whl
+    pip install omero-py==5.19.5
 
 
 


### PR DESCRIPTION
As discussed, opening a PR to make the https://omero.readthedocs.io/en/stable/users/cli/installation.html valid and clear.

This corresponds to https://omero.readthedocs.io/en/stable/developers/Python.html now.


cc @jburel 