### PR TITLE
Add note about POST requests for public user

### DIFF
--- a/omero/sysadmins/public.rst
+++ b/omero/sysadmins/public.rst
@@ -64,8 +64,8 @@ To set this up on your OMERO.web installation:
      $ omero config set omero.web.public.password '<password>'
 
 - By default the public user is only allowed to perform GET requests.
-  (There are limited built-in exceptions allowing POST requests for certain
-  URLs that require it, but do not write or modify any data.) This
+  There are limited built-in exceptions allowing POST requests for certain
+  URLs that require it, but do not write or modify any data. This
   means that the public user will not be able to Create, Edit or Delete data,
   as these require POST requests.
   If you want to allow these actions from the public user, you can change the

--- a/omero/sysadmins/public.rst
+++ b/omero/sysadmins/public.rst
@@ -63,7 +63,9 @@ To set this up on your OMERO.web installation:
 
      $ omero config set omero.web.public.password '<password>'
 
-- By default the public user is only allowed to perform GET requests. This
+- By default the public user is only allowed to perform GET requests.
+  (There are limited built-in exceptions allowing POST requests for certain
+  URLs that require it, but do not write or modify any data.) This
   means that the public user will not be able to Create, Edit or Delete data,
   as these require POST requests.
   If you want to allow these actions from the public user, you can change the

--- a/omero/sysadmins/public.rst
+++ b/omero/sysadmins/public.rst
@@ -63,13 +63,12 @@ To set this up on your OMERO.web installation:
 
      $ omero config set omero.web.public.password '<password>'
 
-- By default the public user is only allowed to perform GET requests.
-  There are limited built-in exceptions allowing POST requests for certain
-  URLs that require it, but do not write or modify any data. This
-  means that the public user will not be able to Create, Edit or Delete data,
-  as these require POST requests.
-  If you want to allow these actions from the public user, you can change the
-  :property:`omero.web.public.get_only` property::
+- By default the public user is not allowed to Create, Edit or Delete data.
+  Requests are restricted to the GET method, with limited built-in exceptions
+  allowing POST method requests only for certain URLs that do not write or
+  modify any data.
+  If you want the public user to be able to Create, Edit or Delete data,
+  you can change the :property:`omero.web.public.get_only` property::
 
       $ omero config set omero.web.public.get_only false
 


### PR DESCRIPTION
https://github.com/ome/omero-web/pull/679 allows `POST` requests for certain functions (as of now, just `webgateway/table/*/slice`) even if `omero.web.public.get_only` is enabled.

This PR adds a note highlighting this in the documentation.