### PR TITLE
Fixes GitHub workflow generating documentation from release artifacts

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -36,7 +36,7 @@ jobs:
           $space/.venv3/bin/pip install https://github.com/glencoesoftware/zeroc-ice-py-ubuntu2204-x86_64/releases/download/20221004/zeroc_ice-3.6.5-cp310-cp310-linux_x86_64.whl
       - name: Update documentation
         run: |
-          WORKSPACE=$space BUILD=false SUFFIX=/dist bash autogen_omero.sh
+          WORKSPACE=$space bash autogen_omero.sh
       - name: Find modified files
         id: upstream_repo
         run: |

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       ICE_HOME: /opt/ice-3.6.5 # location where Ice is installed
+      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
       - name: Install Ice Java and Python binding
@@ -21,13 +22,14 @@ jobs:
           cd ..
           WORKSPACE=$(pwd)
           echo "space="${WORKSPACE} >> $GITHUB_ENV
-          git clone https://github.com/ome/openmicroscopy OMERO.server
           git clone https://github.com/ome/omeroweb-install
           git clone https://github.com/ome/omero-install
-      - name: Build OMERO.server
+      - name: Download latest release of OMERO.server
         run: |
-          cd $space/OMERO.server
-          ./build.py
+          cd ..
+          gh release download -R ome/openmicroscopy --pattern "OMERO.server*zip"
+          unzip OMERO.server*.zip && rm OMERO.server*.zip
+          ln -s OMERO.server* OMERO.server
       - name: Create Virtual environment
         run: |
           python -m venv $space/.venv3

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -51,10 +51,9 @@ jobs:
           fi
           echo "value=$value" >> $GITHUB_OUTPUT
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v7
         with:
           labels: include
-          token: ${{secrets.ACTION_API_TOKEN}}
           commit-message: ${{ steps.upstream_repo.outputs.value }}
           delete-branch: true
           title: ${{ steps.upstream_repo.outputs.value }}

--- a/autogen_omero.sh
+++ b/autogen_omero.sh
@@ -7,14 +7,13 @@ set -x
 echo no linkcheck
 
 # from the sub-script
-export SUFFIX=${SUFFIX:-}
 export WORKSPACE=${WORKSPACE:-$(pwd)}
 export WORKSPACE=${WORKSPACE%/}  # Remove trailing slashes
 export USER=${USER:-$(whoami)}
-export OMERODIR=${WORKSPACE}/OMERO.server$SUFFIX
+export OMERODIR=${WORKSPACE}/OMERO.server
 export DOCVENV=${DOCVENV:-$WORKSPACE/.venv3}
 export PYTHON=${PYTHON:-python}
-export BUILD=${BUILD:-true}
+export BUILD=${BUILD:-false}
 
 # VARIABLES #1
 MESSAGE="Update auto-generated documentation"
@@ -32,7 +31,7 @@ if [ ! -e $DOCVENV ]; then
     echo You may need to manually install zeroc-ice
 fi
 
-WORKSPACE=$WORKSPACE SUFFIX=$SUFFIX omero/autogen_docs
+WORKSPACE=$WORKSPACE omero/autogen_docs
 
 # OSX compatibility for testing
 if [ $BUILD == "true" ]; then

--- a/omero/autogen_db_version.py
+++ b/omero/autogen_db_version.py
@@ -12,10 +12,12 @@ from pkg_resources import parse_version
 
 
 def get_mmp(sqlfile):
-    m = re.search(r'.*/?OMERO(\d+)\.(\d+)(\w*)__(\d+)', sqlfile)
+    # Only consider files/folders with version
+    # OMERO<major>.<minor>__<patch>
+    m = re.search(r'.*/?OMERO(\d+)\.(\d+)__(\d+)', sqlfile)
     if m is None:
         return None
-    mmp = (int(m.group(1)), int(m.group(2)), m.group(3), int(m.group(4)))
+    mmp = (int(m.group(1)), int(m.group(2)), int(m.group(3)))
     return mmp
 
 
@@ -27,26 +29,28 @@ directory = os.path.join(serverdir, 'sql', 'psql')
 subfolders = [f.path for f in os.scandir(directory) if f.is_dir()]
 for f in subfolders:
     ver = os.path.basename(os.path.normpath(f))
-    ver = ver.replace("OMERO", "")
+    if get_mmp(ver) is None:
+        continue
     if current_version is None:
         current_version = ver
+        current_mmp = get_mmp(current_version)
     else:
-        if parse_version(current_version) < parse_version(ver):
+        if get_mmp(current_version) < get_mmp(ver):
             current_version = ver
-current_dbver = "OMERO%s" % current_version
-current_mmp = get_mmp(current_dbver)
+            current_mmp = get_mmp(current_version)
 
 sqlfiles = []
 majorminorpatch = []
-for f in glob.glob(os.path.join(
-        serverdir, 'sql', 'psql', current_dbver, 'OMERO*.sql')):
-    mmp = get_mmp(f)
+for f in glob.glob(os.path.join(directory, current_version, 'OMERO*.sql')):
     sql = os.path.basename(f)[:-4]
