### PR TITLE
Update autogen_dependencies.sh to consume the OMERO.server

### DIFF
--- a/omero/autogen_dependencies.sh
+++ b/omero/autogen_dependencies.sh
@@ -11,6 +11,9 @@
 #    - check version of the dependencies
 
 PREFIX="omero-"
+WORKSPACE=${WORKSPACE:-$(pwd)}
+WORKSPACE=${WORKSPACE%/}  # Remove trailing slashes
+export OMERODIR=${WORKSPACE}/OMERO.server
 
 # General java packages
 # Java packages
@@ -60,38 +63,24 @@ done
 echo $new_version
 
 # Java packages
-
-# the version of GitHub does not match the version in omero/conf_autogen.py
-# Download the latest server release
-# Unzip
 # Determine the version of the dependencies
 # Update omero/conf_autogen.py
-if [ ! -z $new_version ]; then
-    # Download the latest binary to make we have the correct one.
-    # To be replaced by the GitHub url without build number when ready
-    SERVER=https://downloads.openmicroscopy.org/omero/5.6/server-ice36.zip
-    wget $SERVER -O OMERO.server-ice36.zip
-    unzip -q OMERO.server*
-    ln -s OMERO.server-*/ OMERO.server
-    dirs=("OMERO.server/lib/server/omero-blitz.jar" "OMERO.server/lib/server/omero-server.jar" "OMERO.server/lib/server/omero-gateway.jar"
-      "OMERO.server/lib/server/omero-romio.jar" "OMERO.server/lib/server/omero-renderer.jar" "OMERO.server/lib/server/omero-common.jar"
-      "OMERO.server/lib/server/omero-model.jar" "OMERO.server/lib/server/formats-gpl.jar")
-    for dir in "${dirs[@]}"
-    do
-        :
-        values=(${dir//// })
-        value=${values[${#values[@]}-1]}
-        y=${value#"$PREFIX"}
-        v=${y%%.jar}
-        v=${v//"-"/"_"}
-        version=`unzip -p $dir META-INF/MANIFEST.MF | grep "Implementation-Version:" | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/'`
-        sed -i -e "s/version_${v} = .*/version_${v} = \"${version}\"/" omero/conf_autogen.py
-        echo $v
-        echo $version
-    done
-    # clean up 
-    rm -rf OMERO.server*
-fi
+dirs=("$OMERODIR/lib/server/omero-blitz.jar" "$OMERODIR/lib/server/omero-server.jar" "$OMERODIR/lib/server/omero-gateway.jar"
+  "$OMERODIR/lib/server/omero-romio.jar" "$OMERODIR/lib/server/omero-renderer.jar" "$OMERODIR/lib/server/omero-common.jar"
+  "$OMERODIR/lib/server/omero-model.jar" "$OMERODIR/lib/server/formats-gpl.jar")
+for dir in "${dirs[@]}"
+do
+    :
+    values=(${dir//// })
+    value=${values[${#values[@]}-1]}
+    y=${value#"$PREFIX"}
+    v=${y%%.jar}
+    v=${v//"-"/"_"}
+    version=`unzip -p $dir META-INF/MANIFEST.MF | grep "Implementation-Version:" | sed 's/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/'`
+    sed -i -e "s/version_${v} = .*/version_${v} = \"${version}\"/" omero/conf_autogen.py
+    echo $v
+    echo $version
+done
 
 
 # Python packages

--- a/omero/autogen_docs
+++ b/omero/autogen_docs
@@ -46,7 +46,7 @@ echo "Getting db properties"
 omero/autogen_db_version.py $WORKSPACE/OMERO.server  omero/conf_autogen.py
 
 echo "Update dependencies using the latest releases versions of the software e.g. omero-py, omero-web, openmicroscopy"
-bash omero/autogen_dependencies.sh
+WORKSPACE=$WORKSPACE bash omero/autogen_dependencies.sh
 
 echo "Cleanup"
 rm java-help.txt


### PR DESCRIPTION
See https://github.com/ome/omero-documentation/pull/2523#issuecomment-3907380981

The current auto-generation logic download a version of OMERO.server behind a NGINX redirect which might be out-of-sync with the latest released GitHub artifact which is downloaded in the GitHub workflow. Similarly to other scripts, this passes the `WORKSPACE` environment variable and introspects the version of the OMERO server component from the existing bundle.