### PR TITLE
Fix markup for render image example

### DIFF
--- a/omero/developers/Python.rst
+++ b/omero/developers/Python.rst
@@ -1152,6 +1152,7 @@ Render Images
 -  **Get thumbnail**
 
 ::
+
     from PIL import Image
     from io import BytesIO
     # Thumbnail is created using the current rendering settings on the image


### PR DESCRIPTION
The current markup is broken - see https://omero.readthedocs.io/en/v5.6.14/developers/Python.html#render-images

/cc @DavidStirling @emilroz 