+    mmp = get_mmp(sql)
+    if mmp is None:
+        continue
     majorminorpatch.append(mmp)
     sqlfiles.append(sql)
 
 majorminorpatch = sorted(
-    majorminorpatch, key=lambda m: (-m[0], -m[1], m[2], -m[3]))
+    majorminorpatch, key=lambda m: (-m[0], -m[1], -m[2]))
 for previous_mmp in majorminorpatch:
     if previous_mmp[0] < current_mmp[0] or (
             previous_mmp[0] == current_mmp[0] and
@@ -59,10 +63,10 @@ with open(sys.argv[2], "r") as sources:
 with open(sys.argv[2], "w") as sources:
     for line in lines:
         if line.startswith("current_dbver"):
-            sources.write('current_dbver = "%s"' % current_dbver)
+            sources.write('current_dbver = "%s"' % current_version)
             sources.write("\n")
         elif line.startswith("previous_dbver"):
-            sources.write('previous_dbver = "OMERO%d.%d%s__%d"' % previous_mmp)
+            sources.write('previous_dbver = "OMERO%d.%d__%d"' % previous_mmp)
             sources.write("\n")
         else:
             sources.write(line)

--- a/omero/autogen_docs
+++ b/omero/autogen_docs
@@ -14,7 +14,6 @@ set -u
 set -e
 set -x
 set -o pipefail
-SUFFIX=${SUFFIX:-}
 WORKSPACE=${WORKSPACE:-$(pwd)}
 WORKSPACE=${WORKSPACE%/}  # Remove trailing slashes
 USER=${USER:-$(whoami)}

--- a/omero/autogen_openmicroscopy.sh
+++ b/omero/autogen_openmicroscopy.sh
@@ -16,7 +16,7 @@ export DOCVENV=${DOCVENV:-$WORKSPACE/.venv3}
 $DOCVENV/bin/pip install "omero-web[redis]"
 
 #echo "Generating configuration properties page"
-#$DOCVENV/bin/omero config parse --rst | sed "s|$SUFFIX||" | sed "s|$WORKSPACE|/home/omero|" > omero/sysadmins/config.rst
+$DOCVENV/bin/omero config parse --rst | sed "s|$WORKSPACE|/home/omero|" > omero/sysadmins/config.rst
 
 echo "Generating ldap setdn usage page"
 mkdir -p omero/downloads/ldap
@@ -36,5 +36,5 @@ rm OMERO*sql
 echo "Generating Web configuration templates"
 # Nginx / WSGI
 $DOCVENV/bin/omero config set omero.web.application_server wsgi-tcp
-$DOCVENV/bin/omero web config nginx | sed "s|$SUFFIX||" | sed "s|$WORKSPACE/OMERO.server|/opt/omero/web/omero-web|g" > omero/sysadmins/unix/install-web/nginx-omero.conf
-$DOCVENV/bin/omero web config nginx-location | sed "s|$SUFFIX||" | sed "s|$WORKSPACE/OMERO.server|/opt/omero/web/omero-web|g" | grep -v '^#' > omero/sysadmins/unix/install-web/nginx-location.conf
+$DOCVENV/bin/omero web config nginx | sed "s|$WORKSPACE/OMERO.server|/opt/omero/web/omero-web|g" > omero/sysadmins/unix/install-web/nginx-omero.conf
+$DOCVENV/bin/omero web config nginx-location | sed "s|$WORKSPACE/OMERO.server|/opt/omero/web/omero-web|g" | grep -v '^#' > omero/sysadmins/unix/install-web/nginx-location.conf


### PR DESCRIPTION
This effort was primarily motivated to propagate some of the property changes associated with the [OMERO.web 5.30.0 release](https://www.openmicroscopy.org/2025/12/03/omero-web-5.30.0.html) to the OMERO documentation.

A few issues were found as part of an initial investigation:

- the auto-generation workflow has been broken for several months with https://github.com/ome/omero-documentation/pull/2500 being the latest open PR and many failing actions
- the `omero config parse` command is skipped in `autogen_openmicroscopy.sh` and several configuration properties are out-of-sync
- the workflow builds OMERO.server from source which has two downsides:
  * it increases significantly build times
   * it includes changes from merged but unreleased upstream changes into PRs against the reference documentation
- several recent builds failed in `autogen_db_version.py` with  an error of type `packaging.version.InvalidVersion: Invalid version: '4.3__0'`
- the create-pull-request action failed on my fork and is behind

To address all of the above, the following changes are proposed:

- OMERO.server is no longer built from source but the latest GitHub release asset is downloaded using `gh release download`, similarly to the OMERO.py GitHub workflow. The `SUFFIX` and `BUILD` variables are removed or disabled.
- `autogen_db_version.py` is updated to only detect SQL files and folders corresponding to release versions of the OMERO database i.e. under the form `<MAJOR>.<MINOR>__<PATCH>`, excluding historical schema versions as well as all intermediate DEV database versions. The usage of `packaging.version` is dropped in favour of the `get_mmap()`
- the `peter-evans/create-pull-request` action is updated to `v7` and uses `GITHUB_TOKEN` under the hood

Note this workflow is currently configured to run in a `cron` matter making changes hard to evaluate. As a proof of concept, https://github.com/sbesson/omero-documentation/pull/8 was generated by https://github.com/sbesson/omero-documentation/actions/runs/19940358557 which includes an extra commit on top of this branch to force the workflow and a build time <2min