### PR TITLE
Install Python bindings in .venv3

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -28,6 +28,10 @@ jobs:
         run: |
           cd $space/OMERO.server
           ./build.py
+      - name: Create Virtual environment
+        run: |
+          python -m venv $space/.venv3
+          $space/.venv3/bin/pip install https://github.com/glencoesoftware/zeroc-ice-py-ubuntu2204-x86_64/releases/download/20221004/zeroc_ice-3.6.5-cp310-cp310-linux_x86_64.whl
       - name: Update documentation
         run: |
           WORKSPACE=$space BUILD=false SUFFIX=/dist bash autogen_omero.sh


### PR DESCRIPTION
The problem was noticed when running on Ubuntu 24.04 and Python 3.12
The ice-python binding are not installed in the virtual env ``.ven3`` (this is expected by merge-ci for example)
Previously it is built from source when omero-web is installed in the virtual env 
See for example  https://github.com/ome/omero-documentation/actions/runs/13621954191/job/38072830354
```
  Running setup.py install for zeroc-ice: started
  Running setup.py install for zeroc-ice: still running...
  Running setup.py install for zeroc-ice: still running...
```
This won't work when we do the switch
This wheel will need to be updated when we switch again to Python 3.12 on Ubuntu 24.04