### PR TITLE
Python 3.9 -> Python 3.12

### DIFF
--- a/omero/sysadmins/unix/server-rockylinux9-ice36.rst
+++ b/omero/sysadmins/unix/server-rockylinux9-ice36.rst
@@ -8,7 +8,7 @@ This is an example walkthrough for installing OMERO on RHEL 9/Rocky Linux 9, usi
 a dedicated local system user. You can use this as a guide
 for setting up your own test server. For production use you should also read
 the pages listed under :ref:`index-optimizing-server`.
-This guide will install Python 3.9.
+This guide will install Python 3.12.
 Since 5.6, a new :envvar:`OMERODIR` variable is used, you should first unset :envvar:`OMERO_HOME`
 (if set) before beginning the installation process.
 


### PR DESCRIPTION
Fixing simple typo (maybe rather omission).
The factual state is that Rocky9 walkthrough is going to install p312.
The paragraph in the beginning of the walkthrough is stating (wrongly) p39.

I did not find any indication that this bit of text is built in ``omero-install`` repo, so this PR seems adequate.


cc @dominikl 

