### PR TITLE
Django: link to 4.2 documentatoin

### DIFF
--- a/omero/conf.py
+++ b/omero/conf.py
@@ -126,8 +126,6 @@ rst_epilog = """
 .. _Glencoe Software, Inc.: https://www.glencoesoftware.com/
 .. _Pillow: https://pillow.readthedocs.org
 .. _Matplotlib: https://matplotlib.org/
-.. _Django 1.8: https://docs.djangoproject.com/en/1.8/releases/1.8/
-.. _Django 1.6: https://docs.djangoproject.com/en/1.6/releases/1.6/
 .. _Python: https://www.python.org
 .. _Libjpeg: http://libjpeg.sourceforge.net/
 .. _Django: https://www.djangoproject.com/
@@ -237,7 +235,7 @@ extlinks = {
     'zeroc': ('https://zeroc.com/%s', None),
     'zerocforum': ('https://forums.zeroc.com/discussion/%s', None),
     'zerocdoc': ('https://doc.zeroc.com/%s', None),
-    'djangodoc': ('https://docs.djangoproject.com/en/1.11/%s', None),
+    'djangodoc': ('https://docs.djangoproject.com/en/4.2/%s', None),
     'doi': ('https://dx.doi.org/%s', None),
     'pypi': ('https://pypi.org/project/%s', None),
     }

--- a/omero/developers/Web/CSRF.rst
+++ b/omero/developers/Web/CSRF.rst
@@ -43,7 +43,7 @@ POST, PUT and DELETE. These requests can then be protected as follows:
     <script type="text/javascript" src="{% static "webgateway/js/ome.csrf.js" %}"></script>
 
   For more details see
-  :djangodoc:`CSRF for ajax <ref/csrf/#ajax>`.
+  :djangodoc:`CSRF for ajax <howto/csrf/#using-csrf-protection-with-ajax>`.
 
 
 The Django framework also offers decorator methods that can help you protect your


### PR DESCRIPTION
Noticed while writing https://github.com/ome/omero-web/pull/608#issuecomment-2662516608, the current OMERO documentation still points at the Django 1.11 documentation.

https://github.com/ome/omero-documentation/commit/95080eab467f64c984272c2564ab188741e5fa83 updated `common/conf.py` but it looks like this configuration file is either a no-op or overriden by `omero/conf.py`.

To reduce future confusion, bb89a345be5ddd3d3ec67937f318b90cb2ac9f4d proposes to remove this duplication configuration file.