### PR TITLE
Fix recommended RAM

### DIFF
--- a/omero/sysadmins/system-requirements.rst
+++ b/omero/sysadmins/system-requirements.rst
@@ -22,7 +22,7 @@ An OMERO.server specification for between 25-50 users might be:
 A specification for a server future-proofed for 3-4 years might be:
 
 -  Intel Xeon Gold 6426 Processor
--  8x 32 GB DDR5-4800
+-  32 GB DDR5-4800
 -  2 x 2 TB SSD RAID1 for OS, PostgreSQL DB, scratch, log files, etc.
 -  10 GbE connectivity to a separate fileshare for the OMERO binary repository
 


### PR DESCRIPTION
8x 32GB RAM is a bit excessive. Especially as the next paragraph says:
``` In summary, depending on hardware layout 16, 24 or 32 GB of RAM would be ideal for your OMERO server. If you have a separate database server more than 16 GB of RAM may not be of much benefit to you at all.```

This PR changes the recommendation to 32GB (which we use for nightshade too, afaik).
