### PR TITLE
Remove postgres12 link as it is end of life

### DIFF
--- a/omero/sysadmins/version-requirements.rst
+++ b/omero/sysadmins/version-requirements.rst
@@ -242,7 +242,7 @@ If no version is provided, a suitable repository is indicated.
       - CentOS/RHEL
       - Ubuntu
     * - 12
-      - 9 (`postgresql <https://download.postgresql.org/pub/repos/yum/12/redhat/rhel-9-x86_64/>`__)
+      - 9
       - 24.04 (`postgresql <https://apt.postgresql.org/pub/repos/apt/dists/noble-pgdg/>`__)
     * - 13
       - 9


### PR DESCRIPTION
Removing postgres12 link as it is breaking the linkcheck in https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-docs/11/console and postgres12 is end-of-life.


cc @will-moore 

The result of this PR is built in https://omero--2513.org.readthedocs.build/en/2513/sysadmins/version-requirements.html#version-provided-by-distribution

